### PR TITLE
Split Address into two groups.

### DIFF
--- a/examples/example_tunnel.py
+++ b/examples/example_tunnel.py
@@ -3,7 +3,7 @@ import asyncio
 
 from xknx import XKNX
 from xknx.io import GatewayScanner, Tunnel
-from xknx.knx import Address, DPTBinary, Telegram
+from xknx.knx import GroupAddress, PhysicalAddress, DPTBinary, Telegram
 
 
 async def main():
@@ -16,7 +16,7 @@ async def main():
         print("No Gateways found")
         return
 
-    src_address = Address("15.15.249")
+    src_address = PhysicalAddress("15.15.249")
 
     print("Connecting to {}:{} from {}".format(
         gatewayscanner.found_ip_addr,
@@ -33,9 +33,9 @@ async def main():
     await tunnel.connect_udp()
     await tunnel.connect()
 
-    await tunnel.send_telegram(Telegram(Address('1/0/15'), payload=DPTBinary(1)))
+    await tunnel.send_telegram(Telegram(GroupAddress('1/0/15'), payload=DPTBinary(1)))
     await asyncio.sleep(2)
-    await tunnel.send_telegram(Telegram(Address('1/0/15'), payload=DPTBinary(0)))
+    await tunnel.send_telegram(Telegram(GroupAddress('1/0/15'), payload=DPTBinary(0)))
     await asyncio.sleep(2)
 
     await tunnel.connectionstate()

--- a/examples/example_value_reader.py
+++ b/examples/example_value_reader.py
@@ -3,7 +3,7 @@ import asyncio
 
 from xknx import XKNX
 from xknx.core import ValueReader
-from xknx.knx import Address
+from xknx.knx import GroupAddress
 
 
 async def main():
@@ -11,7 +11,7 @@ async def main():
     xknx = XKNX()
     await xknx.start()
 
-    value_reader = ValueReader(xknx, Address('6/2/1'))
+    value_reader = ValueReader(xknx, GroupAddress('6/2/1'))
     telegram = await value_reader.read()
     if telegram is not None:
         print(telegram)

--- a/home-assistant-plugin/custom_components/xknx.py
+++ b/home-assistant-plugin/custom_components/xknx.py
@@ -249,7 +249,7 @@ class KNXModule(object):
     @asyncio.coroutine
     def service_send_to_knx_bus(self, call):
         """Service for sending an arbitrary KNX message to the KNX bus."""
-        from xknx.knx import Telegram, Address, DPTBinary, DPTArray
+        from xknx.knx import Telegram, GroupAddress, DPTBinary, DPTArray
         attr_payload = call.data.get(SERVICE_XKNX_ATTR_PAYLOAD)
         attr_address = call.data.get(SERVICE_XKNX_ATTR_ADDRESS)
 
@@ -259,7 +259,7 @@ class KNXModule(object):
                 return DPTBinary(attr_payload)
             return DPTArray(attr_payload)
         payload = calculate_payload(attr_payload)
-        address = Address(attr_address)
+        address = GroupAddress(attr_address)
 
         telegram = Telegram()
         telegram.payload = payload
@@ -269,10 +269,10 @@ class KNXModule(object):
     @asyncio.coroutine
     def async_broadcast_temperature(self, entity_id, old_state, new_state):
         """Broadcast new temperature of sensor to KNX bus."""
-        from xknx.knx import Telegram, Address, DPTArray, DPTFloat
+        from xknx.knx import Telegram, GroupAddress, DPTArray, DPTFloat
         if new_state is None:
             return
-        address = Address(
+        address = GroupAddress(
             self.config[DOMAIN][CONF_XKNX_OUTSIDE_TEMPERATURE_ADDRESS])
         payload = DPTArray(DPTFloat().to_knx(float(new_state.state)))
         telegram = Telegram()

--- a/test/address_filter_test.py
+++ b/test/address_filter_test.py
@@ -137,7 +137,3 @@ class TestAddressFilter(unittest.TestCase):
         self.assertFalse(af1.match("1/7/10"))
         self.assertFalse(af1.match("2/4/10"))
         self.assertFalse(af1.match("2/1/10"))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestAddressFilter)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/address_test.py
+++ b/test/address_test.py
@@ -1,264 +1,234 @@
 """Unit test for Address class."""
-import unittest
+from unittest import TestCase
 
 from xknx.exceptions import CouldNotParseAddress
-from xknx.knx import Address, AddressFormat, AddressType
+from xknx.knx import GroupAddress, GroupAddressType, PhysicalAddress
 
 
-class TestAddress(unittest.TestCase):
-    """Test class for Address."""
+class TestPhysicalAddress(TestCase):
+    """Test class for PhysicalAddress."""
 
-    # pylint: disable=too-many-public-methods,invalid-name
+    def test_with_valid(self):
+        """Test with some valid addresses."""
+        valid_addresses = (
+            ('0.0.0', 0),
+            ('1.0.0', 4096),
+            ('1.1.0', 4352),
+            ('1.1.1', 4353),
+            ('1.1.11', 4363),
+            ('1.1.111', 4463),
+            ('1.11.111', 7023),
+            ('11.11.111', 47983),
+            ('15.15.255', 65535),
+            ((0xff, 0xff), 65535),
+            (0, 0),
+            (65535, 65535)
+        )
+        for address in valid_addresses:
+            with self.subTest(address=address):
+                self.assertEqual(PhysicalAddress(address[0]).raw, address[1])
 
-    #
-    # INIT
-    #
-    def test_address_init_3level(self):
-        """Test initialization with 3rd level address."""
-        self.assertEqual(Address("2/3/4").raw, 2*2048 + 3*256 + 4)
+    def test_with_invalid(self):
+        """Test with some invalid addresses."""
+        invalid_addresses = (
+            '15.15.256',
+            '16.0.0',
+            '0.16.0',
+            '15.15.255a',
+            'a15.15.255',
+            'abc',
+            '123',
+            65536,
+            (0xff, 0xfff),
+            (0xfff, 0xff),
+            (-1, -1),
+            []
+        )
+        for address in invalid_addresses:
+            with self.subTest(address=address):
+                with self.assertRaises(CouldNotParseAddress):
+                    PhysicalAddress(address)
 
-    def test_address_init_2level(self):
-        """Test initialization with 2nd level address."""
-        self.assertEqual(Address("12/500").raw, 12*2048 + 500)
-
-    def test_address_init_free(self):
-        """Test initialization with free format address as string."""
-        self.assertEqual(Address("49552").raw, 49552)
-
-    def test_address_init_int(self):
+    def test_with_int(self):
         """Test initialization with free format address as integer."""
-        self.assertEqual(Address(49552).raw, 49552)
+        self.assertEqual(PhysicalAddress(49552).raw, 49552)
 
-    def test_address_init_bytes(self):
+    def test_with_bytes(self):
         """Test initialization with Bytes."""
-        self.assertEqual(Address((0x12, 0x34)).raw, 0x1234)
+        self.assertEqual(PhysicalAddress((0x12, 0x34)).raw, 0x1234)
 
-    def test_address_init_address(self):
-        """Test initialization with Address object."""
-        self.assertEqual(Address(Address("2/3/4")).raw, 2*2048 + 3*256 + 4)
-
-    def test_address_init_none(self):
+    def test_with_none(self):
         """Test initialization with None object."""
-        self.assertEqual(Address(None).raw, 0)
+        self.assertEqual(PhysicalAddress(None).raw, 0)
 
-    def test_address_init_address_physical(self):
-        """Test inialization with Physical Address."""
-        address = Address("2.3.4", AddressType.PHYSICAL)
-        self.assertEqual(Address(address).raw, 8964)
+    def test_is_line(self):
+        """Test if `PhysicalAddress.is_line` works like excepted."""
+        self.assertTrue(PhysicalAddress('1.0.0').is_line)
+        self.assertFalse(PhysicalAddress('1.0.1').is_line)
 
-    def test_address_format_3level(self):
-        """Test address_format of 3rd level Address."""
+    def test_is_device(self):
+        """Test if `PhysicalAddress.is_device` works like excepted."""
+        self.assertTrue(PhysicalAddress('1.0.1').is_device)
+        self.assertFalse(PhysicalAddress('1.0.0').is_device)
+
+    def test_to_knx(self):
+        """Test if `PhysicalAddress.to_knx()` generates valid byte tuples."""
+        self.assertEqual(PhysicalAddress('0.0.0').to_knx(), (0x0, 0x0))
+        self.assertEqual(PhysicalAddress('15.15.255').to_knx(), (0xff, 0xff))
+
+    def test_equal(self):
+        """Test if the equal operator works in all cases."""
+        self.assertEqual(PhysicalAddress('1.0.0'), PhysicalAddress(4096))
+        self.assertNotEqual(PhysicalAddress('1.0.0'), PhysicalAddress('1.1.1'))
+        self.assertNotEqual(PhysicalAddress('1.0.0'), None)
+        with self.assertRaises(TypeError):
+            PhysicalAddress('1.0.0') == 'example'  # pylint: disable=expression-not-assigned
+
+    def test_representation(self):
+        """Test string representation of address."""
         self.assertEqual(
-            Address("2/3/4").address_format,
-            AddressFormat.LEVEL3)
+            repr(PhysicalAddress("2.3.4")),
+            'PhysicalAddress("2.3.4")')
 
-    def test_address_format_2level(self):
-        """Test address_format of 2nd level Address."""
+
+class TestGroupAddress(TestCase):
+    """Test class for GroupAddress."""
+
+    def test_with_valid(self):
+        """
+        Test if the class constructor generates valid raw values.
+
+        This test checks:
+        * all allowed input variants (strings, tuples, integers)
+        * for conversation errors
+        * for upper/lower limits still working, to avoid off-by-one errors
+        """
+        valid_addresses = (
+            ('0/0', 0),
+            ('0/1', 1),
+            ('0/11', 11),
+            ('0/111', 111),
+            ('0/1111', 1111),
+            ('0/2047', 2047),
+            ('0/0/0', 0),
+            ('0/0/1', 1),
+            ('0/0/11', 11),
+            ('0/0/111', 111),
+            ('0/0/255', 255),
+            ('0/1/11', 267),
+            ('0/1/111', 367),
+            ('0/7/255', 2047),
+            ('1/0', 2048),
+            ('1/0/0', 2048),
+            ('1/1/111', 2415),
+            ('1/7/255', 4095),
+            ('31/7/255', 65535),
+            ('1', 1),
+            (0, 0),
+            (65535, 65535),
+            ((0xff, 0xff), 65535),
+            (None, 0)
+        )
+        for address in valid_addresses:
+            with self.subTest(address=address):
+                self.assertEqual(GroupAddress(address[0]).raw, address[1])
+
+    def test_with_invalid(self):
+        """
+        Test if constructor raises an exception for all known invalid cases.
+
+        Checks:
+        * addresses or parts of it too high/low
+        * invalid input variants (lists instead of tuples)
+        * invalid strings
+        """
+        invalid_addresses = (
+            '0/2049',
+            '0/8/0',
+            '0/0/256',
+            '32/0',
+            '0/0a',
+            'a0/0',
+            'abc',
+            65536,
+            (0xff, 0xfff),
+            (0xfff, 0xff),
+            (-1, -1),
+            []
+        )
+        for address in invalid_addresses:
+            with self.subTest(address=address):
+                with self.assertRaises(CouldNotParseAddress):
+                    GroupAddress(address)
+
+    def test_main(self):
+        """
+        Test if `GroupAddress.main` works.
+
+        Checks:
+        * Main group part of a strings returns the right value
+        * Return `None` on `GroupAddressType.FREE`
+        """
+        self.assertEqual(GroupAddress('1/0').main, 1)
+        self.assertEqual(GroupAddress('15/0').main, 15)
+        self.assertEqual(GroupAddress('31/0/0').main, 31)
+        self.assertIsNone(GroupAddress('1/0', GroupAddressType.FREE).main)
+
+    def test_middle(self):
+        """
+        Test if `GroupAddress.middle` works.
+
+        Checks:
+        * Middle group part of a strings returns the right value
+        * Return `None` if not `GroupAddressType.LONG`
+        """
+        self.assertEqual(GroupAddress('1/0/1', GroupAddressType.LONG).middle, 0)
+        self.assertEqual(GroupAddress('1/7/1', GroupAddressType.LONG).middle, 7)
+        self.assertIsNone(GroupAddress('1/0', GroupAddressType.SHORT).middle)
+        self.assertIsNone(GroupAddress('1/0', GroupAddressType.FREE).middle)
+
+    def test_sub(self):
+        """
+        Test if `GroupAddress.sub` works.
+
+        Checks:
+        * Sub group part of a strings returns the right value
+        * Return never `None`
+        """
+        self.assertEqual(GroupAddress('1/0', GroupAddressType.SHORT).sub, 0)
+        self.assertEqual(GroupAddress('31/0', GroupAddressType.SHORT).sub, 0)
+        self.assertEqual(GroupAddress('1/2047', GroupAddressType.SHORT).sub, 2047)
+        self.assertEqual(GroupAddress('31/2047', GroupAddressType.SHORT).sub, 2047)
+        self.assertEqual(GroupAddress('1/0/0', GroupAddressType.LONG).sub, 0)
+        self.assertEqual(GroupAddress('1/0/255', GroupAddressType.LONG).sub, 255)
+        self.assertEqual(GroupAddress('0/0', GroupAddressType.FREE).sub, 0)
+        self.assertEqual(GroupAddress('1/0', GroupAddressType.FREE).sub, 2048)
+        self.assertEqual(GroupAddress('31/2047', GroupAddressType.FREE).sub, 65535)
+
+    def test_to_knx(self):
+        """Test if `GroupAddress.to_knx()` generates valid byte tuples."""
+        self.assertEqual(GroupAddress('0/0').to_knx(), (0x0, 0x0))
+        self.assertEqual(GroupAddress('31/2047').to_knx(), (0xff, 0xff))
+
+    def test_equal(self):
+        """Test if the equal operator works in all cases."""
+        self.assertEqual(GroupAddress('1/0'), GroupAddress(2048))
+        self.assertNotEqual(GroupAddress('1/1'), GroupAddress('1/1/0'))
+        self.assertNotEqual(GroupAddress('1/0'), None)
+        with self.assertRaises(TypeError):
+            GroupAddress('1/0') == 'example'  # pylint: disable=expression-not-assigned
+
+    def test_representation(self):
+        """Test string representation of address."""
         self.assertEqual(
-            Address("12/500").address_format,
-            AddressFormat.LEVEL2)
-
-    def test_address_format_free(self):
-        """Test address_format of free format Address."""
+            repr(GroupAddress('0', GroupAddressType.FREE)),
+            'GroupAddress("0")'
+        )
         self.assertEqual(
-            Address("49552").address_format,
-            AddressFormat.FREE)
-
-    def test_address_format_int(self):
-        """Test address_format of Address initalized by int."""
+            repr(GroupAddress('0', GroupAddressType.SHORT)),
+            'GroupAddress("0/0")'
+        )
         self.assertEqual(
-            Address(49552).address_format,
-            AddressFormat.LEVEL3)
-
-    def test_address_format_address(self):
-        """Test address_format of Address initialized by Address."""
-        self.assertEqual(
-            Address(Address("2/3/4")).address_format,
-            AddressFormat.LEVEL3)
-
-    #
-    # ADDRESS TYPE
-    #
-    def test_address_type_physical(self):
-        """Test address_type of physical Address."""
-        self.assertEqual(
-            Address("2.3.4", AddressType.PHYSICAL).address_type,
-            AddressType.PHYSICAL)
-
-    def test_address_type_physical_auto_detect(self):
-        """Test address_type of pyhsical Address (via autodetect)."""
-        self.assertEqual(
-            Address("2.3.4").address_type,
-            AddressType.PHYSICAL)
-
-    def test_address_type_group(self):
-        """Test address_type of group address."""
-        self.assertEqual(
-            Address("2/3/4").address_type,
-            AddressType.GROUP)
-
-    #
-    # STR
-    #
-    def test_address_str_3level(self):
-        """Test string representation of 3rd level group address."""
-        self.assertEqual(
-            Address("2/3/4").str(),
-            "2/3/4")
-
-    def test_address_str_2level(self):
-        """Test string representation of 2nd level group address."""
-        self.assertEqual(
-            Address("12/500").str(),
-            "12/500")
-
-    def test_address_str_free(self):
-        """Test string representation of free format group address."""
-        self.assertEqual(
-            Address("49552").str(),
-            "49552")
-
-    def test_address_str_int(self):
-        """Test string representation of address initialized by int."""
-        self.assertEqual(
-            Address(49552).str(),
-            "24/1/144")
-
-    def test_address_str_address(self):
-        """Test string representation of address initialized by Address object."""
-        self.assertEqual(
-            Address(Address("2/3/4")).str(),
-            "2/3/4")
-
-    def test_address_str_physical(self):
-        """Test string representation of physical address."""
-        self.assertEqual(
-            Address("2.3.4", AddressType.PHYSICAL).str(),
-            "2.3.4")
-
-    #
-    # MAXIMUM ADDRESSES
-    #
-    def test_address_max_3level(self):
-        """Test initialization of Address with maximum 3rd level address."""
-        self.assertEqual(Address("31/7/255").raw, 65535)
-
-    def test_address_max_2level(self):
-        """Test initialization of Address with maximum 2nd level address."""
-        self.assertEqual(Address("31/2047").raw, 65535)
-
-    def test_address_max_free(self):
-        """Test initialization of Address with maximum free format address."""
-        self.assertEqual(Address("65535").raw, 65535)
-
-    def test_address_max_int(self):
-        """Test initialization of Address with max int."""
-        self.assertEqual(Address(65535).raw, 65535)
-
-    def test_address_max_address(self):
-        """Test initialization of Address with maximum Address."""
-        self.assertEqual(Address(Address("31/7/255")).raw, 65535)
-
-    #
-    # INVALID INIT STRINGS
-    #
-    def test_address_init_failed_too_many_parts(self):
-        """Test initialization of Address with invalid string."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("1/2/3/4")
-
-    def test_address_init_failed_string(self):
-        """Test initialization of Address with invalid string."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("bla123")
-
-    def test_address_init_failed_string_part(self):
-        """Test initialization of Address with invalid string."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("1/2/3a")
-
-    def test_address_init_failed_level3_boundaries_sub(self):
-        """Test initialization of 3rd level Address with invalid number value at the end."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("1/2/256")
-
-    def test_address_init_failed_level3_boundaries_middle(self):
-        """Test initialization of 3rd level Address with invalid number value in the middle."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("1/8/3")
-
-    def test_address_init_failed_level3_boundaries_main(self):
-        """Test initialization of 3rd level Address with invalid number value at the beginning."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("32/2/3")
-
-    def test_address_init_failed_level2_boundaries_sub(self):
-        """Test initialization of 2rd level Address with invalid number value at the end."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("1.4096")
-
-    def test_address_init_failed_level2_boundaries_middle(self):
-        """Test initialization of 2rd level Address with invalid number value at the beginning."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("16.3")
-
-    def test_address_init_failed_free_boundaries(self):
-        """Test initialization of free format Address with invalid number value."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("65536")
-
-    def test_address_init_empty_string(self):
-        """Test initialization of Address with invalid empty string."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address("")
-
-    def test_address_init_tuple_3_elements(self):
-        """Test initialization of Address with invalid tuple."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address((1, 2, 3))
-
-    def test_address_init_tuple_string(self):
-        """Test initialization of Address with invalid tuple string."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address((2, "23"))
-
-    def test_address_init_tuple_range_overflow(self):
-        """Test initialization of Address with tuple with invalid 2nd value."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address((4, 256))
-
-    def test_address_init_tuple_range_underflow(self):
-        """Test initialization of Address with tuple with invalid 1st value."""
-        with self.assertRaises(CouldNotParseAddress):
-            Address((1, -1))
-
-    #
-    # __eq__
-    #
-    def test_address_equal(self):
-        """Test equals operator with equal objects."""
-        self.assertTrue(Address("2/3/4") == Address("2/3/4"))
-
-    def test_address_equal_false(self):
-        """Test equals operator with non equal objects."""
-        self.assertFalse(Address("2/3/4") == Address("2/3/5"))
-
-    def test_address_not_equal(self):
-        """Test non equals operator with non equal objects."""
-        self.assertTrue(Address("2/3/4") != Address("2/3/5"))
-
-    def test_address_not_qual_false(self):
-        """Test not equals operator with equal object."""
-        self.assertFalse(Address("2/3/4") != Address("2/3/4"))
-
-    def test_address_equal_diffent_source(self):
-        """Test equals operator. Different format should not have relevance for the equality."""
-        self.assertTrue(Address("2/3/4") == Address("2/772"))
-
-    #
-    # TO KNX
-    #
-
-    def test_address_to_knx(self):
-        """Test to_knx functionality of Address object."""
-        self.assertEqual(Address("2/3/100").to_knx(), (2*8+3, 100))
+            repr(GroupAddress('0', GroupAddressType.LONG)),
+            'GroupAddress("0/0/0")'
+        )

--- a/test/address_test.py
+++ b/test/address_test.py
@@ -262,7 +262,3 @@ class TestAddress(unittest.TestCase):
     def test_address_to_knx(self):
         """Test to_knx functionality of Address object."""
         self.assertEqual(Address("2/3/100").to_knx(), (2*8+3, 100))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestAddress)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/binary_sensor_test.py
+++ b/test/binary_sensor_test.py
@@ -161,7 +161,3 @@ class TestBinarySensor(unittest.TestCase):
         telegram.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(switch.process(telegram)))
         after_update_callback.assert_called_with(switch)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestBinarySensor)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 from xknx import XKNX
 from xknx.devices import Climate
 from xknx.exceptions import DeviceIllegalValue
-from xknx.knx import (Address, DPTArray, DPTBinary, DPTControllerStatus,
+from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTControllerStatus,
                       DPTFloat, DPTHVACMode, DPTTemperature, DPTValue1Count,
                       HVACOperationMode, Telegram, TelegramType)
 
@@ -94,14 +94,14 @@ class TestClimate(unittest.TestCase):
             group_address_operation_mode_night='1/2/7',
             group_address_operation_mode_comfort='1/2/8')
 
-        self.assertTrue(climate.has_group_address(Address('1/2/1')))
-        self.assertTrue(climate.has_group_address(Address('1/2/2')))
-        self.assertTrue(climate.has_group_address(Address('1/2/4')))
-        self.assertTrue(climate.has_group_address(Address('1/2/5')))
-        self.assertTrue(climate.has_group_address(Address('1/2/6')))
-        self.assertTrue(climate.has_group_address(Address('1/2/7')))
-        self.assertTrue(climate.has_group_address(Address('1/2/8')))
-        self.assertFalse(climate.has_group_address(Address('1/2/9')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/1')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/2')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/4')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/5')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/6')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/7')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/8')))
+        self.assertFalse(climate.has_group_address(GroupAddress('1/2/9')))
 
     #
     # TEST CALLBACK
@@ -171,22 +171,22 @@ class TestClimate(unittest.TestCase):
             after_update_callback(device)
         climate.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(Address('1/2/1'), payload=DPTArray(DPTTemperature.to_knx(23)))
+        telegram = Telegram(GroupAddress('1/2/1'), payload=DPTArray(DPTTemperature.to_knx(23)))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
-        telegram = Telegram(Address('1/2/2'), payload=DPTArray(DPTTemperature.to_knx(23)))
+        telegram = Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTTemperature.to_knx(23)))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
-        telegram = Telegram(Address('1/2/3'), payload=DPTArray(DPTValue1Count.to_knx(-4)))
+        telegram = Telegram(GroupAddress('1/2/3'), payload=DPTArray(DPTValue1Count.to_knx(-4)))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
-        telegram = Telegram(Address('1/2/4'), payload=DPTArray(1))
+        telegram = Telegram(GroupAddress('1/2/4'), payload=DPTArray(1))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
@@ -210,7 +210,7 @@ class TestClimate(unittest.TestCase):
             self.assertEqual(
                 telegram,
                 Telegram(
-                    Address('1/2/4'),
+                    GroupAddress('1/2/4'),
                     payload=DPTArray(DPTHVACMode.to_knx(operation_mode))))
 
     def test_set_operation_mode_not_supported(self):
@@ -241,7 +241,7 @@ class TestClimate(unittest.TestCase):
             self.assertEqual(
                 telegram,
                 Telegram(
-                    Address('1/2/4'),
+                    GroupAddress('1/2/4'),
                     payload=DPTArray(DPTControllerStatus.to_knx(operation_mode))))
 
     def test_set_operation_mode_with_separate_addresses(self):
@@ -263,25 +263,25 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                Address('1/2/4'),
+                GroupAddress('1/2/4'),
                 payload=DPTArray(1)))
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
             Telegram(
-                Address('1/2/5'),
+                GroupAddress('1/2/5'),
                 payload=DPTBinary(0)))
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
             Telegram(
-                Address('1/2/6'),
+                GroupAddress('1/2/6'),
                 payload=DPTBinary(0)))
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
             Telegram(
-                Address('1/2/7'),
+                GroupAddress('1/2/7'),
                 payload=DPTBinary(1)))
 
     #
@@ -342,23 +342,23 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(4)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(4)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
 
         # First change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(6)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
         self.assertEqual(climate.target_temperature.value, 24.00)
 
         # Second change
@@ -366,10 +366,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(5)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(5)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.50))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.50))))
         self.assertEqual(climate.target_temperature.value, 23.50)
 
         # Test max target temperature
@@ -393,23 +393,23 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(1)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(1)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
 
         # First change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(0xFD)))  # -3
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFD)))  # -3
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(21.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(21.00))))
         self.assertEqual(climate.target_temperature.value, 21.00)
 
         # Second change
@@ -417,10 +417,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(0xFA)))  # -3
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFA)))  # -3
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(19.50))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(19.50))))
         self.assertEqual(climate.target_temperature.value, 19.50)
 
         # Test min target temperature
@@ -447,22 +447,22 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(10)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(10)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
 
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/3'), payload=DPTArray(20)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(20)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(Address('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
         self.assertEqual(climate.target_temperature.value, 24.00)
 
         # Test max/min target temperature
@@ -484,7 +484,7 @@ class TestClimate(unittest.TestCase):
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram1,
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     def test_sync_operation_mode(self):
         """Test sync function / sending group reads to KNX bus for operation mode."""
@@ -499,11 +499,11 @@ class TestClimate(unittest.TestCase):
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram1,
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram2,
-            Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
 
     def test_sync_operation_mode_state(self):
         """Test sync function / sending group reads to KNX bus for operation mode with explicit state addresses."""
@@ -520,11 +520,11 @@ class TestClimate(unittest.TestCase):
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram1,
-            Telegram(Address('1/2/5'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/5'), TelegramType.GROUP_READ))
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram2,
-            Telegram(Address('1/2/6'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/6'), TelegramType.GROUP_READ))
 
     #
     # TEST PROCESS
@@ -537,7 +537,7 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_temperature='1/2/3')
 
-        telegram = Telegram(Address('1/2/3'))
+        telegram = Telegram(GroupAddress('1/2/3'))
         telegram.payload = DPTArray(DPTTemperature().to_knx(21.34))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         self.assertEqual(climate.temperature.value, 21.34)
@@ -551,14 +551,14 @@ class TestClimate(unittest.TestCase):
             group_address_operation_mode='1/2/5',
             group_address_controller_status='1/2/3')
         for operation_mode in HVACOperationMode:
-            telegram = Telegram(Address('1/2/5'))
+            telegram = Telegram(GroupAddress('1/2/5'))
             telegram.payload = DPTArray(DPTHVACMode.to_knx(operation_mode))
             self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
             self.assertEqual(climate.operation_mode, operation_mode)
         for operation_mode in HVACOperationMode:
             if operation_mode == HVACOperationMode.AUTO:
                 continue
-            telegram = Telegram(Address('1/2/3'))
+            telegram = Telegram(GroupAddress('1/2/3'))
             telegram.payload = DPTArray(DPTControllerStatus.to_knx(operation_mode))
             self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
             self.assertEqual(climate.operation_mode, operation_mode)
@@ -580,7 +580,7 @@ class TestClimate(unittest.TestCase):
             after_update_callback(device)
         climate.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(Address('1/2/3'))
+        telegram = Telegram(GroupAddress('1/2/3'))
         telegram.payload = DPTArray(DPTTemperature().to_knx(21.34))
         self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
         after_update_callback.assert_called_with(climate)

--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -658,7 +658,3 @@ class TestClimate(unittest.TestCase):
             climate.get_supported_operation_modes(),
             [HVACOperationMode.STANDBY,
              HVACOperationMode.NIGHT])
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestClimate)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -259,7 +259,3 @@ class TestConfig(unittest.TestCase):
                          significant_bit=2,
                          device_class='motion',
                          device_updated_cb=xknx.devices.device_updated))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestConfig)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/cover_test.py
+++ b/test/cover_test.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Cover
-from xknx.knx import Address, DPTArray, DPTBinary, Telegram, TelegramType
+from xknx.knx import GroupAddress, DPTArray, DPTBinary, Telegram, TelegramType
 
 
 class TestCover(unittest.TestCase):
@@ -84,7 +84,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     def test_sync_state(self):
         """Test sync function with explicit state address."""
@@ -100,7 +100,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
 
     def test_sync_angle(self):
         """Test sync function for cover with angle."""
@@ -116,10 +116,10 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram2,
-                         Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
 
     def test_sync_angle_state(self):
         """Test sync function with angle/explicit state."""
@@ -135,7 +135,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
 
     #
     # TEST SET UP
@@ -154,7 +154,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/1'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTBinary(0)))
 
     #
     # TEST SET DOWN
@@ -173,7 +173,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/1'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTBinary(1)))
 
     #
     # TEST SET SHORT UP
@@ -192,7 +192,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/2'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('1/2/2'), payload=DPTBinary(1)))
 
     #
     # TEST SET SHORT DOWN
@@ -211,7 +211,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/2'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/2'), payload=DPTBinary(0)))
 
     #
     # TEST STOP
@@ -229,7 +229,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/2'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/2'), payload=DPTBinary(0)))
 
     #
     # TEST POSITION
@@ -248,7 +248,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), payload=DPTArray(0x80)))
+                         Telegram(GroupAddress('1/2/3'), payload=DPTArray(0x80)))
 
     def test_position_without_position_address_up(self):
         """Test moving cover to absolute position - with no absolute positioning supported."""
@@ -264,7 +264,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/1'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTBinary(1)))
 
     def test_position_without_position_address_down(self):
         """Test moving cover down - with no absolute positioning supported."""
@@ -280,7 +280,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/1'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTBinary(0)))
 
     def test_angle(self):
         """Test changing angle."""
@@ -298,7 +298,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/4/18'), payload=DPTArray(0x80)))
+                         Telegram(GroupAddress('1/4/18'), payload=DPTArray(0x80)))
 
     #
     # TEST PROCESS
@@ -313,7 +313,7 @@ class TestCover(unittest.TestCase):
             group_address_short='1/2/2',
             group_address_position='1/2/3',
             group_address_position_state='1/2/4')
-        telegram = Telegram(Address('1/2/4'), payload=DPTArray(42))
+        telegram = Telegram(GroupAddress('1/2/4'), payload=DPTArray(42))
         self.loop.run_until_complete(asyncio.Task(cover.process(telegram)))
         self.assertEqual(cover.current_position(), 84)
 
@@ -327,7 +327,7 @@ class TestCover(unittest.TestCase):
             group_address_short='1/2/2',
             group_address_angle='1/2/3',
             group_address_angle_state='1/2/4')
-        telegram = Telegram(Address('1/2/4'), payload=DPTArray(42))
+        telegram = Telegram(GroupAddress('1/2/4'), payload=DPTArray(42))
         self.loop.run_until_complete(asyncio.Task(cover.process(telegram)))
         self.assertEqual(cover.angle.value, 84)
 
@@ -351,7 +351,7 @@ class TestCover(unittest.TestCase):
             after_update_callback(device)
         cover.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(Address('1/2/4'), payload=DPTArray(42))
+        telegram = Telegram(GroupAddress('1/2/4'), payload=DPTArray(42))
         self.loop.run_until_complete(asyncio.Task(cover.process(telegram)))
 
         after_update_callback.assert_called_with(cover)

--- a/test/cover_test.py
+++ b/test/cover_test.py
@@ -355,7 +355,3 @@ class TestCover(unittest.TestCase):
         self.loop.run_until_complete(asyncio.Task(cover.process(telegram)))
 
         after_update_callback.assert_called_with(cover)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestCover)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/devices_test.py
+++ b/test/devices_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from xknx import XKNX
 from xknx.devices import BinarySensor, Devices, Light, Switch
-from xknx.knx import Address
+from xknx.knx import GroupAddress
 
 
 # pylint: disable=too-many-public-methods,invalid-name
@@ -92,13 +92,13 @@ class TestDevices(unittest.TestCase):
         devices.add(light2)
 
         self.assertEqual(
-            tuple(devices.devices_by_group_address(Address('1/6/7'))),
+            tuple(devices.devices_by_group_address(GroupAddress('1/6/7'))),
             (light1,))
         self.assertEqual(
-            tuple(devices.devices_by_group_address(Address('1/6/8'))),
+            tuple(devices.devices_by_group_address(GroupAddress('1/6/8'))),
             (light2,))
         self.assertEqual(
-            tuple(devices.devices_by_group_address(Address('3/0/1'))),
+            tuple(devices.devices_by_group_address(GroupAddress('3/0/1'))),
             (sensor1, sensor2))
 
     def test_iter(self):
@@ -185,7 +185,7 @@ class TestDevices(unittest.TestCase):
 
         self.assertFalse(light1.state)
 
-        for device in devices.devices_by_group_address(Address('1/6/7')):
+        for device in devices.devices_by_group_address(GroupAddress('1/6/7')):
             self.loop.run_until_complete(asyncio.Task(device.set_on()))
 
         self.assertTrue(light1.state)

--- a/test/dpt_2byte_test.py
+++ b/test/dpt_2byte_test.py
@@ -59,7 +59,3 @@ class TestDPT2byte(unittest.TestCase):
         """Test DPTUElCurrentmA parsing with wrong value."""
         with self.assertRaises(ConversionError):
             DPTUElCurrentmA().from_knx((0xFF, 0x4E, 0x12))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT2byte)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_float_test.py
+++ b/test/dpt_float_test.py
@@ -145,7 +145,3 @@ class TestDPTFloat(unittest.TestCase):
         """Test parsing of DPTHumidity with wrong value."""
         with self.assertRaises(ConversionError):
             DPTHumidity().to_knx(-1)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTFloat)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_hvac_mode_test.py
+++ b/test/dpt_hvac_mode_test.py
@@ -58,7 +58,3 @@ class TestDPTControllerStatus(unittest.TestCase):
         """Test parsing of DPTControllerStatus with wrong value)."""
         with self.assertRaises(ConversionError):
             DPTControllerStatus.from_knx((1, 2))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTControllerStatus)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_relative_value_test.py
+++ b/test/dpt_relative_value_test.py
@@ -55,7 +55,3 @@ class TestDPTRelativeValue(unittest.TestCase):
         self.assertEqual(DPTSignedRelativeValue.unit, 'counter pulses')
         self.assertEqual(DPTPercentV8.unit, '%')
         self.assertEqual(DPTValue1Count.unit, 'counter pulses')
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTRelativeValue)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_scaling_test.py
+++ b/test/dpt_scaling_test.py
@@ -73,7 +73,3 @@ class TestDPTScaling(unittest.TestCase):
         """Test parsing of DPTScaling with wrong value (array containing string)."""
         with self.assertRaises(ConversionError):
             DPTScaling().from_knx(("0x23"))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTScaling)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_string_test.py
+++ b/test/dpt_string_test.py
@@ -66,7 +66,3 @@ class TestDPTFloat(unittest.TestCase):
                0x00, 0x00, 0x00]
         with self.assertRaises(ConversionError):
             DPTString().from_knx(raw)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTFloat)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_test.py
+++ b/test/dpt_test.py
@@ -57,7 +57,3 @@ class TestDPT(unittest.TestCase):
         """Test initialization of DPTBinary objects with wrong value."""
         with self.assertRaises(ConversionError):
             DPTBinary(DPTBinary.APCI_MAX_VALUE + 1)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_time_test.py
+++ b/test/dpt_time_test.py
@@ -77,7 +77,3 @@ class TestDPTTime(unittest.TestCase):
         """Test parsing from DPTTime object from wrong string value."""
         with self.assertRaises(ConversionError):
             DPTTime().to_knx("fnord")
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTTime)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_connect_request_test.py
+++ b/test/knxip_connect_request_test.py
@@ -52,7 +52,3 @@ class Test_KNXIP_ConnectRequest(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_ConnectRequest)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_connect_response_test.py
+++ b/test/knxip_connect_response_test.py
@@ -53,7 +53,3 @@ class Test_KNXIP_ConnectResponse(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_ConnectResponse)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_connectionstate_request_test.py
+++ b/test/knxip_connectionstate_request_test.py
@@ -45,7 +45,3 @@ class Test_KNXIP_ConnStateReq(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_ConnStateReq)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_connectionstate_response_test.py
+++ b/test/knxip_connectionstate_response_test.py
@@ -42,7 +42,3 @@ class Test_KNXIP_ConnStateResp(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_ConnStateResp)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_dib_test.py
+++ b/test/knxip_dib_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 from xknx.exceptions import CouldNotParseKNXIP
-from xknx.knx import Address
+from xknx.knx import PhysicalAddress
 from xknx.knxip import (DIB, DIBDeviceInformation, DIBGeneric,
                         DIBServiceFamily, DIBSuppSVCFamilies, DIBTypeCode,
                         KNXMedium)
@@ -44,7 +44,7 @@ class Test_KNXIP_DIB(unittest.TestCase):
         self.assertEqual(dib.from_knx(raw), DIBDeviceInformation.LENGTH)
         self.assertEqual(dib.knx_medium, KNXMedium.TP1)
         self.assertEqual(dib.programming_mode, False)
-        self.assertEqual(dib.individual_address, Address('1.1.0'))
+        self.assertEqual(dib.individual_address, PhysicalAddress('1.1.0'))
         self.assertEqual(dib.name, 'Gira KNX/IP-Router')
         self.assertEqual(dib.mac_address, '00:01:02:03:04:05')
         self.assertEqual(dib.multicast_address, '224.0.23.12')

--- a/test/knxip_dib_test.py
+++ b/test/knxip_dib_test.py
@@ -76,7 +76,3 @@ class Test_KNXIP_DIB(unittest.TestCase):
         ])
 
         self.assertEqual(dib.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_DIB)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_disconnect_request_test.py
+++ b/test/knxip_disconnect_request_test.py
@@ -44,7 +44,3 @@ class Test_KNXIP_DisconnectReq(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_DisconnectReq)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_disconnect_response_test.py
+++ b/test/knxip_disconnect_response_test.py
@@ -42,7 +42,3 @@ class Test_KNXIP_DisconnectResp(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_DisconnectResp)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_hpai_test.py
+++ b/test/knxip_hpai_test.py
@@ -28,7 +28,3 @@ class Test_KNXIP_HPAI(unittest.TestCase):
 
         with self.assertRaises(CouldNotParseKNXIP):
             HPAI().from_knx(raw)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_HPAI)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_routing_indication_test.py
+++ b/test/knxip_routing_indication_test.py
@@ -3,7 +3,7 @@ import asyncio
 import unittest
 
 from xknx import XKNX
-from xknx.knx import (Address, DPTArray, DPTBinary, DPTTemperature, DPTTime,
+from xknx.knx import (GroupAddress, PhysicalAddress, DPTArray, DPTBinary, DPTTemperature, DPTTime,
                       Telegram, TelegramType)
 from xknx.knxip import CEMIFrame, KNXIPFrame, KNXIPServiceType
 
@@ -33,8 +33,8 @@ class Test_KNXIP(unittest.TestCase):
 
         self.assertTrue(isinstance(knxipframe.body, CEMIFrame))
 
-        self.assertEqual(knxipframe.body.src_addr, Address("1.2.2"))
-        self.assertEqual(knxipframe.body.dst_addr, Address(337))
+        self.assertEqual(knxipframe.body.src_addr, PhysicalAddress("1.2.2"))
+        self.assertEqual(knxipframe.body.dst_addr, GroupAddress(337))
 
         self.assertEqual(len(knxipframe.body.payload.value), 1)
         self.assertEqual(knxipframe.body.payload.value[0], 0xf0)
@@ -59,10 +59,10 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe.body.src_addr = Address("1.2.2")
+        knxipframe.body.src_addr = PhysicalAddress("1.2.2")
 
         telegram = Telegram()
-        telegram.group_address = Address(337)
+        telegram.group_address = GroupAddress(337)
 
         telegram.payload = DPTArray(DPTTime().to_knx(
             {'hours': 13, 'minutes': 23, 'seconds': 42}))
@@ -91,7 +91,7 @@ class Test_KNXIP(unittest.TestCase):
 
         telegram = knxipframe.body.telegram
 
-        self.assertEqual(telegram.group_address, Address(337))
+        self.assertEqual(telegram.group_address, GroupAddress(337))
 
         self.assertEqual(len(telegram.payload.value), 1)
         self.assertEqual(telegram.payload.value[0], 0xf0)
@@ -115,11 +115,11 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("329"), payload=DPTBinary(1)))
+                         Telegram(GroupAddress("329"), payload=DPTBinary(1)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("15.15.249")
+        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -139,11 +139,11 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("329"), payload=DPTBinary(0)))
+                         Telegram(GroupAddress("329"), payload=DPTBinary(0)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("15.15.249")
+        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -163,11 +163,11 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("331"), payload=DPTArray(0x65)))
+                         Telegram(GroupAddress("331"), payload=DPTArray(0x65)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("15.15.249")
+        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -187,13 +187,13 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("2049"),
+                         Telegram(GroupAddress("2049"),
                                   payload=DPTArray(
                                       DPTTemperature().to_knx(19.85))))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("1.4.2")
+        knxipframe2.body.src_addr = PhysicalAddress("1.4.2")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -213,11 +213,11 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("440"), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress("440"), TelegramType.GROUP_READ))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("15.15.249")
+        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -237,13 +237,13 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.from_knx(raw)
         telegram = knxipframe.body.telegram
         self.assertEqual(telegram,
-                         Telegram(Address("392"),
+                         Telegram(GroupAddress("392"),
                                   TelegramType.GROUP_RESPONSE,
                                   payload=DPTBinary(1)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = Address("1.3.1")
+        knxipframe2.body.src_addr = PhysicalAddress("1.3.1")
         knxipframe2.body.telegram = telegram
         knxipframe2.body.set_hops(5)
         knxipframe2.normalize()
@@ -255,12 +255,12 @@ class Test_KNXIP(unittest.TestCase):
     def test_maximum_apci(self):
         """Test parsing and streaming CEMIFrame KNX/IP packet, testing maximum APCI."""
         telegram = Telegram()
-        telegram.group_address = Address(337)
+        telegram.group_address = GroupAddress(337)
         telegram.payload = DPTBinary(DPTBinary.APCI_MAX_VALUE)
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe.body.src_addr = Address("1.3.1")
+        knxipframe.body.src_addr = PhysicalAddress("1.3.1")
         knxipframe.body.telegram = telegram
         knxipframe.body.set_hops(5)
         knxipframe.normalize()

--- a/test/knxip_routing_indication_test.py
+++ b/test/knxip_routing_indication_test.py
@@ -274,7 +274,3 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
         knxipframe2.from_knx(knxipframe.to_knx())
         self.assertEqual(knxipframe2.body.telegram, telegram)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_search_request_test.py
+++ b/test/knxip_search_request_test.py
@@ -40,7 +40,3 @@ class Test_KNXIP_Discovery(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_Discovery)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_search_response_test.py
+++ b/test/knxip_search_response_test.py
@@ -64,7 +64,3 @@ class Test_KNXIP_Discovery(unittest.TestCase):
         knxipframe2.body.dibs.append(knxipframe.body.dibs[1])
         knxipframe2.normalize()
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_Discovery)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_tunnelling_ack_test.py
+++ b/test/knxip_tunnelling_ack_test.py
@@ -42,7 +42,3 @@ class Test_KNXIP_TunnelingReq(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_TunnelingReq)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_tunnelling_request_test.py
+++ b/test/knxip_tunnelling_request_test.py
@@ -47,7 +47,3 @@ class Test_KNXIP_TunnelingReq(unittest.TestCase):
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.to_knx(), list(raw))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(Test_KNXIP_TunnelingReq)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/knxip_tunnelling_request_test.py
+++ b/test/knxip_tunnelling_request_test.py
@@ -3,7 +3,7 @@ import asyncio
 import unittest
 
 from xknx import XKNX
-from xknx.knx import Address, DPTBinary, Telegram
+from xknx.knx import GroupAddress, DPTBinary, Telegram
 from xknx.knxip import (CEMIFrame, KNXIPFrame, KNXIPServiceType,
                         TunnellingRequest)
 
@@ -37,12 +37,12 @@ class Test_KNXIP_TunnelingReq(unittest.TestCase):
         self.assertTrue(isinstance(knxipframe.body.cemi, CEMIFrame))
 
         self.assertEqual(knxipframe.body.cemi.telegram,
-                         Telegram(Address('9/0/8'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('9/0/8'), payload=DPTBinary(1)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.TUNNELLING_REQUEST)
         knxipframe2.body.cemi.telegram = Telegram(
-            Address('9/0/8'), payload=DPTBinary(1))
+            GroupAddress('9/0/8'), payload=DPTBinary(1))
         knxipframe2.body.sequence_counter = 23
         knxipframe2.normalize()
 

--- a/test/light_test.py
+++ b/test/light_test.py
@@ -205,7 +205,3 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.brightness, 80)
         self.loop.run_until_complete(asyncio.Task(light.do("off")))
         self.assertFalse(light.state)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestLight)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/light_test.py
+++ b/test/light_test.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Light
-from xknx.knx import Address, DPTArray, DPTBinary, Telegram, TelegramType
+from xknx.knx import GroupAddress, DPTArray, DPTBinary, Telegram, TelegramType
 
 
 class TestLight(unittest.TestCase):
@@ -56,11 +56,11 @@ class TestLight(unittest.TestCase):
 
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram2,
-                         Telegram(Address('1/2/5'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/5'), TelegramType.GROUP_READ))
 
     #
     # SYNC WITH STATE ADDRESS
@@ -80,10 +80,10 @@ class TestLight(unittest.TestCase):
 
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram1,
-                         Telegram(Address('1/2/6'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/6'), TelegramType.GROUP_READ))
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(telegram2,
-                         Telegram(Address('1/2/9'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/9'), TelegramType.GROUP_READ))
 
     #
     # TEST SET ON
@@ -99,7 +99,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('1/2/3'), payload=DPTBinary(1)))
 
     #
     # TEST SET OFF
@@ -115,7 +115,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/3'), payload=DPTBinary(0)))
 
     #
     # TEST SET BRIGHTNESS
@@ -131,7 +131,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/5'), payload=DPTArray(23)))
+                         Telegram(GroupAddress('1/2/5'), payload=DPTArray(23)))
 
     #
     # TEST PROCESS
@@ -145,11 +145,11 @@ class TestLight(unittest.TestCase):
                       group_address_brightness='1/2/5')
         self.assertEqual(light.state, False)
 
-        telegram = Telegram(Address('1/2/3'), payload=DPTBinary(1))
+        telegram = Telegram(GroupAddress('1/2/3'), payload=DPTBinary(1))
         self.loop.run_until_complete(asyncio.Task(light.process(telegram)))
         self.assertEqual(light.state, True)
 
-        telegram = Telegram(Address('1/2/3'), payload=DPTBinary(0))
+        telegram = Telegram(GroupAddress('1/2/3'), payload=DPTBinary(0))
         self.loop.run_until_complete(asyncio.Task(light.process(telegram)))
         self.assertEqual(light.state, False)
 
@@ -171,7 +171,7 @@ class TestLight(unittest.TestCase):
 
         light.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(Address('1/2/3'), payload=DPTBinary(1))
+        telegram = Telegram(GroupAddress('1/2/3'), payload=DPTBinary(1))
         self.loop.run_until_complete(asyncio.Task(light.process(telegram)))
 
         after_update_callback.assert_called_with(light)
@@ -185,7 +185,7 @@ class TestLight(unittest.TestCase):
                       group_address_brightness='1/2/5')
         self.assertEqual(light.brightness, 0)
 
-        telegram = Telegram(Address('1/2/5'), payload=DPTArray(23))
+        telegram = Telegram(GroupAddress('1/2/5'), payload=DPTArray(23))
         self.loop.run_until_complete(asyncio.Task(light.process(telegram)))
         self.assertEqual(light.brightness, 23)
 

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Sensor
-from xknx.knx import Address, DPTArray, DPTBinary, Telegram, TelegramType
+from xknx.knx import GroupAddress, DPTArray, DPTBinary, Telegram, TelegramType
 
 
 class TestSensor(unittest.TestCase):
@@ -112,7 +112,7 @@ class TestSensor(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     #
     # TEST PROCESS
@@ -125,7 +125,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3')
 
-        telegram = Telegram(Address('1/2/3'))
+        telegram = Telegram(GroupAddress('1/2/3'))
         telegram.payload = DPTArray((0x01, 0x02, 0x03))
         self.loop.run_until_complete(asyncio.Task(sensor.process(telegram)))
         self.assertEqual(sensor.state, DPTArray((0x01, 0x02, 0x03)))
@@ -147,7 +147,7 @@ class TestSensor(unittest.TestCase):
             after_update_callback(device)
         sensor.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(Address('1/2/3'))
+        telegram = Telegram(GroupAddress('1/2/3'))
         telegram.payload = DPTArray((0x01, 0x02, 0x03))
         self.loop.run_until_complete(asyncio.Task(sensor.process(telegram)))
         after_update_callback.assert_called_with(sensor)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -9,7 +9,7 @@ from xknx.devices import (Action, ActionBase, ActionCallback, BinarySensor,
 from xknx.exceptions import (ConversionError, CouldNotParseAddress,
                              CouldNotParseKNXIP, CouldNotParseTelegram,
                              DeviceIllegalValue)
-from xknx.knx import Address, DPTArray, DPTBinary, Telegram
+from xknx.knx import GroupAddress, DPTArray, DPTBinary, Telegram, PhysicalAddress
 from xknx.knxip import (HPAI, CEMIFrame, ConnectionStateRequest,
                         ConnectionStateResponse, ConnectRequest,
                         ConnectRequestType, ConnectResponse,
@@ -42,11 +42,11 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_state='1/2/4')
         self.assertEqual(
             str(remote_value),
-            '<RemoteValue <Address str="1/2/3" />/<Address str="1/2/4" />/None/None/>')
+            '<RemoteValue GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None/>')
         remote_value.payload = DPTArray([0x01, 0x02])
         self.assertEqual(
             str(remote_value),
-            '<RemoteValue <Address str="1/2/3" />/<Address str="1/2/4" />/<DPTArray value="[0x1,0x2]" />/None/>')
+            '<RemoteValue GroupAddress("1/2/3")/GroupAddress("1/2/4")/<DPTArray value="[0x1,0x2]" />/None/>')
 
     def test_binary_sensor(self):
         """Test string representation of binary sensor object."""
@@ -58,7 +58,7 @@ class TestStringRepresentations(unittest.TestCase):
             device_class='motion')
         self.assertEqual(
             str(binary_sensor),
-            '<BinarySensor group_address="<Address str="1/2/3" />" name="Fnord" state="BinarySensorState.OFF"/>')
+            '<BinarySensor group_address="GroupAddress("1/2/3")" name="Fnord" state="BinarySensorState.OFF"/>')
 
     def test_climate(self):
         """Test string representation of climate object."""
@@ -82,10 +82,10 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_controller_status_state='1/2/11')
         self.assertEqual(
             str(climate),
-            '<Climate name="Wohnzimmer" temperature="<Address str="1/2/1" />/None/None/None"  target_temperature="<Address str="1/2/2" />/None/None/'
-            'None"  setpoint_shift="<Address str="1/2/3" />/<Address str="1/2/4" />/None/None" setpoint_shift_step="0.1" setpoint_shift_max="20" set'
-            'point_shift_min="-20" group_address_operation_mode="<Address str="1/2/5" />" group_address_operation_mode_state="<Address str="1/2/6" /'
-            '>" group_address_controller_status="<Address str="1/2/10" />" group_address_controller_status_state="<Address str="1/2/11" />" />')
+            '<Climate name="Wohnzimmer" temperature="GroupAddress("1/2/1")/None/None/None"  target_temperature="GroupAddress("1/2/2")/None/None/'
+            'None"  setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" setpoint_shift_step="0.1" setpoint_shift_max="20" set'
+            'point_shift_min="-20" group_address_operation_mode="GroupAddress("1/2/5")" group_address_operation_mode_state="GroupAddress("1/2/6")'
+            '" group_address_controller_status="GroupAddress("1/2/10")" group_address_controller_status_state="GroupAddress("1/2/11")" />')
 
     def test_cover(self):
         """Test string representation of cover object."""
@@ -103,8 +103,8 @@ class TestStringRepresentations(unittest.TestCase):
             travel_time_up=10)
         self.assertEqual(
             str(cover),
-            '<Cover name="Rolladen" updown"<Address str="1/2/3" />/None/None/None" step="<Address str="1/2/4" />/None/None/None" position="<Address '
-            'str="1/2/5" />/<Address str="1/2/6" />/None/None" angle="<Address str="1/2/7" />/<Address str="1/2/8" />/None/None" travel_time_down="8'
+            '<Cover name="Rolladen" updown"GroupAddress("1/2/3")/None/None/None" step="GroupAddress("1/2/4")/None/None/None" position="Group'
+            'Address("1/2/5")/GroupAddress("1/2/6")/None/None" angle="GroupAddress("1/2/7")/GroupAddress("1/2/8")/None/None" travel_time_down="8'
             '" travel_time_up="10" />')
 
     def test_light(self):
@@ -119,8 +119,8 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_brightness_state='1/2/6')
         self.assertEqual(
             str(light),
-            '<Light name="Licht" switch="<Address str="1/2/3" />/<Address str="1/2/4" />/None/None" group_address_brightness="<Address str="1/2/5" /'
-            '>" group_address_brightness_state="<Address str="1/2/6" />" brightness="0" />')
+            '<Light name="Licht" switch="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" group_address_brightness="GroupAddress("1/2/5")'
+            '" group_address_brightness_state="GroupAddress("1/2/6")" brightness="0" />')
 
     def test_notification(self):
         """Test string representation of notification object."""
@@ -131,11 +131,11 @@ class TestStringRepresentations(unittest.TestCase):
             group_address='1/2/3')
         self.assertEqual(
             str(notification),
-            '<Notification name="Alarm" group_address="<Address str="1/2/3" />" message="" />')
+            '<Notification name="Alarm" group_address="GroupAddress("1/2/3")" message="" />')
         notification.message = 'Einbrecher im Haus'
         self.assertEqual(
             str(notification),
-            '<Notification name="Alarm" group_address="<Address str="1/2/3" />" message="Einbrecher im Haus" />')
+            '<Notification name="Alarm" group_address="GroupAddress("1/2/3")" message="Einbrecher im Haus" />')
 
     def test_sensor(self):
         """Test string representation of sensor object."""
@@ -147,11 +147,11 @@ class TestStringRepresentations(unittest.TestCase):
             value_type='percent')
         self.assertEqual(
             str(sensor),
-            '<Sensor name="MeinSensor" group_address="<Address str="1/2/3" />" state="None" resolve_state="None" />')
+            '<Sensor name="MeinSensor" group_address="GroupAddress("1/2/3")" state="None" resolve_state="None" />')
         self.loop.run_until_complete(asyncio.Task(sensor._set_internal_state(DPTArray((0x23)))))  # pylint: disable=protected-access
         self.assertEqual(
             str(sensor),
-            '<Sensor name="MeinSensor" group_address="<Address str="1/2/3" />" state="<DPTArray value="[0x23]" />" resolve_state="14" />')
+            '<Sensor name="MeinSensor" group_address="GroupAddress("1/2/3")" state="<DPTArray value="[0x23]" />" resolve_state="14" />')
 
     def test_switch(self):
         """Test string representation of switch object."""
@@ -163,7 +163,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_state="1/2/4")
         self.assertEqual(
             str(switch),
-            '<Switch name="Schalter" switch="<Address str="1/2/3" />/<Address str="1/2/4" />/None/None" />')
+            '<Switch name="Schalter" switch="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" />')
 
     def test_time(self):
         """Test string representation of time object."""
@@ -174,7 +174,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address="1/2/3")
         self.assertEqual(
             str(time),
-            '<Time name="Zeit" group_address="<Address str="1/2/3" />" />')
+            '<Time name="Zeit" group_address="GroupAddress("1/2/3")" />')
 
     def test_action_base(self):
         """Test string representation of action base."""
@@ -254,10 +254,10 @@ class TestStringRepresentations(unittest.TestCase):
 
     def test_address(self):
         """Test string representation of address object."""
-        address = Address("1/2/3")
+        address = GroupAddress("1/2/3")
         self.assertEqual(
             str(address),
-            '<Address str="1/2/3" />')
+            'GroupAddress("1/2/3")')
 
     def test_dpt_array(self):
         """Test string representation of DPTBinary."""
@@ -276,11 +276,11 @@ class TestStringRepresentations(unittest.TestCase):
     def test_telegram(self):
         """Test string representation of Telegram."""
         telegram = Telegram(
-            group_address=Address('1/2/3'),
+            group_address=GroupAddress('1/2/3'),
             payload=DPTBinary(7))
         self.assertEqual(
             str(telegram),
-            '<Telegram group_address="<Address str="1/2/3" />", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
+            '<Telegram group_address="GroupAddress("1/2/3")", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
             '"TelegramDirection.OUTGOING" />')
 
     def test_dib_generic(self):
@@ -306,7 +306,7 @@ class TestStringRepresentations(unittest.TestCase):
         dib = DIBDeviceInformation()
         dib.knx_medium = KNXMedium.TP1
         dib.programming_mode = False
-        dib.individual_address = Address('1.1.0')
+        dib.individual_address = PhysicalAddress('1.1.0')
         dib.name = 'Gira KNX/IP-Router'
         dib.mac_address = '00:01:02:03:04:05'
         dib.multicast_address = '224.0.23.12'
@@ -318,7 +318,7 @@ class TestStringRepresentations(unittest.TestCase):
             '<DIBDeviceInformation \n'
             '\tknx_medium="KNXMedium.TP1" \n'
             '\tprogramming_mode="False" \n'
-            '\tindividual_address="<Address str="1.1.0" />" \n'
+            '\tindividual_address="PhysicalAddress("1.1.0")" \n'
             '\tinstallation_number="2" \n'
             '\tproject_number="564" \n'
             '\tserial_number="13:37:13:37:13:37" \n'
@@ -436,8 +436,8 @@ class TestStringRepresentations(unittest.TestCase):
         tunnelling_request.sequence_counter = 42
         self.assertEqual(
             str(tunnelling_request),
-            '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="<CEMIFrame SourceAddress="<Address str="0/0/0" />" Destina'
-            'tionAddress="<Address str="0/0/0" />" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />')
+            '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="<CEMIFrame SourceAddress="GroupAddress("0/0/0")" Destina'
+            'tionAddress="GroupAddress("0/0/0")" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />')
 
     def test_tunnelling_ack(self):
         """Test string representation of KNX/IP TunnellingAck."""
@@ -453,13 +453,13 @@ class TestStringRepresentations(unittest.TestCase):
         """Test string representation of KNX/IP CEMI Frame."""
         xknx = XKNX(loop=self.loop)
         cemi_frame = CEMIFrame(xknx)
-        cemi_frame.src_addr = Address("1/2/3")
+        cemi_frame.src_addr = GroupAddress("1/2/3")
         cemi_frame.telegram = Telegram(
-            group_address=Address('1/2/5'),
+            group_address=GroupAddress('1/2/5'),
             payload=DPTBinary(7))
         self.assertEqual(
             str(cemi_frame),
-            '<CEMIFrame SourceAddress="<Address str="1/2/3" />" DestinationAddress="<Address str="1/2/5" />" Flags="1011110011100000" Command="APCIC'
+            '<CEMIFrame SourceAddress="GroupAddress("1/2/3")" DestinationAddress="GroupAddress("1/2/5")" Flags="1011110011100000" Command="APCIC'
             'ommand.GROUP_WRITE" payload="<DPTBinary value="7" />" />')
 
     def test_knxip_frame(self):

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -472,7 +472,3 @@ class TestStringRepresentations(unittest.TestCase):
             '<KNXIPFrame <KNXIPHeader HeaderLength="6" ProtocolVersion="16" KNXIPServiceType="KNXIPServiceType.SEARCH_REQUEST" Reserve="0" TotalLeng'
             'th="0" />\n'
             ' body="<SearchRequest discovery_endpoint="<HPAI 224.0.23.12:3671 />" />" />')
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestStringRepresentations)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/switch_test.py
+++ b/test/switch_test.py
@@ -132,7 +132,3 @@ class TestSwitch(unittest.TestCase):
         self.assertTrue(switch.state)
         self.loop.run_until_complete(asyncio.Task(switch.do("off")))
         self.assertFalse(switch.state)
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestSwitch)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/switch_test.py
+++ b/test/switch_test.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Switch
-from xknx.knx import Address, DPTBinary, Telegram, TelegramType
+from xknx.knx import GroupAddress, DPTBinary, Telegram, TelegramType
 
 
 class TestSwitch(unittest.TestCase):
@@ -33,7 +33,7 @@ class TestSwitch(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     def test_sync_state_address(self):
         """Test sync function / sending group reads to KNX bus. Test with Switch with explicit state address."""
@@ -47,7 +47,7 @@ class TestSwitch(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+                         Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
 
     #
     # TEST PROCESS
@@ -60,14 +60,14 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(switch.state, False)
 
         telegram_on = Telegram()
-        telegram_on.group_address = Address('1/2/3')
+        telegram_on.group_address = GroupAddress('1/2/3')
         telegram_on.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(switch.process(telegram_on)))
 
         self.assertEqual(switch.state, True)
 
         telegram_off = Telegram()
-        telegram_off.group_address = Address('1/2/3')
+        telegram_off.group_address = GroupAddress('1/2/3')
         telegram_off.payload = DPTBinary(0)
         self.loop.run_until_complete(asyncio.Task(switch.process(telegram_off)))
 
@@ -89,7 +89,7 @@ class TestSwitch(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram()
-        telegram.group_address = Address('1/2/3')
+        telegram.group_address = GroupAddress('1/2/3')
         telegram.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(switch.process(telegram)))
 
@@ -106,7 +106,7 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), payload=DPTBinary(1)))
+                         Telegram(GroupAddress('1/2/3'), payload=DPTBinary(1)))
 
     #
     # TEST SET OFF
@@ -119,7 +119,7 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(Address('1/2/3'), payload=DPTBinary(0)))
+                         Telegram(GroupAddress('1/2/3'), payload=DPTBinary(0)))
 
     #
     # TEST DO

--- a/test/telegram_received_cb_test.py
+++ b/test/telegram_received_cb_test.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import Mock
 
 from xknx import XKNX
-from xknx.knx import (Address, AddressFilter, DPTBinary, Telegram,
+from xknx.knx import (GroupAddress, AddressFilter, DPTBinary, Telegram,
                       TelegramDirection)
 
 
@@ -40,7 +40,7 @@ class TestTelegramReceivedCallback(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=Address("1/2/3"))
+            group_address=GroupAddress("1/2/3"))
         self.loop.run_until_complete(asyncio.Task(
             xknx.telegram_queue.process_telegram(telegram)))
         telegram_received_callback.assert_called_with(telegram)
@@ -66,7 +66,7 @@ class TestTelegramReceivedCallback(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=Address("1/2/3"))
+            group_address=GroupAddress("1/2/3"))
         self.loop.run_until_complete(asyncio.Task(
             xknx.telegram_queue.process_telegram(telegram)))
         telegram_received_callback.assert_called_with(telegram)
@@ -92,7 +92,7 @@ class TestTelegramReceivedCallback(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=Address("1/2/3"))
+            group_address=GroupAddress("1/2/3"))
         self.loop.run_until_complete(asyncio.Task(
             xknx.telegram_queue.process_telegram(telegram)))
         telegram_received_callback.assert_not_called()
@@ -118,7 +118,7 @@ class TestTelegramReceivedCallback(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=Address("1/2/3"))
+            group_address=GroupAddress("1/2/3"))
         self.loop.run_until_complete(asyncio.Task(
             xknx.telegram_queue.process_telegram(telegram)))
         telegram_received_callback.assert_not_called()

--- a/test/telegram_received_cb_test.py
+++ b/test/telegram_received_cb_test.py
@@ -122,7 +122,3 @@ class TestTelegramReceivedCallback(unittest.TestCase):
         self.loop.run_until_complete(asyncio.Task(
             xknx.telegram_queue.process_telegram(telegram)))
         telegram_received_callback.assert_not_called()
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestTelegramReceivedCallback)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/telegram_test.py
+++ b/test/telegram_test.py
@@ -28,7 +28,3 @@ class TestTelegram(unittest.TestCase):
             Telegram(Address('1/2/3'), TelegramType.GROUP_READ),
             Telegram(Address('1/2/3'), TelegramType.GROUP_READ,
                      TelegramDirection.INCOMING))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestTelegram)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/telegram_test.py
+++ b/test/telegram_test.py
@@ -1,7 +1,7 @@
 """Unit test for Telegram objects."""
 import unittest
 
-from xknx.knx import Address, Telegram, TelegramDirection, TelegramType
+from xknx.knx import GroupAddress, Telegram, TelegramDirection, TelegramType
 
 
 class TestTelegram(unittest.TestCase):
@@ -13,18 +13,18 @@ class TestTelegram(unittest.TestCase):
     def test_telegram_equal(self):
         """Test equals operator."""
         self.assertEqual(
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ),
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ),
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     def test_telegram_not_equal(self):
         """Test not equals operator."""
         self.assertNotEqual(
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ),
-            Telegram(Address('1/2/4'), TelegramType.GROUP_READ))
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ),
+            Telegram(GroupAddress('1/2/4'), TelegramType.GROUP_READ))
         self.assertNotEqual(
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ),
-            Telegram(Address('1/2/3'), TelegramType.GROUP_WRITE))
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ),
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_WRITE))
         self.assertNotEqual(
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ),
-            Telegram(Address('1/2/3'), TelegramType.GROUP_READ,
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ),
+            Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ,
                      TelegramDirection.INCOMING))

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -44,7 +44,3 @@ class TestTime(unittest.TestCase):
         time = Time(xknx, "TestTime", group_address='1/2/3')
         self.assertTrue(time.has_group_address(Address('1/2/3')))
         self.assertFalse(time.has_group_address(Address('1/2/4')))
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestTime)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/time_test.py
+++ b/test/time_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from xknx import XKNX
 from xknx.devices import Time
-from xknx.knx import Address, TelegramType
+from xknx.knx import GroupAddress, TelegramType
 
 
 class TestTime(unittest.TestCase):
@@ -31,7 +31,7 @@ class TestTime(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
 
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.group_address, Address('1/2/3'))
+        self.assertEqual(telegram.group_address, GroupAddress('1/2/3'))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 3)
 
@@ -42,5 +42,5 @@ class TestTime(unittest.TestCase):
         """Test if has_group_address function works."""
         xknx = XKNX(loop=self.loop)
         time = Time(xknx, "TestTime", group_address='1/2/3')
-        self.assertTrue(time.has_group_address(Address('1/2/3')))
-        self.assertFalse(time.has_group_address(Address('1/2/4')))
+        self.assertTrue(time.has_group_address(GroupAddress('1/2/3')))
+        self.assertFalse(time.has_group_address(GroupAddress('1/2/4')))

--- a/test/travelcalculator_test.py
+++ b/test/travelcalculator_test.py
@@ -230,7 +230,3 @@ class TestTravelCalculator(unittest.TestCase):
 
         travelcalculator.time_set_from_outside = 1005
         self.assertFalse(travelcalculator.is_traveling())
-
-
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestTravelCalculator)
-unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -9,7 +9,7 @@ import yaml
 
 from xknx.devices import (BinarySensor, Climate, Cover, Light, Notification,
                           Sensor, Switch, Time)
-from xknx.knx import Address, AddressType
+from xknx.knx import PhysicalAddress
 
 
 class Config:
@@ -32,8 +32,7 @@ class Config:
         if "general" in doc:
             if "own_address" in doc["general"]:
                 self.xknx.own_address = \
-                    Address(doc["general"]["own_address"],
-                            AddressType.PHYSICAL)
+                    PhysicalAddress(doc["general"]["own_address"])
 
     def parse_groups(self, doc):
         """Parse the group section of xknx.yaml."""

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -13,7 +13,7 @@ import time
 from enum import Enum
 
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.knx import Address
+from xknx.knx import GroupAddress
 
 from .action import Action
 from .device import Device
@@ -46,7 +46,7 @@ class BinarySensor(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
         if isinstance(group_address, (str, int)):
-            group_address = Address(group_address)
+            group_address = GroupAddress(group_address)
         if not isinstance(significant_bit, int):
             raise TypeError()
         if actions is None:

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -7,7 +7,7 @@ Module for managing the climate within a room.
 import asyncio
 
 from xknx.exceptions import CouldNotParseTelegram, DeviceIllegalValue
-from xknx.knx import (Address, DPTArray, DPTBinary, DPTControllerStatus,
+from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTControllerStatus,
                       DPTHVACMode, HVACOperationMode)
 
 from .device import Device
@@ -45,19 +45,19 @@ class Climate(Device):
         # pylint: disable=too-many-arguments, too-many-locals
         Device.__init__(self, xknx, name, device_updated_cb)
         if isinstance(group_address_operation_mode, (str, int)):
-            group_address_operation_mode = Address(group_address_operation_mode)
+            group_address_operation_mode = GroupAddress(group_address_operation_mode)
         if isinstance(group_address_operation_mode_state, (str, int)):
-            group_address_operation_mode_state = Address(group_address_operation_mode_state)
+            group_address_operation_mode_state = GroupAddress(group_address_operation_mode_state)
         if isinstance(group_address_operation_mode_protection, (str, int)):
-            group_address_operation_mode_protection = Address(group_address_operation_mode_protection)
+            group_address_operation_mode_protection = GroupAddress(group_address_operation_mode_protection)
         if isinstance(group_address_operation_mode_night, (str, int)):
-            group_address_operation_mode_night = Address(group_address_operation_mode_night)
+            group_address_operation_mode_night = GroupAddress(group_address_operation_mode_night)
         if isinstance(group_address_operation_mode_comfort, (str, int)):
-            group_address_operation_mode_comfort = Address(group_address_operation_mode_comfort)
+            group_address_operation_mode_comfort = GroupAddress(group_address_operation_mode_comfort)
         if isinstance(group_address_controller_status, (str, int)):
-            group_address_controller_status = Address(group_address_controller_status)
+            group_address_controller_status = GroupAddress(group_address_controller_status)
         if isinstance(group_address_controller_status_state, (str, int)):
-            group_address_controller_status_state = Address(group_address_controller_status_state)
+            group_address_controller_status_state = GroupAddress(group_address_controller_status_state)
 
         self.group_address_operation_mode = group_address_operation_mode
         self.group_address_operation_mode_state = group_address_operation_mode_state

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -10,7 +10,7 @@ It provides functionality for
 import asyncio
 
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.knx import Address, DPTArray
+from xknx.knx import GroupAddress, DPTArray
 
 from .device import Device
 from .remote_value import RemoteValueSwitch1001
@@ -31,9 +31,9 @@ class Light(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
         if isinstance(group_address_brightness, (str, int)):
-            group_address_brightness = Address(group_address_brightness)
+            group_address_brightness = GroupAddress(group_address_brightness)
         if isinstance(group_address_brightness_state, (str, int)):
-            group_address_brightness_state = Address(group_address_brightness_state)
+            group_address_brightness_state = GroupAddress(group_address_brightness_state)
 
         self.switch = RemoteValueSwitch1001(
             xknx,

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -2,7 +2,7 @@
 import asyncio
 
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.knx import Address, DPTArray, DPTString
+from xknx.knx import GroupAddress, DPTArray, DPTString
 
 from .device import Device
 
@@ -19,7 +19,7 @@ class Notification(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
         if isinstance(group_address, (str, int)):
-            group_address = Address(group_address)
+            group_address = GroupAddress(group_address)
 
         self.group_address = group_address
         self.message = ""

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -9,7 +9,7 @@ import asyncio
 from enum import Enum
 
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.knx import (Address, DPTArray, DPTBinary, DPTScaling, DPTTemperature,
+from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTScaling, DPTTemperature,
                       DPTValue1Count, Telegram)
 
 
@@ -24,9 +24,9 @@ class RemoteValue():
         """Initialize RemoteValue class."""
         self.xknx = xknx
         if isinstance(group_address, (str, int)):
-            group_address = Address(group_address)
+            group_address = GroupAddress(group_address)
         if isinstance(group_address_state, (str, int)):
-            group_address_state = Address(group_address_state)
+            group_address_state = GroupAddress(group_address_state)
 
         self.group_address = group_address
         self.group_address_state = group_address_state

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -8,7 +8,7 @@ It provides functionality for
 """
 import asyncio
 
