### PR TITLE
Implement group reads

### DIFF
--- a/home-assistant-plugin/custom_components/binary_sensor/xknx.py
+++ b/home-assistant-plugin/custom_components/binary_sensor/xknx.py
@@ -25,6 +25,7 @@ CONF_DEFAULT_HOOK = 'on'
 CONF_COUNTER = 'counter'
 CONF_DEFAULT_COUNTER = 1
 CONF_ACTION = 'action'
+CONF_RESET_AFTER = 'reset_after'
 
 CONF__ACTION = 'turn_off_action'
 
@@ -48,6 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Optional(CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT):
         cv.positive_int,
+    vol.Optional(CONF_RESET_AFTER, default=None): cv.positive_int,
     vol.Optional(CONF_AUTOMATION, default=None): AUTOMATIONS_SCHEMA,
 })
 
@@ -88,7 +90,8 @@ def async_add_devices_config(hass, config, async_add_devices):
         name=name,
         group_address=config.get(CONF_ADDRESS),
         device_class=config.get(CONF_DEVICE_CLASS),
-        significant_bit=config.get(CONF_SIGNIFICANT_BIT))
+        significant_bit=config.get(CONF_SIGNIFICANT_BIT),
+        reset_after=config.get(CONF_RESET_AFTER))
     hass.data[DATA_XKNX].xknx.devices.add(binary_sensor)
 
     entity = KNXBinarySensor(hass, binary_sensor)

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -9,7 +9,7 @@ You may register callbacks to be notified if a telegram was pushed to the queue.
 """
 import asyncio
 
-from xknx.knx import TelegramDirection, TelegramType
+from xknx.knx import TelegramDirection
 
 
 class TelegramQueue():
@@ -115,9 +115,7 @@ class TelegramQueue():
                 if ret:
                     processed = True
 
-        if (not processed and
-                (telegram.telegramtype == TelegramType.GROUP_WRITE or
-                 telegram.telegramtype == TelegramType.GROUP_RESPONSE)):
+        if not processed:
             for device in self.xknx.devices.devices_by_group_address(
                     telegram.group_address):
                 await device.process(telegram)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -9,6 +9,7 @@ A binary sensor can be:
 A BinarySensor may also have Actions attached which are executed after state was changed.
 """
 import time
+import asyncio
 from enum import Enum
 
 from xknx.exceptions import CouldNotParseTelegram
@@ -132,8 +133,8 @@ class BinarySensor(Device):
             self.count_set_off = 1
         return 1
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         bit_masq = 1 << (self.significant_bit-1)
         binary_value = telegram.payload.value & bit_masq != 0
 

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -39,6 +39,7 @@ class BinarySensor(Device):
                  group_address=None,
                  device_class=None,
                  significant_bit=1,
+                 reset_after=None,
                  actions=None,
                  device_updated_cb=None):
         """Initialize BinarySensor class."""
@@ -54,6 +55,7 @@ class BinarySensor(Device):
         self.group_address = group_address
         self.device_class = device_class
         self.significant_bit = significant_bit
+        self.reset_after = reset_after
         self.state = BinarySensorState.OFF
         self.actions = actions
 
@@ -139,6 +141,9 @@ class BinarySensor(Device):
             await self._set_internal_state(BinarySensorState.OFF)
         elif binary_value == 1:
             await self._set_internal_state(BinarySensorState.ON)
+            if self.reset_after is not None:
+                await asyncio.sleep(self.reset_after/1000)
+                await self._set_internal_state(BinarySensorState.OFF)
         else:
             raise CouldNotParseTelegram()
 

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -264,8 +264,8 @@ class Climate(Device):
             operation_modes.append(HVACOperationMode.FROST_PROTECTION)
         return operation_modes
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         if self.supports_operation_mode and \
                 telegram.group_address == self.group_address_operation_mode or \
                 telegram.group_address == self.group_address_operation_mode_state:

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -219,8 +219,8 @@ class Cover(Device):
         state_addresses.extend(self.angle.state_addresses())
         return state_addresses
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         position_processed = await self.position.process(telegram)
         if position_processed:
             self.travelcalculator.set_position(self.position.value)

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -140,8 +140,8 @@ class Light(Device):
             state_addresses.append(state_address_brightness)
         return state_addresses
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         await self.switch.process(telegram)
 
         if (self.supports_dimming and

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -69,8 +69,8 @@ class Notification(Device):
         """Return group addresses which should be requested to sync state."""
         return [self.group_address, ]
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         if telegram.group_address == self.group_address:
             await self._process_message(telegram)
 

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -95,8 +95,8 @@ class Sensor(Device):
         """Return group addresses which should be requested to sync state."""
         return [self.group_address, ]
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         await self._set_internal_state(telegram.payload)
 
     def unit_of_measurement(self):

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -72,8 +72,8 @@ class Switch(Device):
         """Return group addresses which should be requested to sync state."""
         return self.switch.state_addresses()
 
-    async def process(self, telegram):
-        """Process incoming telegram."""
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
         await self.switch.process(telegram)
 
     def __str__(self):

--- a/xknx/devices/time.py
+++ b/xknx/devices/time.py
@@ -1,0 +1,64 @@
+"""
+Module for broadcasting time to KNX bus.
+
+Time is a virtual/pseudo device, using the infrastructure for
+beeing configured via xknx.yaml and synchronized periodically
+by StateUpdate.
+"""
+from xknx.knx import GroupAddress, DPTArray, DPTTime
+
+from .device import Device
+
+
+class Time(Device):
+    """Class for virtual time device."""
+
+    def __init__(self,
+                 xknx,
+                 name,
+                 group_address=None,
+                 device_updated_cb=None):
+        """Initialize Time class."""
+        Device.__init__(self, xknx, name, device_updated_cb)
+
+        if isinstance(group_address, (str, int)):
+            group_address = GroupAddress(group_address)
+
+        self.group_address = group_address
+
+    @classmethod
+    def from_config(cls, xknx, name, config):
+        """Initialize object from configuration structure."""
+        group_address = \
+            config.get('group_address')
+        return cls(xknx,
+                   name,
+                   group_address=group_address)
+
+    def has_group_address(self, group_address):
+        """Test if device has given group address."""
+        return self.group_address == group_address
+
+    async def broadcast_time(self, response=False):
+        """Broadcast time to KNX bus."""
+        await self.send(
+            self.group_address,
+            DPTArray(DPTTime.current_time_as_knx()),
+            response=response)
+
+    async def process_group_read(self, telegram):
+        """Process incoming GROUP READ telegram."""
+        await self.broadcast_time(True)
+
+    async def sync(self, wait_for_result=True):
+        """Read state of device from KNX bus. Used here to broadcast time to KNX bus."""
+        await self.broadcast_time()
+
+    def __str__(self):
+        """Return object as readable string."""
+        return '<Time name="{0}" group_address="{1}" />' \
+            .format(self.name, self.group_address)
+
+    def __eq__(self, other):
+        """Equal operator."""
+        return self.__dict__ == other.__dict__


### PR DESCRIPTION
At the moment XKNX ignores group reads.

With this pull requests devices may implement a method for processing group reads. 

The time device now answers to group reads.