### PR TITLE
Add electric sensors

### DIFF
--- a/home-assistant-plugin/custom_components/xknx.py
+++ b/home-assistant-plugin/custom_components/xknx.py
@@ -269,12 +269,12 @@ class KNXModule(object):
     @asyncio.coroutine
     def async_broadcast_temperature(self, entity_id, old_state, new_state):
         """Broadcast new temperature of sensor to KNX bus."""
-        from xknx.knx import Telegram, GroupAddress, DPTArray, DPTFloat
+        from xknx.knx import Telegram, GroupAddress, DPTArray, DPT2ByteFloat
         if new_state is None:
             return
         address = GroupAddress(
             self.config[DOMAIN][CONF_XKNX_OUTSIDE_TEMPERATURE_ADDRESS])
-        payload = DPTArray(DPTFloat().to_knx(float(new_state.state)))
+        payload = DPTArray(DPT2ByteFloat().to_knx(float(new_state.state)))
         telegram = Telegram()
         telegram.group_address = address
         telegram.payload = payload

--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Climate
 from xknx.exceptions import DeviceIllegalValue
 from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTControllerStatus,
-                      DPTFloat, DPTHVACMode, DPTTemperature, DPTValue1Count,
+                      DPT2ByteFloat, DPTHVACMode, DPTTemperature, DPTValue1Count,
                       HVACOperationMode, Telegram, TelegramType)
 
 
@@ -348,7 +348,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
 
         # First change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
@@ -358,7 +358,7 @@ class TestClimate(unittest.TestCase):
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
         self.assertEqual(climate.target_temperature.value, 24.00)
 
         # Second change
@@ -369,7 +369,7 @@ class TestClimate(unittest.TestCase):
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(5)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.50))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.50))))
         self.assertEqual(climate.target_temperature.value, 23.50)
 
         # Test max target temperature
@@ -399,7 +399,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
 
         # First change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
@@ -409,7 +409,7 @@ class TestClimate(unittest.TestCase):
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFD)))  # -3
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(21.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(21.00))))
         self.assertEqual(climate.target_temperature.value, 21.00)
 
         # Second change
@@ -420,7 +420,7 @@ class TestClimate(unittest.TestCase):
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFA)))  # -3
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(19.50))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(19.50))))
         self.assertEqual(climate.target_temperature.value, 19.50)
 
         # Test min target temperature
@@ -453,7 +453,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(23.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
 
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
@@ -462,7 +462,7 @@ class TestClimate(unittest.TestCase):
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(20)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPTFloat().to_knx(24.00))))
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
         self.assertEqual(climate.target_temperature.value, 24.00)
 
         # Test max/min target temperature

--- a/test/dpt_4byte_test.py
+++ b/test/dpt_4byte_test.py
@@ -11,7 +11,7 @@ class TestDPT4Byte(unittest.TestCase):
 
     # pylint: disable=too-many-public-methods,invalid-name
 
-    #
+    # ####################################################################
     # DPT4ByteUnsigned
     #
     def test_unsigned_settings(self):
@@ -35,7 +35,7 @@ class TestDPT4Byte(unittest.TestCase):
         self.assertEqual(DPT4ByteUnsigned().from_knx((0xFF, 0xFF, 0xFF, 0xFF)), 4294967295)
 
     def test_unsigned_value_min_value(self):
-        """Test DPTUElCurrentmA parsing and streaming with null values."""
+        """Test parsing and streaming with null values."""
         self.assertEqual(DPT4ByteUnsigned().to_knx(0), (0x00, 0x00, 0x00, 0x00))
         self.assertEqual(DPT4ByteUnsigned().from_knx((0x00, 0x00, 0x00, 0x00)), 0)
 
@@ -49,8 +49,7 @@ class TestDPT4Byte(unittest.TestCase):
         with self.assertRaises(ConversionError):
             DPT4ByteUnsigned().from_knx((0xFF, 0x4E, 0x12))
 
-
-    #
+    # ####################################################################
     # DPT4ByteSigned
     #
     def test_signed_settings(self):