-from xknx.knx import (Address, DPTArray, DPTBinary, DPTHumidity, DPTLux,
+from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTHumidity, DPTLux,
                       DPTScaling, DPTTemperature, DPTUElCurrentmA, DPTWsp)
 
 from .device import Device
@@ -27,7 +27,7 @@ class Sensor(Device):
         # pylint: disable=too-many-arguments
         Device.__init__(self, xknx, name, device_updated_cb)
         if isinstance(group_address, (str, int)):
-            group_address = Address(group_address)
+            group_address = GroupAddress(group_address)
         if value_type == 'brightness':
             value_type = 'illuminance'
         self.group_address = group_address

--- a/xknx/devices/time.py
+++ b/xknx/devices/time.py
@@ -8,7 +8,7 @@ by StateUpdate.
 
 import asyncio
 
-from xknx.knx import Address, DPTArray, DPTTime
+from xknx.knx import GroupAddress, DPTArray, DPTTime
 
 from .device import Device
 
@@ -25,7 +25,7 @@ class Time(Device):
         Device.__init__(self, xknx, name, device_updated_cb)
 
         if isinstance(group_address, (str, int)):
-            group_address = Address(group_address)
+            group_address = GroupAddress(group_address)
 
         self.group_address = group_address
 

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -7,7 +7,7 @@ Module for handling KNX primitves.
 
 """
 # flake8: noqa
-from .address import Address, AddressType, AddressFormat
+from .address import GroupAddress, GroupAddressType, PhysicalAddress
 from .address_filter import AddressFilter
 from .telegram import Telegram, TelegramDirection, TelegramType
 from .dpt import DPTBase, DPTBinary, DPTArray, DPTComparator

--- a/xknx/knx/address_filter.py
+++ b/xknx/knx/address_filter.py
@@ -23,7 +23,7 @@ Patterns can be
 """
 from xknx.exceptions import ConversionError
 
