### PR TITLE
Implemented is_group() to avoid many potential wrong isinstance() calls.

### DIFF
--- a/test/knx_groups_test.py
+++ b/test/knx_groups_test.py
@@ -1,0 +1,57 @@
+"""Unit test for KNX Groups and related stuff."""
+from unittest import TestCase
+
+from xknx.knx.groups import is_group
+
+
+class TestGroupsTools(TestCase):
+    """Test class for all group tools."""
+
+    def test_is_group_with_string(self):
+        """
+        Test is_group with strings as input.
+
+        Test some basic string examples agains is_group. A empty string is
+        never a valid group address.
+        """
+        self.assertEqual(is_group('Example'), True)
+        self.assertEqual(is_group('1/0/0'), True)
+        self.assertEqual(is_group('1/0'), True)
+        self.assertEqual(is_group(''), False)
+
+    def test_is_group_with_integer(self):
+        """
+        Test is_group with integers as input.
+
+        KNX Groups have an allowed range between 1-65536, all other integers
+        are invalid.
+        """
+        self.assertEqual(is_group(0), False)
+        self.assertEqual(is_group(65537), False)
+        self.assertEqual(is_group(123), True)
+
+    def test_is_group_with_float(self):
+        """
+        Test is_group with floats as input.
+
+        KNX Groups can be represented as integer, hex or string, but never as
+        float.
+        """
+        self.assertEqual(is_group(1.123), False)
+
+    def test_is_group_with_none(self):
+        """
+        Test is_group with None as input.
+
+        Test if is_group(None) returns False.
+        """
+        self.assertEqual(is_group(None), False)
+
+    def test_is_group_with_boolean(self):
+        """
+        Test is_group with boolean as input.
+
+        Boolean representation of KNX Groups make no sense.
+        """
+        self.assertEqual(is_group(True), False)
+        self.assertEqual(is_group(False), False)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -14,6 +14,7 @@ from enum import Enum
 
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.knx import Address
+from xknx.knx.groups import is_group
 
 from .action import Action
 from .device import Device
@@ -45,7 +46,7 @@ class BinarySensor(Device):
         """Initialize BinarySensor class."""
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
-        if isinstance(group_address, (str, int)):
+        if is_group(group_address):
             group_address = Address(group_address)
         if not isinstance(significant_bit, int):
             raise TypeError()

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -9,6 +9,7 @@ import asyncio
 from xknx.exceptions import CouldNotParseTelegram, DeviceIllegalValue
 from xknx.knx import (Address, DPTArray, DPTBinary, DPTControllerStatus,
                       DPTHVACMode, HVACOperationMode)
+from xknx.knx.groups import is_group
 
 from .device import Device
 from .remote_value import RemoteValue1Count, RemoteValueTemp
@@ -44,19 +45,19 @@ class Climate(Device):
         """Initialize Climate class."""
         # pylint: disable=too-many-arguments, too-many-locals
         Device.__init__(self, xknx, name, device_updated_cb)
-        if isinstance(group_address_operation_mode, (str, int)):
+        if is_group(group_address_operation_mode):
             group_address_operation_mode = Address(group_address_operation_mode)
-        if isinstance(group_address_operation_mode_state, (str, int)):
+        if is_group(group_address_operation_mode_state):
             group_address_operation_mode_state = Address(group_address_operation_mode_state)
-        if isinstance(group_address_operation_mode_protection, (str, int)):
+        if is_group(group_address_operation_mode_protection):
             group_address_operation_mode_protection = Address(group_address_operation_mode_protection)
-        if isinstance(group_address_operation_mode_night, (str, int)):
+        if is_group(group_address_operation_mode_night):
             group_address_operation_mode_night = Address(group_address_operation_mode_night)
-        if isinstance(group_address_operation_mode_comfort, (str, int)):
+        if is_group(group_address_operation_mode_comfort):
             group_address_operation_mode_comfort = Address(group_address_operation_mode_comfort)
-        if isinstance(group_address_controller_status, (str, int)):
+        if is_group(group_address_controller_status):
             group_address_controller_status = Address(group_address_controller_status)
-        if isinstance(group_address_controller_status_state, (str, int)):
+        if is_group(group_address_controller_status_state):
             group_address_controller_status_state = Address(group_address_controller_status_state)
 
         self.group_address_operation_mode = group_address_operation_mode

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -11,6 +11,7 @@ import asyncio
 
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.knx import Address, DPTArray
+from xknx.knx.groups import is_group
 
 from .device import Device
 from .remote_value import RemoteValueSwitch1001