--- a/test/dpt_4byte_test.py
+++ b/test/dpt_4byte_test.py
@@ -1,0 +1,93 @@
+"""Unit test for KNX 2 byte objects."""
+import unittest
+
+from xknx.exceptions import ConversionError
+from xknx.knx import DPT4ByteUnsigned
+from xknx.knx import DPT4ByteSigned
+
+
+class TestDPT4Byte(unittest.TestCase):
+    """Test class for KNX 4 byte objects."""
+
+    # pylint: disable=too-many-public-methods,invalid-name
+
+    #
+    # DPT4ByteUnsigned
+    #
+    def test_unsigned_settings(self):
+        """Test members of DPT4ByteUnsigned."""
+        self.assertEqual(DPT4ByteUnsigned().value_min, 0)
+        self.assertEqual(DPT4ByteUnsigned().value_max, 4294967295)
+
+    def test_unsigned_assert_min_exceeded(self):
+        """Test initialization of DPT4ByteUnsigned with wrong value (Underflow)."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteUnsigned().to_knx(-1)
+
+    def test_unsigned_to_knx_exceed_limits(self):
+        """Test initialization of DPT4ByteUnsigned with wrong value (Overflow)."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteUnsigned().to_knx(4294967296)
+
+    def test_unsigned_value_max_value(self):
+        """Test DPT4ByteUnsigned parsing and streaming."""
+        self.assertEqual(DPT4ByteUnsigned().to_knx(4294967295), (0xFF, 0xFF, 0xFF, 0xFF))
+        self.assertEqual(DPT4ByteUnsigned().from_knx((0xFF, 0xFF, 0xFF, 0xFF)), 4294967295)
+
+    def test_unsigned_value_min_value(self):
+        """Test DPTUElCurrentmA parsing and streaming with null values."""
+        self.assertEqual(DPT4ByteUnsigned().to_knx(0), (0x00, 0x00, 0x00, 0x00))
+        self.assertEqual(DPT4ByteUnsigned().from_knx((0x00, 0x00, 0x00, 0x00)), 0)
+
+    def test_unsigned_value_01234567(self):
+        """Test DPT4ByteUnsigned parsing and streaming."""
+        self.assertEqual(DPT4ByteUnsigned().to_knx(19088743), (0x01, 0x23, 0x45, 0x67))
+        self.assertEqual(DPT4ByteUnsigned().from_knx((0x01, 0x23, 0x45, 0x67)), 19088743)
+
+    def test_unsigned_wrong_value_from_knx(self):
+        """Test DPT4ByteUnsigned parsing with wrong value."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteUnsigned().from_knx((0xFF, 0x4E, 0x12))
+
+
+    #
+    # DPT4ByteSigned
+    #
+    def test_signed_settings(self):
+        """Test members of DPT4ByteSigned."""
+        self.assertEqual(DPT4ByteSigned().value_min, -2147483648)
+        self.assertEqual(DPT4ByteSigned().value_max, 2147483647)
+
+    def test_signed_assert_min_exceeded(self):
+        """Test initialization of DPT4ByteSigned with wrong value (Underflow)."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteSigned().to_knx(-2147483649)
+
+    def test_signed_to_knx_exceed_limits(self):
+        """Test initialization of DPT4ByteSigned with wrong value (Overflow)."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteSigned().to_knx(2147483648)
+
+    def test_signed_value_max_value(self):
+        """Test DPT4ByteSigned parsing and streaming."""
+        self.assertEqual(DPT4ByteSigned().to_knx(2147483647), (0x7F, 0xFF, 0xFF, 0xFF))
+        self.assertEqual(DPT4ByteSigned().from_knx((0x7F, 0xFF, 0xFF, 0xFF)), 2147483647)
+
+    def test_signed_value_min_value(self):
+        """Test DPT4ByteSigned parsing and streaming with null values."""
+        self.assertEqual(DPT4ByteSigned().to_knx(-2147483648), (0x80, 0x00, 0x00, 0x00))
+        self.assertEqual(DPT4ByteSigned().from_knx((0x80, 0x00, 0x00, 0x00)), -2147483648)
+
+    def test_signed_value_01234567(self):
+        """Test DPT4ByteSigned parsing and streaming."""
+        self.assertEqual(DPT4ByteSigned().to_knx(19088743), (0x01, 0x23, 0x45, 0x67))
+        self.assertEqual(DPT4ByteSigned().from_knx((0x01, 0x23, 0x45, 0x67)), 19088743)
+
+    def test_signed_wrong_value_from_knx(self):
+        """Test DPT4ByteSigned parsing with wrong value."""
+        with self.assertRaises(ConversionError):
+            DPT4ByteSigned().from_knx((0xFF, 0x4E, 0x12))
+
+
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT4Byte)
+unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_float_test.py
+++ b/test/dpt_float_test.py
@@ -2,99 +2,99 @@
 import unittest
 
 from xknx.exceptions import ConversionError
-from xknx.knx import DPTFloat, DPTIEEE754, DPTHumidity, DPTLux, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower
+from xknx.knx import DPT2ByteFloat, DPT4ByteFloat, DPTHumidity, DPTLux, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower
 
 
-class TestDPTFloat(unittest.TestCase):
+class TestDPT2ByteFloat(unittest.TestCase):
     """Test class for KNX float object."""
 
     # pylint: disable=too-many-public-methods,invalid-name
 
     def test_value_from_documentation(self):
-        """Test parsing and streaming of DPTFloat -30.00. Example from the internet[tm]."""
-        self.assertEqual(DPTFloat().to_knx(-30.00), (0x8a, 0x24))
-        self.assertEqual(DPTFloat().from_knx((0x8a, 0x24)), -30.00)
+        """Test parsing and streaming of DPT2ByteFloat -30.00. Example from the internet[tm]."""
+        self.assertEqual(DPT2ByteFloat().to_knx(-30.00), (0x8a, 0x24))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x8a, 0x24)), -30.00)
 
     def test_value_taken_from_live_thermostat(self):
-        """Test parsing and streaming of DPTFloat 19.96."""
-        self.assertEqual(DPTFloat().to_knx(16.96), (0x06, 0xa0))
-        self.assertEqual(DPTFloat().from_knx((0x06, 0xa0)), 16.96)
+        """Test parsing and streaming of DPT2ByteFloat 19.96."""
+        self.assertEqual(DPT2ByteFloat().to_knx(16.96), (0x06, 0xa0))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x06, 0xa0)), 16.96)
 
     def test_zero_value(self):
-        """Test parsing and streaming of DPTFloat zero value."""
-        self.assertEqual(DPTFloat().to_knx(0.00), (0x00, 0x00))
-        self.assertEqual(DPTFloat().from_knx((0x00, 0x00)), 0.00)
+        """Test parsing and streaming of DPT2ByteFloat zero value."""
+        self.assertEqual(DPT2ByteFloat().to_knx(0.00), (0x00, 0x00))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x00, 0x00)), 0.00)
 
     def test_room_temperature(self):
-        """Test parsing and streaming of DPTFloat 21.00. Room temperature."""
-        self.assertEqual(DPTFloat().to_knx(21.00), (0x0c, 0x1a))
-        self.assertEqual(DPTFloat().from_knx((0x0c, 0x1a)), 21.00)
+        """Test parsing and streaming of DPT2ByteFloat 21.00. Room temperature."""
+        self.assertEqual(DPT2ByteFloat().to_knx(21.00), (0x0c, 0x1a))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x0c, 0x1a)), 21.00)
 
     def test_high_temperature(self):
-        """Test parsing and streaming of DPTFloat 500.00, 499.84, 500.16. Testing rounding issues."""
-        self.assertEqual(DPTFloat().to_knx(500.00), (0x2E, 0x1A))
-        self.assertAlmostEqual(DPTFloat().from_knx((0x2E, 0x1A)), 499.84)
-        self.assertAlmostEqual(DPTFloat().from_knx((0x2E, 0x1B)), 500.16)
-        self.assertEqual(DPTFloat().to_knx(499.84), (0x2E, 0x1A))
-        self.assertEqual(DPTFloat().to_knx(500.16), (0x2E, 0x1B))
+        """Test parsing and streaming of DPT2ByteFloat 500.00, 499.84, 500.16. Testing rounding issues."""
+        self.assertEqual(DPT2ByteFloat().to_knx(500.00), (0x2E, 0x1A))
+        self.assertAlmostEqual(DPT2ByteFloat().from_knx((0x2E, 0x1A)), 499.84)
+        self.assertAlmostEqual(DPT2ByteFloat().from_knx((0x2E, 0x1B)), 500.16)
+        self.assertEqual(DPT2ByteFloat().to_knx(499.84), (0x2E, 0x1A))
+        self.assertEqual(DPT2ByteFloat().to_knx(500.16), (0x2E, 0x1B))
 
     def test_minor_negative_temperature(self):
-        """Test parsing and streaming of DPTFloat -10.00. Testing negative values."""
-        self.assertEqual(DPTFloat().to_knx(-10.00), (0x84, 0x18))
-        self.assertEqual(DPTFloat().from_knx((0x84, 0x18)), -10.00)
+        """Test parsing and streaming of DPT2ByteFloat -10.00. Testing negative values."""
+        self.assertEqual(DPT2ByteFloat().to_knx(-10.00), (0x84, 0x18))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x84, 0x18)), -10.00)
 
     def test_very_cold_temperature(self):
-        """Test parsing and streaming of DPTFloat -1000.00,-999.68, -1000.32. Testing rounding issues of negative values."""
-        self.assertEqual(DPTFloat().to_knx(-1000.00), (0xB1, 0xE6))
-        self.assertEqual(DPTFloat().from_knx((0xB1, 0xE6)), -999.68)
-        self.assertEqual(DPTFloat().from_knx((0xB1, 0xE5)), -1000.32)
-        self.assertEqual(DPTFloat().to_knx(-999.68), (0xB1, 0xE6))
-        self.assertEqual(DPTFloat().to_knx(-1000.32), (0xB1, 0xE5))
+        """Test parsing and streaming of DPT2ByteFloat -1000.00,-999.68, -1000.32. Testing rounding issues of negative values."""
+        self.assertEqual(DPT2ByteFloat().to_knx(-1000.00), (0xB1, 0xE6))
+        self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE6)), -999.68)
+        self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE5)), -1000.32)
+        self.assertEqual(DPT2ByteFloat().to_knx(-999.68), (0xB1, 0xE6))
+        self.assertEqual(DPT2ByteFloat().to_knx(-1000.32), (0xB1, 0xE5))
 
     def test_max(self):
-        """Test parsing and streaming of DPTFloat with maximum value."""
-        self.assertEqual(DPTFloat().to_knx(DPTFloat.value_max), (0x7F, 0xFF))
-        self.assertEqual(DPTFloat().from_knx((0x7F, 0xFF)), DPTFloat.value_max)
+        """Test parsing and streaming of DPT2ByteFloat with maximum value."""
+        self.assertEqual(DPT2ByteFloat().to_knx(DPT2ByteFloat.value_max), (0x7F, 0xFF))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x7F, 0xFF)), DPT2ByteFloat.value_max)
 
     def test_min(self):
-        """Test parsing and streaming of DPTFloat with minimum value."""
-        self.assertEqual(DPTFloat().to_knx(DPTFloat.value_min), (0xF8, 0x00))
-        self.assertEqual(DPTFloat().from_knx((0xF8, 0x00)), DPTFloat.value_min)
+        """Test parsing and streaming of DPT2ByteFloat with minimum value."""
+        self.assertEqual(DPT2ByteFloat().to_knx(DPT2ByteFloat.value_min), (0xF8, 0x00))
+        self.assertEqual(DPT2ByteFloat().from_knx((0xF8, 0x00)), DPT2ByteFloat.value_min)
 
     def test_close_to_max(self):
-        """Test parsing and streaming of DPTFloat with maximum value -1."""
-        self.assertEqual(DPTFloat().to_knx(670433.28), (0x7F, 0xFE))
-        self.assertEqual(DPTFloat().from_knx((0x7F, 0xFE)), 670433.28)
+        """Test parsing and streaming of DPT2ByteFloat with maximum value -1."""
+        self.assertEqual(DPT2ByteFloat().to_knx(670433.28), (0x7F, 0xFE))
+        self.assertEqual(DPT2ByteFloat().from_knx((0x7F, 0xFE)), 670433.28)
 
     def test_close_to_min(self):
-        """Test parsing and streaming of DPTFloat with minimum value +1."""
-        self.assertEqual(DPTFloat().to_knx(-670760.96), (0xF8, 0x01))
-        self.assertEqual(DPTFloat().from_knx((0xF8, 0x01)), -670760.96)
+        """Test parsing and streaming of DPT2ByteFloat with minimum value +1."""
+        self.assertEqual(DPT2ByteFloat().to_knx(-670760.96), (0xF8, 0x01))
+        self.assertEqual(DPT2ByteFloat().from_knx((0xF8, 0x01)), -670760.96)
 
     def test_to_knx_min_exceeded(self):
-        """Test parsing of DPTFloat with wrong value (underflow)."""
+        """Test parsing of DPT2ByteFloat with wrong value (underflow)."""
         with self.assertRaises(ConversionError):
-            DPTFloat().to_knx(DPTFloat.value_min - 1)
+            DPT2ByteFloat().to_knx(DPT2ByteFloat.value_min - 1)
 
     def test_to_knx_max_exceeded(self):
-        """Test parsing of DPTFloat with wrong value (overflow)."""
+        """Test parsing of DPT2ByteFloat with wrong value (overflow)."""
         with self.assertRaises(ConversionError):
-            DPTFloat().to_knx(DPTFloat.value_max + 1)
+            DPT2ByteFloat().to_knx(DPT2ByteFloat.value_max + 1)
 
     def test_to_knx_wrong_parameter(self):
-        """Test parsing of DPTFloat with wrong value (string)."""
+        """Test parsing of DPT2ByteFloat with wrong value (string)."""
         with self.assertRaises(ConversionError):
-            DPTFloat().to_knx("fnord")
+            DPT2ByteFloat().to_knx("fnord")
 
     def test_from_knx_wrong_parameter(self):
-        """Test parsing of DPTFloat with wrong value (wrong number of bytes)."""
+        """Test parsing of DPT2ByteFloat with wrong value (wrong number of bytes)."""
         with self.assertRaises(ConversionError):
-            DPTFloat().from_knx((0xF8, 0x01, 0x23))
+            DPT2ByteFloat().from_knx((0xF8, 0x01, 0x23))
 
     def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTFloat with wrong value (second parameter is a string)."""