-from .address import Address
+from .address import GroupAddress
 
 
 class AddressFilter:
@@ -47,7 +47,7 @@ class AddressFilter:
     def match(self, address):
         """Test if provided address matches Addressfilter."""
         if isinstance(address, str):
-            address = Address(address)
+            address = GroupAddress(address)
         if len(self.level_filters) == 3:
             return self._match_level3(address)
         elif len(self.level_filters) == 2:
@@ -57,21 +57,24 @@ class AddressFilter:
 
     def _match_level3(self, address):
         return (
-            self.level_filters[0].match(address.get_level3_1())
+            self.level_filters[0].match(address.main)
             and
-            self.level_filters[1].match(address.get_level3_2())
+            self.level_filters[1].match(address.middle)
             and
-            self.level_filters[2].match(address.get_level3_3()))
+            self.level_filters[2].match(address.sub)
+        )
 
     def _match_level2(self, address):
         return (
-            self.level_filters[0].match(address.get_level2_1())
+            self.level_filters[0].match(address.main)
             and
-            self.level_filters[1].match(address.get_level2_2()))
+            self.level_filters[1].match(address.sub)
+        )
 
     def _match_free(self, address):
         return (
-            self.level_filters[0].match(address.get_free()))
+            self.level_filters[0].match(address.sub)
+        )
 
     class Range:
         """Class for filtering patterns like "8", "*", "8-10"."""
