### PR TITLE
Rename RemoteValue object to Group

### DIFF
--- a/test/str_test.py
+++ b/test/str_test.py
@@ -4,7 +4,7 @@ import asyncio
 
 from xknx import XKNX
 from xknx.devices import Light, Switch, Cover, Climate, Time, \
-    BinarySensor, Action, Sensor, Notification, RemoteValue, \
+    BinarySensor, Action, Sensor, Notification, Group, \
     ActionBase, ActionCallback
 from xknx.knx import DPTArray, DPTBinary, Address, Telegram
 from xknx.exceptions import CouldNotParseTelegram, CouldNotParseKNXIP, \
@@ -29,20 +29,20 @@ class TestStringRepresentations(unittest.TestCase):
         """Tear down test class."""
         self.loop.close()
 
-    def test_remote_value(self):
-        """Test string representation of remote value."""
+    def test_group(self):
+        """Test string representation of group."""
         xknx = XKNX(loop=self.loop)
-        remote_value = RemoteValue(
+        group = Group(
             xknx,
             group_address='1/2/3',
             group_address_state='1/2/4')
         self.assertEqual(
-            str(remote_value),
-            '<RemoteValue <Address str="1/2/3" />/<Address str="1/2/4" />/None/None/>')
-        remote_value.payload = DPTArray([0x01, 0x02])
+            str(group),
+            '<Group <Address str="1/2/3" />/<Address str="1/2/4" />/None/None/>')
+        group.payload = DPTArray([0x01, 0x02])
         self.assertEqual(
-            str(remote_value),
-            '<RemoteValue <Address str="1/2/3" />/<Address str="1/2/4" />/<DPTArray value="[0x1,0x2]" />/None/>')
+            str(group),
+            '<Group <Address str="1/2/3" />/<Address str="1/2/4" />/<DPTArray value="[0x1,0x2]" />/None/>')
 
     def test_binary_sensor(self):
         """Test string representation of binary sensor object."""

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -11,4 +11,4 @@ from .time import Time
 from .sensor import Sensor
 from .binary_sensor import BinarySensor, BinarySensorState
 from .notification import Notification
-from .remote_value import RemoteValue
+from .group import Group

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -9,7 +9,7 @@ from xknx.knx import Address, DPTBinary, DPTArray, \
     HVACOperationMode, DPTControllerStatus, DPTHVACMode
 from xknx.exceptions import CouldNotParseTelegram, DeviceIllegalValue
 from .device import Device
-from .remote_value import RemoteValueTemp, RemoteValue1Count
+from .group import GroupTemp, Group1Count
 
 
 class Climate(Device):
@@ -67,15 +67,15 @@ class Climate(Device):
 
         self.operation_mode = HVACOperationMode.STANDBY
 