+        """Test parsing of DPT2ByteFloat with wrong value (second parameter is a string)."""
         with self.assertRaises(ConversionError):
-            DPTFloat().from_knx((0xF8, "0x23"))
+            DPT2ByteFloat().from_knx((0xF8, "0x23"))
 
     #
     # DPTTemperature
@@ -148,38 +148,38 @@ class TestDPTFloat(unittest.TestCase):
 
     
     #
-    # DPTIEEE754
+    # DPT4ByteFloat
     #
     def test_ieee754_values_from_power_meter(self):
-        self.assertEqual(DPTIEEE754().from_knx((0x43, 0xC6, 0x80, 00)), 397)
-        self.assertEqual(DPTIEEE754().to_knx(397), (0x43, 0xC6, 0x80, 00))
-        self.assertEqual(DPTIEEE754().from_knx((0x42, 0x38, 0x00, 00)), 46)
-        self.assertEqual(DPTIEEE754().to_knx(46), (0x42, 0x38, 0x00, 00))
+        self.assertEqual(DPT4ByteFloat().from_knx((0x43, 0xC6, 0x80, 00)), 397)
+        self.assertEqual(DPT4ByteFloat().to_knx(397), (0x43, 0xC6, 0x80, 00))
+        self.assertEqual(DPT4ByteFloat().from_knx((0x42, 0x38, 0x00, 00)), 46)
+        self.assertEqual(DPT4ByteFloat().to_knx(46), (0x42, 0x38, 0x00, 00))
 
 
     def test_ieee754_values_from_voltage_meter(self):
-        self.assertEqual(round(DPTIEEE754().from_knx((0x43, 0x65, 0xE3, 0xD7)), 2), 229.89)
-        self.assertEqual(DPTIEEE754().to_knx(229.89), (0x43, 0x65, 0xE3, 0xD7))
+        self.assertEqual(round(DPT4ByteFloat().from_knx((0x43, 0x65, 0xE3, 0xD7)), 2), 229.89)
+        self.assertEqual(DPT4ByteFloat().to_knx(229.89), (0x43, 0x65, 0xE3, 0xD7))
 
     def test_ieee754_zero_value(self):
-        """Test parsing and streaming of DPTFloat zero value."""
-        self.assertEqual(DPTIEEE754().from_knx((0x00, 0x00, 0x00, 0x00)), 0.00)
-        self.assertEqual(DPTIEEE754().to_knx(0.00), (0x00, 0x00, 0x00, 0x00))
+        """Test parsing and streaming of DPT2ByteFloat zero value."""
+        self.assertEqual(DPT4ByteFloat().from_knx((0x00, 0x00, 0x00, 0x00)), 0.00)
+        self.assertEqual(DPT4ByteFloat().to_knx(0.00), (0x00, 0x00, 0x00, 0x00))
 
     def test_ieee754_to_knx_wrong_parameter(self):
-        """Test parsing of DPTFloat with wrong value (string)."""
+        """Test parsing of DPT2ByteFloat with wrong value (string)."""
         with self.assertRaises(ConversionError):
-            DPTIEEE754().to_knx("fnord")
+            DPT4ByteFloat().to_knx("fnord")
 
     def test_ieee754_from_knx_wrong_parameter(self):
-        """Test parsing of DPTFloat with wrong value (wrong number of bytes)."""
+        """Test parsing of DPT2ByteFloat with wrong value (wrong number of bytes)."""
         with self.assertRaises(ConversionError):