@@ -95,7 +98,7 @@ class AddressFilter:
 
         def _init_wildcard(self):
             self.range_from = 0
-            self.range_to = Address.MAX_FREE
+            self.range_to = GroupAddress.MAX_FREE
 
         def _init_digit(self, pattern):
             digit = int(pattern)
@@ -107,12 +110,12 @@ class AddressFilter:
             self.range_from = int(range_from) \
                 if range_from else 0
             self.range_to = int(range_to) \
-                if range_to else Address.MAX_FREE
+                if range_to else GroupAddress.MAX_FREE
 
         @staticmethod
         def _adjust_range(digit):
-            if digit > Address.MAX_FREE:
-                return Address.MAX_FREE
+            if digit > GroupAddress.MAX_FREE:
+                return GroupAddress.MAX_FREE
             if digit < 0:
                 return 0
             return digit

--- a/xknx/knx/telegram.py
+++ b/xknx/knx/telegram.py
@@ -16,7 +16,7 @@ It contains
 """
 from enum import Enum
 
-from .address import Address
+from .address import GroupAddress
 
 
 class TelegramDirection(Enum):
@@ -39,7 +39,7 @@ class Telegram:
 
     # pylint: disable=too-few-public-methods
 
-    def __init__(self, group_address=Address(),
+    def __init__(self, group_address=GroupAddress(None),
                  telegramtype=TelegramType.GROUP_WRITE,
                  direction=TelegramDirection.OUTGOING,
                  payload=None):

--- a/xknx/knxip/dib.py
+++ b/xknx/knxip/dib.py
@@ -12,7 +12,7 @@ A KNX/IP Search Response may contain several DIBs of different types:
 """
 
 from xknx.exceptions import CouldNotParseKNXIP