-        self.temperature = RemoteValueTemp(
+        self.temperature = GroupTemp(
             xknx,
             group_address_temperature,
             after_update_cb=self.after_update)
-        self.target_temperature = RemoteValueTemp(
+        self.target_temperature = GroupTemp(
             xknx,
             group_address_target_temperature,
             after_update_cb=self.after_update)
-        self.setpoint_shift = RemoteValue1Count(
+        self.setpoint_shift = Group1Count(
             xknx,
             group_address_setpoint_shift,
             group_address_setpoint_shift_state,

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -10,8 +10,8 @@ It provides functionality for
 import asyncio
 from .device import Device
 from .travelcalculator import TravelCalculator
-from .remote_value import RemoteValueScaling5001, RemoteValueUpDown1008, \
-    RemoteValueStep1007
+from .group import GroupScaling5001, GroupUpDown1008, \
+    GroupStep1007
 
 
 class Cover(Device):
@@ -42,26 +42,26 @@ class Cover(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
 
-        self.updown = RemoteValueUpDown1008(
+        self.updown = GroupUpDown1008(
             xknx,
             group_address_long,
             after_update_cb=self.after_update,
             invert=invert_position)
 
-        self.step = RemoteValueStep1007(
+        self.step = GroupStep1007(
             xknx,
             group_address_short,
             after_update_cb=self.after_update,
             invert=invert_position)
 
-        self.position = RemoteValueScaling5001(
+        self.position = GroupScaling5001(
             xknx,
             group_address_position,
             group_address_position_state,
             after_update_cb=self.after_update,
             invert=invert_position)
 
-        self.angle = RemoteValueScaling5001(
+        self.angle = GroupScaling5001(
             xknx,
             group_address_angle,
             group_address_angle_state,

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -11,7 +11,7 @@ import asyncio
 
 from .device import Device
 from .group import (GroupScaling5001, GroupStep1007,
-                           GroupUpDown1008)
+                    GroupUpDown1008)
 from .travelcalculator import TravelCalculator
 
 

--- a/xknx/devices/group.py
+++ b/xknx/devices/group.py
@@ -1,7 +1,7 @@
 """
-Module for managing a remote value KNX.
+Module for managing a KNX group.
 
-Remote value can either be a group address for reading
+Group can either be a group address for reading
 and and one group address wor writing a KNX value
 or a group address for both.
 """
@@ -13,7 +13,7 @@ from xknx.knx import Telegram, DPTScaling, DPTValue1Count, \
     DPTTemperature
 
 
-class RemoteValue():
+class Group():
     """Class for managing remlte knx value."""
 
     def __init__(self,
@@ -21,7 +21,7 @@ class RemoteValue():
                  group_address=None,
                  group_address_state=None,
                  after_update_cb=None):
-        """Initialize RemoteValue class."""
+        """Initialize Group class."""
         self.xknx = xknx
         if isinstance(group_address, (str, int)):
             group_address = Address(group_address)
@@ -35,7 +35,7 @@ class RemoteValue():
 
     @property
     def initialized(self):
-        """Evaluate if remote value is initialized with group address."""
+        """Evaluate if group is initialized with group address."""
         return bool(self.group_address_state or self.group_address)
 
     def has_group_address(self, group_address):
@@ -135,8 +135,8 @@ class RemoteValue():
         return True
 
 
-class RemoteValueSwitch1001(RemoteValue):
-    """Abstraction for remote value of KNX DPT 1.001 / DPT_Switch."""
+class GroupSwitch1001(Group):
+    """Abstraction for group of KNX DPT 1.001 / DPT_Switch."""
 
     class Value(Enum):
         """Enum for indicating the direction."""
@@ -151,9 +151,9 @@ class RemoteValueSwitch1001(RemoteValue):
                  group_address_state=None,
                  after_update_cb=None,
                  invert=False):
-        """Initialize remote value of KNX DPT 1.001."""
+        """Initialize group of KNX DPT 1.001."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueSwitch1001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(GroupSwitch1001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
     @staticmethod
@@ -189,8 +189,8 @@ class RemoteValueSwitch1001(RemoteValue):
         yield from self.set(self.Value.ON)
 
 
-class RemoteValueUpDown1008(RemoteValue):
-    """Abstraction for remote value of KNX DPT 1.008 / DPT_UpDown."""
+class GroupUpDown1008(Group):
+    """Abstraction for group of KNX DPT 1.008 / DPT_UpDown."""
 
     class Direction(Enum):
         """Enum for indicating the direction."""
@@ -205,9 +205,9 @@ class RemoteValueUpDown1008(RemoteValue):
                  group_address_state=None,
                  after_update_cb=None,
                  invert=False):
-        """Initialize remote value of KNX DPT 1.008."""
+        """Initialize group of KNX DPT 1.008."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueUpDown1008, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(GroupUpDown1008, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
     @staticmethod
@@ -243,8 +243,8 @@ class RemoteValueUpDown1008(RemoteValue):
         yield from self.set(self.Direction.UP)
 
 
-class RemoteValueStep1007(RemoteValue):
-    """Abstraction for remote value of KNX DPT 1.007 / DPT_Step."""
+class GroupStep1007(Group):
+    """Abstraction for group of KNX DPT 1.007 / DPT_Step."""
 
     class Direction(Enum):
         """Enum for indicating the direction."""
@@ -258,9 +258,9 @@ class RemoteValueStep1007(RemoteValue):
                  group_address_state=None,
                  after_update_cb=None,
                  invert=False):
-        """Initialize remote value of KNX DPT 1.007."""
+        """Initialize group of KNX DPT 1.007."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueStep1007, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(GroupStep1007, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
     @staticmethod
@@ -295,8 +295,8 @@ class RemoteValueStep1007(RemoteValue):
         yield from self.set(self.Direction.DECREASE)
 
 
-class RemoteValueScaling5001(RemoteValue):
-    """Abstraction for remote value of KNX DPT 5.001 (DPT_Scaling)."""
+class GroupScaling5001(Group):
+    """Abstraction for group of KNX DPT 5.001 (DPT_Scaling)."""
 
     def __init__(self,
                  xknx,
@@ -304,9 +304,9 @@ class RemoteValueScaling5001(RemoteValue):
                  group_address_state=None,
                  after_update_cb=None,
                  invert=False):
-        """Initialize remote value of KNX DPT 5.001 (DPT_Scaling)."""
+        """Initialize group of KNX DPT 5.001 (DPT_Scaling)."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueScaling5001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(GroupScaling5001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
     @staticmethod
@@ -329,8 +329,8 @@ class RemoteValueScaling5001(RemoteValue):
         return value
 
 
-class RemoteValue1Count(RemoteValue):
-    """Abstraction for remote value of KNX 6.010 (DPT_Value_1_Count)."""
+class Group1Count(Group):
+    """Abstraction for group of KNX 6.010 (DPT_Value_1_Count)."""
 
     @staticmethod
     def payload_valid(payload):
@@ -347,8 +347,8 @@ class RemoteValue1Count(RemoteValue):
         return DPTValue1Count.from_knx(payload.value)
 
 
-class RemoteValueTemp(RemoteValue):
-    """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
+class GroupTemp(Group):
+    """Abstraction for group of KNX 9.001 (DPT_Value_Temp)."""
 
     @staticmethod
     def payload_valid(payload):

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -11,7 +11,7 @@ import asyncio
 from xknx.knx import Address, DPTArray
 from xknx.exceptions import CouldNotParseTelegram
 from .device import Device
-from .remote_value import RemoteValueSwitch1001
+from .group import GroupSwitch1001
 
 
 class Light(Device):
@@ -33,7 +33,7 @@ class Light(Device):
         if isinstance(group_address_brightness_state, (str, int)):
             group_address_brightness_state = Address(group_address_brightness_state)
 
-        self.switch = RemoteValueSwitch1001(
+        self.switch = GroupSwitch1001(
             xknx,
             group_address_switch,
             group_address_switch_state,
@@ -95,7 +95,7 @@ class Light(Device):
     @property
     def state(self):
         """Return the current switch state of the device."""
-        return self.switch.value == RemoteValueSwitch1001.Value.ON
+        return self.switch.value == GroupSwitch1001.Value.ON
 
     @asyncio.coroutine
     def _set_internal_brightness(self, brightness):

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -8,7 +8,7 @@ It provides functionality for
 """
 import asyncio
 from .device import Device
-from .remote_value import RemoteValueSwitch1001
+from .group import GroupSwitch1001
 
 
 class Switch(Device):
@@ -24,7 +24,7 @@ class Switch(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
 
-        self.switch = RemoteValueSwitch1001(
+        self.switch = GroupSwitch1001(
             xknx,
             group_address,
             group_address_state,
@@ -50,7 +50,7 @@ class Switch(Device):
     @property
     def state(self):
         """Return the current switch state of the device."""
-        return self.switch.value == RemoteValueSwitch1001.Value.ON
+        return self.switch.value == GroupSwitch1001.Value.ON
 
     @asyncio.coroutine
     def set_on(self):


### PR DESCRIPTION
As discussed yesterday in Discord, RemoteValue is a bad name. Lets rename it to Group.