-            DPTIEEE754().from_knx((0xF8, 0x01, 0x23))
+            DPT4ByteFloat().from_knx((0xF8, 0x01, 0x23))
 
     def test_ieee754_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTFloat with wrong value (second parameter is a string)."""
+        """Test parsing of DPT2ByteFloat with wrong value (second parameter is a string)."""
         with self.assertRaises(ConversionError):
-            DPTIEEE754().from_knx((0xF8, "0x23", 0x00, 0x00))
+            DPT4ByteFloat().from_knx((0xF8, "0x23", 0x00, 0x00))
 
 
     #
@@ -204,5 +204,5 @@ class TestDPTFloat(unittest.TestCase):
             self.assertEqual(DPTPower().unit, "W")
     
 
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTFloat)
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT2ByteFloat)
 unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_float_test.py
+++ b/test/dpt_float_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 from xknx.exceptions import ConversionError
-from xknx.knx import DPTFloat, DPTHumidity, DPTLux, DPTTemperature
+from xknx.knx import DPTFloat, DPTIEEE754, DPTHumidity, DPTLux, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower
 
 
 class TestDPTFloat(unittest.TestCase):
@@ -145,3 +145,64 @@ class TestDPTFloat(unittest.TestCase):
         """Test parsing of DPTHumidity with wrong value."""
         with self.assertRaises(ConversionError):
             DPTHumidity().to_knx(-1)
+
+    
+    #
+    # DPTIEEE754
+    #
+    def test_ieee754_values_from_power_meter(self):
+        self.assertEqual(DPTIEEE754().from_knx((0x43, 0xC6, 0x80, 00)), 397)
+        self.assertEqual(DPTIEEE754().to_knx(397), (0x43, 0xC6, 0x80, 00))
+        self.assertEqual(DPTIEEE754().from_knx((0x42, 0x38, 0x00, 00)), 46)
+        self.assertEqual(DPTIEEE754().to_knx(46), (0x42, 0x38, 0x00, 00))
+
+
+    def test_ieee754_values_from_voltage_meter(self):
+        self.assertEqual(round(DPTIEEE754().from_knx((0x43, 0x65, 0xE3, 0xD7)), 2), 229.89)
+        self.assertEqual(DPTIEEE754().to_knx(229.89), (0x43, 0x65, 0xE3, 0xD7))
+
+    def test_ieee754_zero_value(self):
+        """Test parsing and streaming of DPTFloat zero value."""
+        self.assertEqual(DPTIEEE754().from_knx((0x00, 0x00, 0x00, 0x00)), 0.00)
+        self.assertEqual(DPTIEEE754().to_knx(0.00), (0x00, 0x00, 0x00, 0x00))
+
+    def test_ieee754_to_knx_wrong_parameter(self):
+        """Test parsing of DPTFloat with wrong value (string)."""
+        with self.assertRaises(ConversionError):
+            DPTIEEE754().to_knx("fnord")
+
+    def test_ieee754_from_knx_wrong_parameter(self):
+        """Test parsing of DPTFloat with wrong value (wrong number of bytes)."""
+        with self.assertRaises(ConversionError):
+            DPTIEEE754().from_knx((0xF8, 0x01, 0x23))
+
+    def test_ieee754_from_knx_wrong_parameter2(self):
+        """Test parsing of DPTFloat with wrong value (second parameter is a string)."""
+        with self.assertRaises(ConversionError):
+            DPTIEEE754().from_knx((0xF8, "0x23", 0x00, 0x00))
+
+
+    #
+    # DPTElectricCurrent
+    #
+    def test_electric_current_settings(self):
+        """Test attributes of DPTLux."""
+        self.assertEqual(DPTElectricCurrent().unit, "A")
+
+    #
+    # DPTElectricPotential
+    #
+    def test_electric_potential_settings(self):
+        """Test attributes of DPTLux."""
+        self.assertEqual(DPTElectricPotential().unit, "V")
+
+    #
+    # DPTPower
+    #
+    def test_power_settings(self):
+            """Test attributes of DPTLux."""
+            self.assertEqual(DPTPower().unit, "W")
+    
+
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTFloat)
+unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_float_test.py
+++ b/test/dpt_float_test.py
@@ -1,15 +1,19 @@
-"""Unit test for KNX float object."""
+"""Unit test for KNX 2 and 4 byte float objects."""
 import unittest
 
 from xknx.exceptions import ConversionError
-from xknx.knx import DPT2ByteFloat, DPT4ByteFloat, DPTHumidity, DPTLux, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower
+from xknx.knx import DPT2ByteFloat, DPT4ByteFloat, DPTHumidity, DPTLux, DPTTemperature, DPTElectricPotential, \
+    DPTElectricCurrent, DPTPower, DPTFrequency, DPTPhaseAngleDeg
 
 
-class TestDPT2ByteFloat(unittest.TestCase):
-    """Test class for KNX float object."""
+class TestDPTFloat(unittest.TestCase):
+    """Test class for KNX 2 & 4 byte/octet float object."""
 
     # pylint: disable=too-many-public-methods,invalid-name
 
+    # ####################################################################
+    # DPT2ByteFloat
+    #
     def test_value_from_documentation(self):
         """Test parsing and streaming of DPT2ByteFloat -30.00. Example from the internet[tm]."""
         self.assertEqual(DPT2ByteFloat().to_knx(-30.00), (0x8a, 0x24))
@@ -44,7 +48,8 @@ class TestDPT2ByteFloat(unittest.TestCase):
         self.assertEqual(DPT2ByteFloat().from_knx((0x84, 0x18)), -10.00)
 
     def test_very_cold_temperature(self):
-        """Test parsing and streaming of DPT2ByteFloat -1000.00,-999.68, -1000.32. Testing rounding issues of negative values."""
+        """Test parsing and streaming of DPT2ByteFloat -1000.00,-999.68, -1000.32.
+           Testing rounding issues of negative values."""
         self.assertEqual(DPT2ByteFloat().to_knx(-1000.00), (0xB1, 0xE6))
         self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE6)), -999.68)
         self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE5)), -1000.32)
@@ -146,41 +151,51 @@ class TestDPT2ByteFloat(unittest.TestCase):
         with self.assertRaises(ConversionError):
             DPTHumidity().to_knx(-1)
 
-    
-    #
+    # ####################################################################
     # DPT4ByteFloat
     #
-    def test_ieee754_values_from_power_meter(self):
+    def test_4byte_float_values_from_power_meter(self):
         self.assertEqual(DPT4ByteFloat().from_knx((0x43, 0xC6, 0x80, 00)), 397)
         self.assertEqual(DPT4ByteFloat().to_knx(397), (0x43, 0xC6, 0x80, 00))
         self.assertEqual(DPT4ByteFloat().from_knx((0x42, 0x38, 0x00, 00)), 46)
         self.assertEqual(DPT4ByteFloat().to_knx(46), (0x42, 0x38, 0x00, 00))
 
+    def test_14_033(self):  # DPTFrequency
+        self.assertEqual(DPTFrequency().unit, "Hz")
 
-    def test_ieee754_values_from_voltage_meter(self):
+    def test_14_055(self):  # DPTPhaseAngleDeg
+        self.assertEqual(DPT4ByteFloat().from_knx((0x42, 0xEF, 0x00, 0x00)), 119.5)
+        self.assertEqual(DPT4ByteFloat().to_knx(119.5), (0x42, 0xEF, 0x00, 0x00))
+        self.assertEqual(DPTPhaseAngleDeg().unit, "°")
+
+    def test_14_057(self):  # DPTPowerFactor
+        self.assertEqual(round(DPT4ByteFloat().from_knx((0x3F, 0x71, 0xEB, 0x86)), 7), 0.9450001)
+        self.assertEqual(DPT4ByteFloat().to_knx(0.945000052452), (0x3F, 0x71, 0xEB, 0x86))
+        # No unit
+
+    def test_4byte_float_values_from_voltage_meter(self):
         self.assertEqual(round(DPT4ByteFloat().from_knx((0x43, 0x65, 0xE3, 0xD7)), 2), 229.89)
         self.assertEqual(DPT4ByteFloat().to_knx(229.89), (0x43, 0x65, 0xE3, 0xD7))
 
-    def test_ieee754_zero_value(self):
+    def test_4byte_float_zero_value(self):
         """Test parsing and streaming of DPT2ByteFloat zero value."""
         self.assertEqual(DPT4ByteFloat().from_knx((0x00, 0x00, 0x00, 0x00)), 0.00)
         self.assertEqual(DPT4ByteFloat().to_knx(0.00), (0x00, 0x00, 0x00, 0x00))
 
-    def test_ieee754_to_knx_wrong_parameter(self):
+    def test_4byte_float_to_knx_wrong_parameter(self):
         """Test parsing of DPT2ByteFloat with wrong value (string)."""
         with self.assertRaises(ConversionError):
             DPT4ByteFloat().to_knx("fnord")
 
-    def test_ieee754_from_knx_wrong_parameter(self):
+    def test_4byte_float_from_knx_wrong_parameter(self):
         """Test parsing of DPT2ByteFloat with wrong value (wrong number of bytes)."""
         with self.assertRaises(ConversionError):
             DPT4ByteFloat().from_knx((0xF8, 0x01, 0x23))
 
-    def test_ieee754_from_knx_wrong_parameter2(self):
+    def test_4byte_float_from_knx_wrong_parameter2(self):
         """Test parsing of DPT2ByteFloat with wrong value (second parameter is a string)."""
         with self.assertRaises(ConversionError):
             DPT4ByteFloat().from_knx((0xF8, "0x23", 0x00, 0x00))
-
 
     #
     # DPTElectricCurrent
@@ -204,5 +219,5 @@ class TestDPT2ByteFloat(unittest.TestCase):
             self.assertEqual(DPTPower().unit, "W")
     
 
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT2ByteFloat)
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTFloat)
 unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_string_test.py
+++ b/test/dpt_string_test.py
@@ -5,7 +5,7 @@ from xknx.exceptions import ConversionError
 from xknx.knx import DPTString
 
 
-class TestDPTFloat(unittest.TestCase):
+class TestDPT2ByteFloat(unittest.TestCase):
     """Test class for KNX float object."""
 
     # pylint: disable=too-many-public-methods,invalid-name
@@ -47,7 +47,7 @@ class TestDPTFloat(unittest.TestCase):
         self.assertEqual(DPTString.from_knx(raw), string)
 
     def test_to_knx_wrong_parameter(self):
-        """Test parsing of DPTFloat with wrong value (string)."""
+        """Test parsing of DPT2ByteFloat with wrong value (string)."""
         with self.assertRaises(ConversionError):
             DPTString().to_knx(123)
 
@@ -66,3 +66,7 @@ class TestDPTFloat(unittest.TestCase):
                0x00, 0x00, 0x00]
         with self.assertRaises(ConversionError):
             DPTString().from_knx(raw)
+
+
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT2ByteFloat)
+unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/dpt_string_test.py
+++ b/test/dpt_string_test.py
@@ -1,11 +1,11 @@
-"""Unit test for KNX float object."""
+"""Unit test for KNX string object."""
 import unittest
 
 from xknx.exceptions import ConversionError
 from xknx.knx import DPTString
 
 
-class TestDPT2ByteFloat(unittest.TestCase):
+class TestDPTString(unittest.TestCase):
     """Test class for KNX float object."""
 
     # pylint: disable=too-many-public-methods,invalid-name
@@ -68,5 +68,5 @@ class TestDPT2ByteFloat(unittest.TestCase):
             DPTString().from_knx(raw)
 
 
-SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPT2ByteFloat)
+SUITE = unittest.TestLoader().loadTestsFromTestCase(TestDPTString)
 unittest.TextTestRunner(verbosity=2).run(SUITE)

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -108,7 +108,6 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(sensor.resolve_state(), 397)
         self.assertEqual(sensor.unit_of_measurement(), "W")
 
-    
     def test_str_electric_potential(self):
         """Test resolve state with voltage sensor."""
         xknx = XKNX(loop=self.loop)
@@ -121,7 +120,6 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(round(sensor.resolve_state(), 2), 229.89)
         self.assertEqual(sensor.unit_of_measurement(), "V")
-        
 
     #
     # SYNC

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -95,6 +95,34 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(sensor.resolve_state(), 33.02)
         self.assertEqual(sensor.unit_of_measurement(), "%")
 
+    def test_str_power(self):
+        """Test resolve state with power sensor."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="power")
+        sensor.state = DPTArray((0x43, 0xC6, 0x80, 00))
+
+        self.assertEqual(sensor.resolve_state(), 397)
+        self.assertEqual(sensor.unit_of_measurement(), "W")
+
+    
+    def test_str_electric_potential(self):
+        """Test resolve state with voltage sensor."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="electric_potential")
+        sensor.state = DPTArray((0x43, 0x65, 0xE3, 0xD7))
+
+        self.assertEqual(round(sensor.resolve_state(), 2), 229.89)
+        self.assertEqual(sensor.unit_of_measurement(), "V")
+        
+
     #
     # SYNC
     #

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -9,7 +9,9 @@ It provides functionality for
 import asyncio
 
 from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTHumidity, DPTLux,
-                      DPTScaling, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp)
+                      DPTScaling, DPTTemperature, DPTElectricPotential, \
+                      DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp, \
+                      DPT4ByteUnsigned, DPT4ByteSigned)
 
 from .device import Device
 
@@ -42,8 +44,10 @@ class Sensor(Device):
             'current'           : DPTUElCurrentmA,
             'power'             : DPTPower,
             'electric_current'  : DPTElectricCurrent,
-            'electric_potential': DPTElectricPotential 
+            'electric_potential': DPTElectricPotential,
 
+            '4byte_unsigned'    : DPT4ByteUnsigned,
+            '4byte_signed'      : DPT4ByteSigned
         }
 
     @classmethod

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -9,9 +9,11 @@ It provides functionality for
 import asyncio
 
 from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTHumidity, DPTLux,
-                      DPTScaling, DPTTemperature, DPTElectricPotential, \
-                      DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp, \
-                      DPT4ByteUnsigned, DPT4ByteSigned)
+                      DPTScaling, DPTTemperature, DPTElectricPotential,
+                      DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp,
+                      DPTBrightness, DPTEnergy, DPTHeatFlowRate, DPTFrequency, DPTPhaseAngleRad, DPTPhaseAngleDeg,
+                      DPTPowerFactor, DPTSpeed,
+                      DPT2ByteUnsigned, DPT2ByteFloat, DPT4ByteUnsigned, DPT4ByteSigned, DPT4ByteFloat)
 
 from .device import Device
 
@@ -40,14 +42,32 @@ class Sensor(Device):
             'temperature'       : DPTTemperature,
             'humidity'          : DPTHumidity,
             'illuminance'       : DPTLux,
+            'brightness'        : DPTBrightness,
             'speed_ms'          : DPTWsp,
             'current'           : DPTUElCurrentmA,
             'power'             : DPTPower,
             'electric_current'  : DPTElectricCurrent,
             'electric_potential': DPTElectricPotential,
+            'energy'            : DPTEnergy,
+            'frequency'         : DPTFrequency,
+            'heatflowrate'      : DPTHeatFlowRate,
+            'phaseanglerad'     : DPTPhaseAngleRad,
+            'phaseangledeg'     : DPTPhaseAngleDeg,
+            'powerfactor'       : DPTPowerFactor,
+            'speed'             : DPTSpeed,
 
+            # Generic DPT Without Min/Max and Unit.
+            'DPT-7'             : DPT2ByteUnsigned,
+            '2byte_unsigned'    : DPT2ByteUnsigned,
+            'DPT-9'             : DPT2ByteFloat,
+
+            'DPT-12'            : DPT4ByteUnsigned,
             '4byte_unsigned'    : DPT4ByteUnsigned,
-            '4byte_signed'      : DPT4ByteSigned
+
+            'DPT-13'            : DPT4ByteSigned,
+            '4byte_signed'      : DPT4ByteSigned,
+            'DPT-14'            : DPT4ByteFloat,
+            '4byte_float'       : DPT4ByteFloat
         }
 
     @classmethod

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -9,7 +9,7 @@ It provides functionality for
 import asyncio
 
 from xknx.knx import (GroupAddress, DPTArray, DPTBinary, DPTHumidity, DPTLux,
-                      DPTScaling, DPTTemperature, DPTUElCurrentmA, DPTWsp)
+                      DPTScaling, DPTTemperature, DPTElectricPotential, DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp)
 
 from .device import Device
 
@@ -33,6 +33,18 @@ class Sensor(Device):
         self.group_address = group_address
         self.value_type = value_type
         self.state = None
+
+        self.dptmap = {
+            'temperature'       : DPTTemperature,
+            'humidity'          : DPTHumidity,
+            'illuminance'       : DPTLux,
+            'speed_ms'          : DPTWsp,
+            'current'           : DPTUElCurrentmA,
+            'power'             : DPTPower,
+            'electric_current'  : DPTElectricCurrent,
+            'electric_potential': DPTElectricPotential 
+
+        }
 
     @classmethod
     def from_config(cls, xknx, name, config):
@@ -72,16 +84,8 @@ class Sensor(Device):
         # pylint: disable=too-many-return-statements
         if self.value_type == 'percent':
             return "%"
-        elif self.value_type == 'temperature':
-            return DPTTemperature.unit
-        elif self.value_type == 'humidity':
-            return DPTHumidity.unit
-        elif self.value_type == 'illuminance':
-            return DPTLux.unit
-        elif self.value_type == 'speed_ms':
-            return DPTWsp.unit
-        elif self.value_type == 'current':
-            return DPTUElCurrentmA.unit
+        elif self.value_type in self.dptmap:
+            return self.dptmap[self.value_type].unit
         return None
 
     def resolve_state(self):
@@ -94,16 +98,8 @@ class Sensor(Device):
                 len(self.state.value) == 1:
             # TODO: Instanciate DPTScaling object with DPTArray class
             return "{0}".format(DPTScaling().from_knx(self.state.value))
-        elif self.value_type == 'humidity':
-            return DPTHumidity().from_knx(self.state.value)
-        elif self.value_type == 'temperature':
-            return DPTTemperature().from_knx(self.state.value)
-        elif self.value_type == 'illuminance':
-            return DPTLux().from_knx(self.state.value)
-        elif self.value_type == 'speed_ms':
-            return DPTWsp().from_knx(self.state.value)
-        elif self.value_type == 'current':
-            return DPTUElCurrentmA().from_knx(self.state.value)
+        elif self.value_type in self.dptmap:
+            return self.dptmap[self.value_type].from_knx(self.state.value)
         elif isinstance(self.state, DPTArray):
             return ','.join('0x%02x' % i for i in self.state.value)
         elif isinstance(self.state, DPTBinary):

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -10,12 +10,13 @@ Module for handling KNX primitves.
 from .address import GroupAddress, GroupAddressType, PhysicalAddress
 from .address_filter import AddressFilter
 from .telegram import Telegram, TelegramDirection, TelegramType
-
 from .dpt import DPTBase, DPTBinary, DPTArray, DPTComparator, DPTWeekday
-from .dpt_float import DPTFloat, DPTIEEE754, DPTLux, DPTTemperature, DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower
+from .dpt_float import DPTFloat, DPTIEEE754, DPTLux, DPTTemperature, \
+    DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus
 from .dpt_2byte import DPTUElCurrentmA
+from .dpt_4byte import DPT4ByteUnsigned, DPT4ByteSigned
 from .dpt_scaling import DPTScaling
 from .dpt_time import DPTTime
 from .dpt_date import DPTDate

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -11,7 +11,7 @@ from .address import GroupAddress, GroupAddressType, PhysicalAddress
 from .address_filter import AddressFilter
 from .telegram import Telegram, TelegramDirection, TelegramType
 from .dpt import DPTBase, DPTBinary, DPTArray, DPTComparator, DPTWeekday
-from .dpt_float import DPTFloat, DPTIEEE754, DPTLux, DPTTemperature, \
+from .dpt_float import DPT2ByteFloat, DPT4ByteFloat, DPTLux, DPTTemperature, \
     DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -10,8 +10,9 @@ Module for handling KNX primitves.
 from .address import GroupAddress, GroupAddressType, PhysicalAddress
 from .address_filter import AddressFilter
 from .telegram import Telegram, TelegramDirection, TelegramType
+
 from .dpt import DPTBase, DPTBinary, DPTArray, DPTComparator, DPTWeekday
-from .dpt_float import DPTFloat, DPTLux, DPTTemperature, DPTHumidity, DPTWsp
+from .dpt_float import DPTFloat, DPTIEEE754, DPTLux, DPTTemperature, DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus
 from .dpt_2byte import DPTUElCurrentmA

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -12,10 +12,12 @@ from .address_filter import AddressFilter
 from .telegram import Telegram, TelegramDirection, TelegramType
 from .dpt import DPTBase, DPTBinary, DPTArray, DPTComparator, DPTWeekday
 from .dpt_float import DPT2ByteFloat, DPT4ByteFloat, DPTLux, DPTTemperature, \
-    DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower
+    DPTHumidity, DPTWsp, DPTElectricPotential, DPTElectricCurrent, DPTPower, \
+    DPTEnergy, DPTFrequency, DPTHeatFlowRate, DPTPhaseAngleRad, DPTPhaseAngleDeg, \
+    DPTPowerFactor, DPTSpeed
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus
-from .dpt_2byte import DPTUElCurrentmA
+from .dpt_2byte import DPT2ByteUnsigned, DPTUElCurrentmA, DPT2Ucount, DPTBrightness
 from .dpt_4byte import DPT4ByteUnsigned, DPT4ByteSigned
 from .dpt_scaling import DPTScaling
 from .dpt_time import DPTTime

--- a/xknx/knx/dpt.py
+++ b/xknx/knx/dpt.py
@@ -4,7 +4,39 @@ from xknx.exceptions import ConversionError
 
 
 class DPTBase:
-    """Base class for KNX data types."""
+    """
+    Base class for KNX data types.
+    KNX communicates using Group-addresses, and every Group Object represents a data point of some type.
+    To have a standardized interpretation of the data there are a number of Data Point types (DPT).
+    The DPT's is written like: xx.yyy, for example 14.056 for a 4-octet float, with Power info in Watts.
+    The Major number (xx) describes the data type (format and encoding) - while the the minor (YYY) number
+    describes the measurement with value range and unit.
+
+    More DTP's are added as new needs come up, but this a list of some of the commonly used ones:
+    1.yyy  boolean, like switching, on/off, open/close, move up/down, step
+    2.yyy  2 x boolean, e.g. switching + priority control
+    3.yyy  boolean + 3-bit unsigned value, e.g. dimming up/down
+    4.yyy  character (8-bit)
+    5.yyy  8-bit unsigned value, like dim value (0..100%), blinds position (0..100%)
+    6.yyy  8-bit signed (2's complement), e.g. +/- %
+    7.yyy  2-byte unsigned value, i.e. pulse counter
+    8.yyy  2-byte signed (2's complement), e.g. +/- %
+    9.yyy  2-byte float, e.g. temperature
+    10.yyy time (3 bytes)
+    11.yyy date (3 bytes)
+    12.yyy 4-byte unsigned value, i.e. pulse counter
+    13.yyy 4-byte signed (2's complement), i.e. flow, energy
+    14.yyy 4-byte float, IEEE 754, i.e. Electrical measurements: current, power
+    15.yyy access control
+    16.yyy string -> 14 characters (14 x 8-bit)
+    17.yyy scene number
+    18.yyy scene control
+    19.yyy date / time
+    20.yyy 8-bit enumeration, e.g. HVAC mode ('auto', 'comfort', 'standby', 'economy', 'protection')
+    28.yyy UTF-8
+    29.yyy V64, 64-bit signed value
+
+    """
 
     # pylint: disable=too-few-public-methods
     @staticmethod

--- a/xknx/knx/dpt.py
+++ b/xknx/knx/dpt.py
@@ -35,6 +35,7 @@ class DPTBase:
     20.yyy 8-bit enumeration, e.g. HVAC mode ('auto', 'comfort', 'standby', 'economy', 'protection')
     28.yyy UTF-8
     29.yyy V64, 64-bit signed value
+    232.yyy RGB [0,0,0]...[255,255,255]
 
     """
 

--- a/xknx/knx/dpt_2byte.py
+++ b/xknx/knx/dpt_2byte.py
@@ -1,20 +1,21 @@
-"""Implementation of Basic KNX 2-Byte."""
+"""Implementation of Basic KNX 2-Byte/octet values."""
 
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
 
 
-class DPT2Byte(DPTBase):
+class DPT2ByteUnsigned(DPTBase):
     """
-    Abstraction for KNX 2 Byte "2-octet unsigned counter value".
+    Abstraction for KNX 2 Byte "2-octet unsigned value".
+    Contain smaller counters, timers and more
 
-    DPT 7.001
+    DPT 7.xxx
     """
 
     value_min = 0
     value_max = 65535
-    unit = "pulses"
+    unit = ""
     resolution = 1
 
     @classmethod
@@ -33,18 +34,25 @@ class DPT2Byte(DPTBase):
     @classmethod
     def _test_boundaries(cls, value):
         """Test if value is within defined range for this object."""
-        return value >= cls.value_min and \
-            value <= cls.value_max
+        return cls.value_min <= value <= cls.value_max
 
 
-class DPTUElCurrentmA(DPT2Byte):
+class DPT2Ucount(DPT2ByteUnsigned):
     """
-    Abstraction for KNX 2 Byte DPTUElCurrentmA.
-
-    DPT 7.012
+    DPT 7.001 DPT_Value_2_Ucount
     """
+    unit = "pulses"
 
-    value_min = 0
-    value_max = 65535
+
+class DPTUElCurrentmA(DPT2ByteUnsigned):
+    """
+    DPT 7.012 Abstraction for KNX 2 Byte DPTUElCurrentmA.
+    """
     unit = "mA"
-    resolution = 1
+
+
+class DPTBrightness(DPT2ByteUnsigned):
+    """
+    DPT 7.012 DPT_Brightness (lux)
+    """
+    unit = "lx"

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -1,4 +1,10 @@
-"""Implementation of Basic KNX 4-Byte."""
+"""
+Implementation of Basic KNX 4-Byte Signed and Unsigned Values.
+
+They correspond the following KNX DPTs:
+    12.yyy 4-byte/octet unsigned value, i.e. pulse counter
+    13.yyy 4-byte/octet signed (2's complement), i.e. flow, energy
+"""
 
 import struct
 from xknx.exceptions import ConversionError
@@ -60,4 +66,3 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     resolution = 1
 
     _struct_format = ">i"
-

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -1,0 +1,65 @@
+"""Implementation of Basic KNX 4-Byte."""
+
+import struct
+from xknx.exceptions import ConversionError
+
+from .dpt import DPTBase
+
+
+class DPT4ByteUnsigned(DPTBase):
+    """
+    Abstraction for KNX 4 Byte "32-bit unsigned".
+
+    DPT 12.x
+    """
+
+    value_min = 0
+    value_max = 4294967295
+    unit = ""
+    resolution = 1
+    
+    _struct_format = ">I"
+
+    @classmethod
+    def from_knx(cls, raw):
+        """Parse/deserialize from KNX/IP raw data."""
+        cls.test_bytesarray(raw, 4)
+
+        try:
+            return struct.unpack(cls._struct_format, bytes(raw))[0]
+        except struct.error:
+            raise ConversionError(raw)
+
+    @classmethod
+    def to_knx(cls, value):
+        """Serialize to KNX/IP raw data."""
+        if not cls._test_boundaries(value):
+            raise ConversionError(value)
+
+        try:
+            return tuple(struct.pack(cls._struct_format, value))
+        except struct.error:
+            raise ConversionError(value)
+
+    @classmethod
+    def _test_boundaries(cls, value):
+        """Test if value is within defined range for this object."""
+        return value >= cls.value_min and \
+            value <= cls.value_max
+
+
+
+class DPT4ByteSigned(DPT4ByteUnsigned):
+    """
+    Abstraction for KNX 4 Byte "32-bit signed".
+
+    DPT 13.x
+    """
+
+    value_min = -2147483648
+    value_max =  2147483647
+    unit = ""
+    resolution = 1
+
+    _struct_format = ">i"
+

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -44,9 +44,7 @@ class DPT4ByteUnsigned(DPTBase):
     @classmethod
     def _test_boundaries(cls, value):
         """Test if value is within defined range for this object."""
-        return value >= cls.value_min and \
-            value <= cls.value_max
-
+        return cls.value_min <= value <= cls.value_max
 
 
 class DPT4ByteSigned(DPT4ByteUnsigned):
@@ -57,7 +55,7 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     """
 
     value_min = -2147483648
-    value_max =  2147483647
+    value_max = 2147483647
     unit = ""
     resolution = 1
 

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -70,14 +70,16 @@ class DPTFloat(DPTBase):
     @classmethod
     def _test_boundaries(cls, value):
         """Test if value is within defined range for this object."""
-        return value >= cls.value_min and \
-            value <= cls.value_max
+        return cls.value_min <= value <= cls.value_max
 
 
 class DPTIEEE754(DPTBase):
     """
-    Abstraction for KNX 4 Octet Floating Point Numbers (IEEE754).
-    No value range seems to be defined for these values.
+    Abstraction for KNX 4 Octet Floating Point Numbers, with a maximum usable range as specified in IEEE 754.
+    The largest positive finite float literal is 3.40282347e+38f.
+    The smallest positive finite non-zero literal of type float is 1.40239846e-45f.
+    The negative minimum finite float literal is -3.40282347e+38f.
+    No value range are defined for DPTs 14.000-079.
 
     DPT 14.xxx
     """
@@ -169,9 +171,57 @@ class DPTElectricPotential(DPTIEEE754):
     unit = "V"
 
 
+class DPTEnergy(DPTIEEE754):
+    """
+    DPT_Value_Energy 14.031
+    """
+    unit = 'J'
+
+
+class DPTFrequency(DPTIEEE754):
+    """
+    DPT_Value_Frequency 14.033
+    """
+    unit = 'Hz'
+
+
+class DPTHeatFlowRate(DPTIEEE754):
+    """
+    DPT_Value_Heat_Flow_Rate 14.036
+    """
+    unit = 'W'
+
+
+class DPTPhaseAngleRad(DPTIEEE754):
+    """
+    DPT_Value_Phase_Angle, Radiant 14.054
+    """
+    unit = 'rad'
+
+
+class DPTPhaseAngleDeg(DPTIEEE754):
+    """
+    DPT_Value_Phase_Angle, Degree 14.055
+    """
+    unit = '°'
+
+
 class DPTPower(DPTIEEE754):
     """
-    DPT_Value_Power 14.056 
+    DPT_Value_Power 14.056
     """
     unit = "W"
 
+
+class DPTPowerFactor(DPTIEEE754):
+    """
+    DPT_Value_Power 14.057
+    """
+    unit = ''
+
+
+class DPTSpeed(DPTIEEE754):
+    """
+    DPT_Value_Speed 14.065
+    """
+    unit = 'm/s'

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -6,8 +6,7 @@ from xknx.exceptions import ConversionError
 from .dpt import DPTBase
 
 
-
-class DPTFloat(DPTBase):
+class DPT2ByteFloat(DPTBase):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
@@ -73,7 +72,7 @@ class DPTFloat(DPTBase):
         return cls.value_min <= value <= cls.value_max
 
 
-class DPTIEEE754(DPTBase):
+class DPT4ByteFloat(DPTBase):
     """
     Abstraction for KNX 4 Octet Floating Point Numbers, with a maximum usable range as specified in IEEE 754.
     The largest positive finite float literal is 3.40282347e+38f.
@@ -105,7 +104,7 @@ class DPTIEEE754(DPTBase):
             raise ConversionError(value)
 
 
-class DPTTemperature(DPTFloat):
+class DPTTemperature(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
@@ -118,7 +117,7 @@ class DPTTemperature(DPTFloat):
     resolution = 1
 
 
-class DPTLux(DPTFloat):
+class DPTLux(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
@@ -131,7 +130,7 @@ class DPTLux(DPTFloat):
     resolution = 1
 
 
-class DPTWsp(DPTFloat):
+class DPTWsp(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
@@ -144,7 +143,7 @@ class DPTWsp(DPTFloat):
     resolution = 1
 
 
-class DPTHumidity(DPTFloat):
+class DPTHumidity(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
@@ -157,70 +156,70 @@ class DPTHumidity(DPTFloat):
     resolution = 1
 
 
-class DPTElectricCurrent(DPTIEEE754):
+class DPTElectricCurrent(DPT4ByteFloat):
     """
     DPT_Value_Electric_Current 14.019
     """
     unit = "A"
 
 
-class DPTElectricPotential(DPTIEEE754):
+class DPTElectricPotential(DPT4ByteFloat):
     """
     DPT_Value_Electric_Potential 14.027
     """
     unit = "V"
 
 
-class DPTEnergy(DPTIEEE754):
+class DPTEnergy(DPT4ByteFloat):
     """
     DPT_Value_Energy 14.031
     """
     unit = 'J'
 
 
-class DPTFrequency(DPTIEEE754):
+class DPTFrequency(DPT4ByteFloat):
     """
     DPT_Value_Frequency 14.033
     """
     unit = 'Hz'
 
 
-class DPTHeatFlowRate(DPTIEEE754):
+class DPTHeatFlowRate(DPT4ByteFloat):
     """
     DPT_Value_Heat_Flow_Rate 14.036
     """
     unit = 'W'
 
 
-class DPTPhaseAngleRad(DPTIEEE754):
+class DPTPhaseAngleRad(DPT4ByteFloat):
     """
     DPT_Value_Phase_Angle, Radiant 14.054
     """
     unit = 'rad'
 
 
-class DPTPhaseAngleDeg(DPTIEEE754):
+class DPTPhaseAngleDeg(DPT4ByteFloat):
     """
     DPT_Value_Phase_Angle, Degree 14.055
     """
     unit = '°'
 
 
-class DPTPower(DPTIEEE754):
+class DPTPower(DPT4ByteFloat):
     """
     DPT_Value_Power 14.056
     """
     unit = "W"
 
 
-class DPTPowerFactor(DPTIEEE754):
+class DPTPowerFactor(DPT4ByteFloat):
     """
     DPT_Value_Power 14.057
     """
     unit = ''
 
 
-class DPTSpeed(DPTIEEE754):
+class DPTSpeed(DPT4ByteFloat):
     """
     DPT_Value_Speed 14.065
     """

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -1,4 +1,10 @@
-"""Implementation of Basic KNX Floats."""
+"""
+Implementation of KNX Float-values.
+
+They can be either 2 or 4 bytes, and correspond to the the following KDN DPTs.
+    9.yyy  2-byte/octet float, e.g. temperature
+    14.yyy 4-byte/octet float, IEEE 754, i.e. Electrical measurements: current, power
+"""
 
 import struct
 from xknx.exceptions import ConversionError
@@ -108,7 +114,7 @@ class DPTTemperature(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
-    DPT 9.001
+    DPT 9.001 DPT_Value_Temp
     """
 
     value_min = -273
@@ -121,7 +127,7 @@ class DPTLux(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
-    DPT 9.004
+    DPT 9.004 DPT_Value_Lux
     """
 
     value_min = 0
@@ -134,7 +140,7 @@ class DPTWsp(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
-    DPT 9.005
+    DPT 9.005 DPT_Value_Ws Speed (m/s)
     """
 
     value_min = 0
@@ -147,7 +153,7 @@ class DPTHumidity(DPT2ByteFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
-    DPT 9.007
+    DPT 9.007 DPT_Value_Humidity
     """
 
     value_min = 0
@@ -158,69 +164,69 @@ class DPTHumidity(DPT2ByteFloat):
 
 class DPTElectricCurrent(DPT4ByteFloat):
     """
-    DPT_Value_Electric_Current 14.019
+    DPT 14.019 DPT_Value_Electric_Current
     """
     unit = "A"
 
 
 class DPTElectricPotential(DPT4ByteFloat):
     """
-    DPT_Value_Electric_Potential 14.027
+    DPT 14.027 DPT_Value_Electric_Potential
     """
     unit = "V"
 
 
 class DPTEnergy(DPT4ByteFloat):
     """
-    DPT_Value_Energy 14.031
+    DPT 14.031 DPT_Value_Energy
     """
     unit = 'J'
 
 
 class DPTFrequency(DPT4ByteFloat):
     """
-    DPT_Value_Frequency 14.033
+    DPT 14.033 DPT_Value_Frequency
     """
     unit = 'Hz'
 
 
 class DPTHeatFlowRate(DPT4ByteFloat):
     """
-    DPT_Value_Heat_Flow_Rate 14.036
+    DPT 14.036 DPT_Value_Heat_Flow_Rate
     """
     unit = 'W'
 
 
 class DPTPhaseAngleRad(DPT4ByteFloat):
     """
-    DPT_Value_Phase_Angle, Radiant 14.054
+    DPT 14.054 DPT_Value_Phase_Angle, Radiant
     """
     unit = 'rad'
 
 
 class DPTPhaseAngleDeg(DPT4ByteFloat):
     """
-    DPT_Value_Phase_Angle, Degree 14.055
+    14.055 DPT_Value_Phase_Angle, Degree
     """
     unit = '°'
 
 
 class DPTPower(DPT4ByteFloat):
     """
-    DPT_Value_Power 14.056
+    DPT 14.056 DPT_Value_Power
     """
     unit = "W"
 
 
 class DPTPowerFactor(DPT4ByteFloat):
     """
-    DPT_Value_Power 14.057
+    DPT 14.057 DPT_Value_Power
     """
     unit = ''
 
 
 class DPTSpeed(DPT4ByteFloat):
     """
-    DPT_Value_Speed 14.065
+    DPT 14.065 DPT_Value_Speed
     """
     unit = 'm/s'

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -1,8 +1,10 @@
 """Implementation of Basic KNX Floats."""
 
+import struct
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+
 
 
 class DPTFloat(DPTBase):
@@ -72,6 +74,35 @@ class DPTFloat(DPTBase):
             value <= cls.value_max
 
 
+class DPTIEEE754(DPTBase):
+    """
+    Abstraction for KNX 4 Octet Floating Point Numbers (IEEE754).
+    No value range seems to be defined for these values.
+
+    DPT 14.xxx
+    """
+
+    unit = ""
+
+    @classmethod
+    def from_knx(cls, raw):
+        """Parse/deserialize from KNX/IP raw data (big endian)."""
+        cls.test_bytesarray(raw, 4)
+        try:
+            return struct.unpack(">f", bytes(raw))[0]
+        except struct.error:
+            raise ConversionError(raw)
+
+
+    @classmethod
+    def to_knx(cls, value):
+        """Serialize to KNX/IP raw data."""
+        try:
+            return tuple(struct.pack(">f", value))
+        except struct.error:
+            raise ConversionError(value)
+
+
 class DPTTemperature(DPTFloat):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
@@ -122,3 +153,25 @@ class DPTHumidity(DPTFloat):
     value_max = 670760
     unit = "%"
     resolution = 1
+
+
+class DPTElectricCurrent(DPTIEEE754):
+    """
+    DPT_Value_Electric_Current 14.019
+    """
+    unit = "A"
+
+
+class DPTElectricPotential(DPTIEEE754):
+    """
+    DPT_Value_Electric_Potential 14.027
+    """
+    unit = "V"
+
+
+class DPTPower(DPTIEEE754):
+    """
+    DPT_Value_Power 14.056 
+    """
+    unit = "W"
+


### PR DESCRIPTION
Work on more DPT to support Electrical Sensors made by user Straeng.
This included 4-byte singed and unsigned values, as well as 4-byte floats.

I added some more DPT's and documentation.
We have also added some generic types that supports the "conversion"  - but doesn't necessary have the proper Min/Max limits - and are missing Unit.
Get it merged in so we don't get to far away from the Dev-branch.