@@ -30,9 +31,9 @@ class Light(Device):
         """Initialize Light class."""
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
-        if isinstance(group_address_brightness, (str, int)):
+        if is_group(group_address_brightness):
             group_address_brightness = Address(group_address_brightness)
-        if isinstance(group_address_brightness_state, (str, int)):
+        if is_group(group_address_brightness_state):
             group_address_brightness_state = Address(group_address_brightness_state)
 
         self.switch = RemoteValueSwitch1001(

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -3,6 +3,7 @@ import asyncio
 
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.knx import Address, DPTArray, DPTString
+from xknx.knx.groups import is_group
 
 from .device import Device
 
@@ -18,7 +19,7 @@ class Notification(Device):
         """Initialize notification class."""
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
-        if isinstance(group_address, (str, int)):
+        if is_group(group_address):
             group_address = Address(group_address)
 
         self.group_address = group_address

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -11,6 +11,7 @@ from enum import Enum
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.knx import (Address, DPTArray, DPTBinary, DPTScaling, DPTTemperature,
                       DPTValue1Count, Telegram)
+from xknx.knx.groups import is_group
 
 
 class RemoteValue():
@@ -23,9 +24,9 @@ class RemoteValue():
                  after_update_cb=None):
         """Initialize RemoteValue class."""
         self.xknx = xknx
-        if isinstance(group_address, (str, int)):
+        if is_group(group_address):
             group_address = Address(group_address)
-        if isinstance(group_address_state, (str, int)):
+        if is_group(group_address_state):
             group_address_state = Address(group_address_state)
 
         self.group_address = group_address

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -10,6 +10,7 @@ import asyncio
 
 from xknx.knx import (Address, DPTArray, DPTBinary, DPTHumidity, DPTLux,
                       DPTScaling, DPTTemperature, DPTUElCurrentmA, DPTWsp)
+from xknx.knx.groups import is_group
 
 from .device import Device
 
@@ -26,7 +27,7 @@ class Sensor(Device):
         """Initialize Sensor class."""
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
-        if isinstance(group_address, (str, int)):
+        if is_group(group_address):
             group_address = Address(group_address)
         if value_type == 'brightness':
             value_type = 'illuminance'

--- a/xknx/devices/time.py
+++ b/xknx/devices/time.py
@@ -9,6 +9,7 @@ by StateUpdate.
 import asyncio
 
 from xknx.knx import Address, DPTArray, DPTTime
+from xknx.knx.groups import is_group
 
 from .device import Device
 
@@ -24,7 +25,7 @@ class Time(Device):
         """Initialize Time class."""
         Device.__init__(self, xknx, name, device_updated_cb)
 
-        if isinstance(group_address, (str, int)):
+        if is_group(group_address):
             group_address = Address(group_address)
 
         self.group_address = group_address

--- a/xknx/knx/groups/__init__.py
+++ b/xknx/knx/groups/__init__.py
@@ -1,0 +1,3 @@
+"""Module for KNX groups."""
+# flake8: noqa
+from .tools import is_group

--- a/xknx/knx/groups/tools.py
+++ b/xknx/knx/groups/tools.py
@@ -1,0 +1,28 @@
+"""
+KNX Group related tools.
+
+Most tools inside this submodule are usefull helpers for XKNX Devices
+and KNX Groups.
+"""
+
+
+def is_group(group_address):
+    """
+    Check if `group_address` could be a valid KNX Group Adress.
+
+    Returns `True` if `group_address` is a object useable as input for
+    and KNX Group or XKNX Device.
+    """
+    # True/False are also a instance of int, but not valid as group address
+    if isinstance(group_address, bool):
+        pass
+    elif isinstance(group_address, str):
+        # An empty string can never be a group address
+        # TODO: Check strings with regular expressions
+        if not group_address == '':
+            return True
+    elif isinstance(group_address, int):
+        # Group addresses as integer, have an allowed range of 1-65536
+        if group_address >= 1 and group_address <= 65536:
+            return True
+    return False


### PR DESCRIPTION
isinstance() as the only check if a object is an valid/possible knx group
is wrong, at least booleans are integers, but never valid knx groups.

Later we should to much more validation, but for now it fixes some possible
issues related to input validation.