-from xknx.knx import Address, AddressType
+from xknx.knx import PhysicalAddress
 
 from .knxip_enum import DIBServiceFamily, DIBTypeCode, KNXMedium
 
@@ -186,7 +186,7 @@ class DIBDeviceInformation(DIB):
         super(DIBDeviceInformation, self).__init__()
         self.knx_medium = KNXMedium.TP1
         self.programming_mode = False
-        self.individual_address = Address()
+        self.individual_address = PhysicalAddress(None)
         self.installation_number = 0
         self.project_number = 0
         self.serial_number = ""
@@ -211,7 +211,7 @@ class DIBDeviceInformation(DIB):
         # last bit of device_status. All other bits are unused
         self.programming_mode = bool(raw[3])
         self.individual_address = \
-            Address((raw[4], raw[5]), AddressType.PHYSICAL)
+            PhysicalAddress((raw[4], raw[5]))
         installation_project_identifier = raw[6]*256+raw[7]
         self.project_number = installation_project_identifier >> 4
         self.installation_number = installation_project_identifier & 15

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -6,7 +6,7 @@ import signal
 from xknx.core import Config, TelegramQueue
 from xknx.devices import Devices
 from xknx.io import ConnectionConfig, KNXIPInterface
-from xknx.knx import Address, AddressFormat
+from xknx.knx import PhysicalAddress, GroupAddressType
 
 
 class XKNX:
@@ -19,8 +19,8 @@ class XKNX:
     def __init__(self,
                  config=None,
                  loop=None,
-                 own_address=Address(DEFAULT_ADDRESS),
-                 address_format=AddressFormat.LEVEL3,
+                 own_address=PhysicalAddress(DEFAULT_ADDRESS),
+                 address_format=GroupAddressType.LONG,
                  telegram_received_cb=None,
                  device_updated_cb=None):
         """Initialize XKNX class."""


### PR DESCRIPTION
Currently we use `Address()` for just everything address related. This results in a lot of unstructured code and is not really python like.

This change splits `Address()` in `GroupAddress` and `PhysicalAddress` to honor the specials of these types much better. Later on we should provide more helpers, like `is_valid`.

After all, we should think about uninitialized Addresses in xknx at all, to avoid potential fuckups as 0 is the current default address in some parts.

This changes breaks compatibility with existing third party software, if they use `Address`. I think its time to create some CHANGELOG.md for the next release.