### PR TITLE
[WIP] Expose local sensors to KNX bus

### DIFF
--- a/test/config_test.py
+++ b/test/config_test.py
@@ -254,6 +254,7 @@ class TestConfig(unittest.TestCase):
             Sensor(xknx,
                    'Some.Other.Value',
                    group_address='2/0/2',
+                   value_type='temperature',
                    device_updated_cb=xknx.devices.device_updated))
 
     def test_config_sensor_binary_device_class(self):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -4,7 +4,7 @@ import unittest
 
 from xknx import XKNX
 from xknx.devices import (Action, BinarySensor, Climate, Cover, DateTime,
-                          Light, Notification, Sensor, Switch)
+                          Light, Notification, ExposeSensor, Sensor, Switch)
 from xknx.devices.datetime import DateTimeBroadcastType
 
 
@@ -236,7 +236,7 @@ class TestConfig(unittest.TestCase):
                          device_updated_cb=xknx.devices.device_updated))
 
     def test_config_sensor_percent(self):
-        """Test reading Sensor with value_type from config file."""
+        """Test reading percent Sensor from config file."""
         xknx = XKNX(config='xknx.yaml', loop=self.loop)
         self.assertEqual(
             xknx.devices['Heating.Valve1'],
@@ -246,16 +246,28 @@ class TestConfig(unittest.TestCase):
                    value_type='percent',
                    device_updated_cb=xknx.devices.device_updated))
 
-    def test_config_sensor_no_value_type(self):
-        """Test reading Sensor without value_type from config file."""
+    def test_config_sensor_temperature_type(self):
+        """Test reading temperature Sensor from config file."""
         xknx = XKNX(config='xknx.yaml', loop=self.loop)
         self.assertEqual(
-            xknx.devices['Some.Other.Value'],
+            xknx.devices['Kitchen.Temperature'],
             Sensor(xknx,
-                   'Some.Other.Value',
+                   'Kitchen.Temperature',
                    group_address='2/0/2',
                    value_type='temperature',
                    device_updated_cb=xknx.devices.device_updated))
+
+    def test_config_expose_sensor(self):
+        """Test reading ExposeSensor from config file."""
+        xknx = XKNX(config='xknx.yaml', loop=self.loop)
+        self.assertEqual(
+            xknx.devices['Outside.Temperature'],
+            ExposeSensor(
+                xknx,
+                'Outside.Temperature',
+                group_address='2/0/3',
+                value_type='temperature',
+                device_updated_cb=xknx.devices.device_updated))
 
     def test_config_sensor_binary_device_class(self):
         """Test reading Sensor with device_class from config file."""

--- a/test/expose_sensor_test.py
+++ b/test/expose_sensor_test.py
@@ -20,7 +20,6 @@ class TestExposeSensor(unittest.TestCase):
         """Tear down test class."""
         self.loop.close()
 
-
     #
     # STR FUNCTIONS
     #
@@ -66,10 +65,12 @@ class TestExposeSensor(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         print(telegram)
-        self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/3'),
-                         TelegramType.GROUP_WRITE,
-                         payload=DPTArray((0x40,))))
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                TelegramType.GROUP_WRITE,
+                payload=DPTArray((0x40,))))
 
     def test_set_temperature(self):
         """Test set with temperatur sensor."""
@@ -83,10 +84,12 @@ class TestExposeSensor(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         print(telegram)
-        self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/3'),
-                         TelegramType.GROUP_WRITE,
-                         payload=DPTArray((0x0c, 0x1a))))
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                TelegramType.GROUP_WRITE,
+                payload=DPTArray((0x0c, 0x1a))))
 
     #
     # TEST PROCESS (GROUP READ)
@@ -106,10 +109,12 @@ class TestExposeSensor(unittest.TestCase):
         self.loop.run_until_complete(asyncio.Task(expose_sensor.process(telegram)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/3'),
-                         TelegramType.GROUP_RESPONSE,
-                         payload=DPTArray((0x40, ))))
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                TelegramType.GROUP_RESPONSE,
+                payload=DPTArray((0x40, ))))
 
     def test_process_temperature(self):
         """Test reading temperature expose sensor from bus."""
@@ -126,18 +131,16 @@ class TestExposeSensor(unittest.TestCase):
         self.loop.run_until_complete(asyncio.Task(expose_sensor.process(telegram)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/3'),
-                         TelegramType.GROUP_RESPONSE,
-                         payload=DPTArray((0x0c, 0x1a))))
-
-
-        #self.assertEqual(sensor.sensor_value.payload, DPTArray((0x06, 0xa0)))
-        #self.assertEqual(sensor.resolve_state(), 16.96)
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                TelegramType.GROUP_RESPONSE,
+                payload=DPTArray((0x0c, 0x1a))))
 
     #
     # HAS GROUP ADDRESS
-    # 
+    #
     def test_has_group_address(self):
         """Test expose sensor has group address."""
         xknx = XKNX(loop=self.loop)
@@ -149,7 +152,7 @@ class TestExposeSensor(unittest.TestCase):
         self.assertTrue(expose_sensor.has_group_address(GroupAddress('1/2/3')))
         self.assertFalse(expose_sensor.has_group_address(GroupAddress('1/2/4')))
 
-    # 
+    #
     # STATE ADDRESSES
     #
     def test_state_addresses(self):
@@ -161,7 +164,6 @@ class TestExposeSensor(unittest.TestCase):
             value_type='temperature',
             group_address='1/2/3')
         self.assertEqual(expose_sensor.state_addresses(), [])
-
 
     #
     # PROCESS CALLBACK

--- a/test/expose_sensor_test.py
+++ b/test/expose_sensor_test.py
@@ -1,0 +1,159 @@
+"""Unit test for Sensor objects."""
+import asyncio
+import unittest
+from unittest.mock import Mock
+
+from xknx import XKNX
+from xknx.devices import ExposeSensor
+from xknx.knx import DPTArray, GroupAddress, Telegram, TelegramType
+
+
+class TestExposeSensor(unittest.TestCase):
+    """Test class for Sensor objects."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+
+    #
+    # STR FUNCTIONS
+    #
+    def test_str_percent(self):
+        """Test resolve state with percent sensor."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="percent")
+        expose_sensor.sensor_value.payload = DPTArray((0x40,))
+
+        self.assertEqual(expose_sensor.resolve_state(), 75)
+        self.assertEqual(expose_sensor.unit_of_measurement(), "%")
+
+    def test_str_temperature(self):
+        """Test resolve state with temperature sensor."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="temperature")
+        expose_sensor.sensor_value.payload = DPTArray((0x0c, 0x1a))
+
+        self.assertEqual(expose_sensor.resolve_state(), 21.0)
+        self.assertEqual(expose_sensor.unit_of_measurement(), "°C")
+
+    #
+    # TEST SET
+    #
+    def test_set_percent(self):
+        """Test set with percent sensor."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="percent")
+        self.loop.run_until_complete(asyncio.Task(expose_sensor.set(75)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+
+        telegram = xknx.telegrams.get_nowait()
+        print(telegram)
+        self.assertEqual(telegram,
+                         Telegram(GroupAddress('1/2/3'),
+                         TelegramType.GROUP_WRITE,
+                         payload=DPTArray((0x40,))))
+
+    def test_set_temperature(self):
+        """Test set with temperatur sensor."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="temperature")
+        self.loop.run_until_complete(asyncio.Task(expose_sensor.set(21.0)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        print(telegram)
+        self.assertEqual(telegram,
+                         Telegram(GroupAddress('1/2/3'),
+                         TelegramType.GROUP_WRITE,
+                         payload=DPTArray((0x0c, 0x1a))))
+
+    #
+    # TEST PROCESS (GROUP READ)
+    #
+    def test_process_percent(self):
+        """Test reading percent expose sensor from bus."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            value_type='percent',
+            group_address='1/2/3')
+        expose_sensor.sensor_value.payload = DPTArray((0x40,))
+
+        telegram = Telegram(GroupAddress('1/2/3'))
+        telegram.telegramtype = TelegramType.GROUP_READ
+        self.loop.run_until_complete(asyncio.Task(expose_sensor.process(telegram)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(telegram,
+                         Telegram(GroupAddress('1/2/3'),
+                         TelegramType.GROUP_RESPONSE,
+                         payload=DPTArray((0x40, ))))
+
+    def test_process_temperature(self):
+        """Test reading temperature expose sensor from bus."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address='1/2/3')
+        expose_sensor.sensor_value.payload = DPTArray((0x0c, 0x1a))
+
+        telegram = Telegram(GroupAddress('1/2/3'))
+        telegram.telegramtype = TelegramType.GROUP_READ
+        self.loop.run_until_complete(asyncio.Task(expose_sensor.process(telegram)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(telegram,
+                         Telegram(GroupAddress('1/2/3'),
+                         TelegramType.GROUP_RESPONSE,
+                         payload=DPTArray((0x0c, 0x1a))))
+
+
+        #self.assertEqual(sensor.sensor_value.payload, DPTArray((0x06, 0xa0)))
+        #self.assertEqual(sensor.resolve_state(), 16.96)
+
+    #
+    # PROCESS CALLBACK
+    #
+    def test_process_callback(self):
+        """Test setting value. Test if callback is called."""
+        # pylint: disable=no-self-use
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            group_address='1/2/3',
+            value_type="temperature")
+
+        after_update_callback = Mock()
+
+        async def async_after_update_callback(device):
+            """Async callback."""
+            after_update_callback(device)
+        expose_sensor.register_device_updated_cb(async_after_update_callback)
+
+        self.loop.run_until_complete(asyncio.Task(expose_sensor.set(21.0)))
+        after_update_callback.assert_called_with(expose_sensor)

--- a/test/expose_sensor_test.py
+++ b/test/expose_sensor_test.py
@@ -136,6 +136,34 @@ class TestExposeSensor(unittest.TestCase):
         #self.assertEqual(sensor.resolve_state(), 16.96)
 
     #
+    # HAS GROUP ADDRESS
+    # 
+    def test_has_group_address(self):
+        """Test expose sensor has group address."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address='1/2/3')
+        self.assertTrue(expose_sensor.has_group_address(GroupAddress('1/2/3')))
+        self.assertFalse(expose_sensor.has_group_address(GroupAddress('1/2/4')))
+
+    # 
+    # STATE ADDRESSES
+    #
+    def test_state_addresses(self):
+        """Test expose sensor returns empty list as state addresses."""
+        xknx = XKNX(loop=self.loop)
+        expose_sensor = ExposeSensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address='1/2/3')
+        self.assertEqual(expose_sensor.state_addresses(), [])
+
+
+    #
     # PROCESS CALLBACK
     #
     def test_process_callback(self):

--- a/test/remote_value_sensor_test.py
+++ b/test/remote_value_sensor_test.py
@@ -1,0 +1,33 @@
+"""Unit test for Sensor objects."""
+import asyncio
+import unittest
+
+from xknx import XKNX
+from xknx.exceptions import ConversionError
+from xknx.devices import RemoteValueSensor
+
+
+class TestSRemoteValueensor(unittest.TestCase):
+    """Test class for Sensor objects."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+    def test_wrong_value_type(self):
+        """Test initializing with wrong value_type."""
+        xknx = XKNX(loop=self.loop)
+        with self.assertRaises(ConversionError):
+            RemoteValueSensor(xknx=xknx, value_type="wrong_value_type")
+
+    def test_payload_length_defined(self):
+        """Test if all members of DPTMAP implement payload_length."""
+        for value_type in RemoteValueSensor.DPTMAP:
+            self.assertTrue(
+                isinstance(RemoteValueSensor.DPTMAP[value_type].payload_length,
+                           int))

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -123,7 +123,7 @@ class TestSensor(unittest.TestCase):
 
     #
     # HAS GROUP ADDRESS
-    # 
+    #
     def test_has_group_address(self):
         """Test sensor has group address."""
         xknx = XKNX(loop=self.loop)
@@ -135,7 +135,7 @@ class TestSensor(unittest.TestCase):
         self.assertTrue(sensor.has_group_address(GroupAddress('1/2/3')))
         self.assertFalse(sensor.has_group_address(GroupAddress('1/2/4')))
 
-    # 
+    #
     # STATE ADDRESSES
     #
     def test_state_addresses(self):

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -122,6 +122,33 @@ class TestSensor(unittest.TestCase):
                          Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
     #
+    # HAS GROUP ADDRESS
+    # 
+    def test_has_group_address(self):
+        """Test sensor has group address."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address='1/2/3')
+        self.assertTrue(sensor.has_group_address(GroupAddress('1/2/3')))
+        self.assertFalse(sensor.has_group_address(GroupAddress('1/2/4')))
+
+    # 
+    # STATE ADDRESSES
+    #
+    def test_state_addresses(self):
+        """Test expose sensor returns empty list as state addresses."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address='1/2/3')
+        self.assertEqual(sensor.state_addresses(), [GroupAddress('1/2/3')])
+
+    #
     # TEST PROCESS
     #
     def test_process(self):

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Sensor
-from xknx.knx import DPTArray, DPTBinary, GroupAddress, Telegram, TelegramType
+from xknx.knx import DPTArray, GroupAddress, Telegram, TelegramType
 
 
 class TestSensor(unittest.TestCase):
@@ -23,26 +23,6 @@ class TestSensor(unittest.TestCase):
     #
     # STR FUNCTIONS
     #
-    def test_str_array(self):
-        """Test resolve_state fallback method with DPTArray."""
-        xknx = XKNX(loop=self.loop)
-        sensor = Sensor(
-            xknx,
-            'TestSensor',
-            group_address='1/2/3')
-        sensor.state = DPTArray((0x01, 0x02, 0x03))
-        self.assertEqual(sensor.resolve_state(), "0x01,0x02,0x03")
-
-    def test_str_binary(self):
-        """Test resolve_state fallback method with integer object."""
-        xknx = XKNX(loop=self.loop)
-        sensor = Sensor(
-            xknx,
-            'TestSensor',
-            group_address='1/2/3')
-        sensor.state = DPTBinary(5)
-        self.assertEqual(sensor.resolve_state(), "101")
-
     def test_str_scaling(self):
         """Test resolve state with percent sensor."""
         xknx = XKNX(loop=self.loop)
@@ -51,9 +31,9 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="percent")
-        sensor.state = DPTArray((0x40,))
+        sensor.sensor_value.payload = DPTArray((0x40,))
 
-        self.assertEqual(sensor.resolve_state(), "25")
+        self.assertEqual(sensor.resolve_state(), 75)
         self.assertEqual(sensor.unit_of_measurement(), "%")
 
     def test_str_speed_ms(self):
@@ -64,7 +44,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="speed_ms")
-        sensor.state = DPTArray((0x00, 0x1b,))
+        sensor.sensor_value.payload = DPTArray((0x00, 0x1b,))
 
         self.assertEqual(sensor.resolve_state(), 0.27)
         self.assertEqual(sensor.unit_of_measurement(), "m/s")
@@ -77,7 +57,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="temperature")
-        sensor.state = DPTArray((0x0c, 0x1a))
+        sensor.sensor_value.payload = DPTArray((0x0c, 0x1a))
 
         self.assertEqual(sensor.resolve_state(), 21.00)
         self.assertEqual(sensor.unit_of_measurement(), "°C")
@@ -90,7 +70,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="humidity")
-        sensor.state = DPTArray((0x0e, 0x73))
+        sensor.sensor_value.payload = DPTArray((0x0e, 0x73))
 
         self.assertEqual(sensor.resolve_state(), 33.02)
         self.assertEqual(sensor.unit_of_measurement(), "%")
@@ -103,7 +83,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="power")
-        sensor.state = DPTArray((0x43, 0xC6, 0x80, 00))
+        sensor.sensor_value.payload = DPTArray((0x43, 0xC6, 0x80, 00))
 
         self.assertEqual(sensor.resolve_state(), 397)
         self.assertEqual(sensor.unit_of_measurement(), "W")
@@ -116,7 +96,7 @@ class TestSensor(unittest.TestCase):
             'TestSensor',
             group_address='1/2/3',
             value_type="electric_potential")
-        sensor.state = DPTArray((0x43, 0x65, 0xE3, 0xD7))
+        sensor.sensor_value.payload = DPTArray((0x43, 0x65, 0xE3, 0xD7))
 
         self.assertEqual(round(sensor.resolve_state(), 2), 229.89)
         self.assertEqual(sensor.unit_of_measurement(), "V")
@@ -130,6 +110,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
+            value_type="temperature",
             group_address='1/2/3')
 
         self.loop.run_until_complete(asyncio.Task(sensor.sync(False)))
@@ -149,12 +130,14 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
+            value_type='temperature',
             group_address='1/2/3')
 
         telegram = Telegram(GroupAddress('1/2/3'))
-        telegram.payload = DPTArray((0x01, 0x02, 0x03))
+        telegram.payload = DPTArray((0x06, 0xa0))
         self.loop.run_until_complete(asyncio.Task(sensor.process(telegram)))
-        self.assertEqual(sensor.state, DPTArray((0x01, 0x02, 0x03)))
+        self.assertEqual(sensor.sensor_value.payload, DPTArray((0x06, 0xa0)))
+        self.assertEqual(sensor.resolve_state(), 16.96)
 
     def test_process_callback(self):
         """Test process / reading telegrams from telegram queue. Test if callback is called."""
@@ -163,7 +146,8 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3')
+            group_address='1/2/3',
+            value_type="temperature")
 
         after_update_callback = Mock()
 
@@ -173,6 +157,6 @@ class TestSensor(unittest.TestCase):
         sensor.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(GroupAddress('1/2/3'))
-        telegram.payload = DPTArray((0x01, 0x02, 0x03))
+        telegram.payload = DPTArray((0x01, 0x02))
         self.loop.run_until_complete(asyncio.Task(sensor.process(telegram)))
         after_update_callback.assert_called_with(sensor)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -148,11 +148,11 @@ class TestStringRepresentations(unittest.TestCase):
             value_type='percent')
         self.assertEqual(
             str(sensor),
-            '<Sensor name="MeinSensor" group_address="GroupAddress("1/2/3")" state="None" resolve_state="None" />')
-        self.loop.run_until_complete(asyncio.Task(sensor._set_internal_state(DPTArray((0x23)))))  # pylint: disable=protected-access
+            '<Sensor name="MeinSensor" sensor="None/GroupAddress("1/2/3")/None/None" value="None" unit="%"/>')
+        self.loop.run_until_complete(asyncio.Task(sensor.sensor_value.set(25)))
         self.assertEqual(
             str(sensor),
-            '<Sensor name="MeinSensor" group_address="GroupAddress("1/2/3")" state="<DPTArray value="[0x23]" />" resolve_state="14" />')
+            '<Sensor name="MeinSensor" sensor="None/GroupAddress("1/2/3")/<DPTArray value="[0xc0]" />/25" value="25" unit="%"/>')
 
     def test_switch(self):
         """Test string representation of switch object."""

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -5,7 +5,7 @@ import unittest
 from xknx import XKNX
 from xknx.devices import (Action, ActionBase, ActionCallback, BinarySensor,
                           Climate, Cover, DateTime, Light, Notification,
-                          RemoteValue, Sensor, Switch)
+                          RemoteValue, ExposeSensor, Sensor, Switch)
 from xknx.exceptions import (ConversionError, CouldNotParseAddress,
                              CouldNotParseKNXIP, CouldNotParseTelegram,
                              DeviceIllegalValue)
@@ -153,6 +153,22 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(sensor),
             '<Sensor name="MeinSensor" sensor="None/GroupAddress("1/2/3")/<DPTArray value="[0xc0]" />/25" value="25" unit="%"/>')
+
+    def test_expose_sensor(self):
+        """Test string representation of expose sensor object."""
+        xknx = XKNX(loop=self.loop)
+        sensor = ExposeSensor(
+            xknx,
+            name='MeinSensor',
+            group_address='1/2/3',
+            value_type='percent')
+        self.assertEqual(
+            str(sensor),
+            '<ExposeSensor name="MeinSensor" sensor="GroupAddress("1/2/3")/None/None/None" value="None" unit="%"/>')
+        self.loop.run_until_complete(asyncio.Task(sensor.set(25)))
+        self.assertEqual(
+            str(sensor),
+            '<ExposeSensor name="MeinSensor" sensor="GroupAddress("1/2/3")/None/<DPTArray value="[0xc0]" />/25" value="25" unit="%"/>')
 
     def test_switch(self):
         """Test string representation of switch object."""

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -98,5 +98,7 @@ groups:
     sensor:
         Heating.Valve1: {group_address: '2/0/0', value_type: 'percent'}
         Heating.Valve2: {group_address: '2/0/1', value_type: 'percent'}
-        Some.Other.Value: {group_address: '2/0/2', value_type: 'temperature'}
+        Kitchen.Temperature: {group_address: '2/0/2', value_type: 'temperature'}
 
+    expose_sensor:
+        Outside.Temperature: {group_address: '2/0/3', value_type: 'temperature'}

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -98,5 +98,5 @@ groups:
     sensor:
         Heating.Valve1: {group_address: '2/0/0', value_type: 'percent'}
         Heating.Valve2: {group_address: '2/0/1', value_type: 'percent'}
-        Some.Other.Value: {group_address: '2/0/2'}
+        Some.Other.Value: {group_address: '2/0/2', value_type: 'temperature'}
 

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -8,7 +8,7 @@ Module for reading configfiles (xknx.yaml).
 import yaml
 
 from xknx.devices import (BinarySensor, Climate, Cover, DateTime, Light,
-                          Notification, Sensor, Switch)
+                          Notification, ExposeSensor, Sensor, Switch)
 from xknx.knx import PhysicalAddress
 
 
@@ -49,6 +49,8 @@ class Config:
                 self.parse_group_datetime(doc["groups"][group])
             elif group.startswith("sensor"):
                 self.parse_group_sensor(doc["groups"][group])
+            elif group.startswith("expose_sensor"):
+                self.parse_group_expose_sensor(doc["groups"][group])
             elif group.startswith("binary_sensor"):
                 self.parse_group_binary_sensor(doc["groups"][group])
             elif group.startswith("notification"):
@@ -116,6 +118,15 @@ class Config:
                 entry,
                 entries[entry])
             self.xknx.devices.add(sensor)
+
+    def parse_group_expose_sensor(self, entries):
+        """Parse a exposed sensor section of xknx.yaml."""
+        for entry in entries:
+            expose_sensor = ExposeSensor.from_config(
+                self.xknx,
+                entry,
+                entries[entry])
+            self.xknx.devices.add(expose_sensor)
 
     def parse_group_notification(self, entries):
         """Parse a sensor section of xknx.yaml."""

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -12,3 +12,4 @@ from .sensor import Sensor
 from .binary_sensor import BinarySensor, BinarySensorState
 from .notification import Notification
 from .remote_value import RemoteValue
+from .remote_value_sensor import RemoteValueSensor

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -9,6 +9,7 @@ from .light import Light
 from .switch import Switch
 from .datetime import DateTime
 from .sensor import Sensor
+from .expose_sensor import ExposeSensor
 from .binary_sensor import BinarySensor, BinarySensorState
 from .notification import Notification
 from .remote_value import RemoteValue

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -1,0 +1,93 @@
+"""
+Module for exposing a (virtual) sensor to KNX bus.
+
+It provides functionality for
+
+* push local state changes to KNX bus
+* KNX devices may read local values via GROUP READ.
+
+(A typical example for using this class is the outside temperature
+read from an internet service (e.g. Yahoo weather) and exposed to
+ths KNX bus. KNX sensors may show this outside temperature within their
+LCD display.
+"""
+from .device import Device
+from .remote_value_sensor import RemoteValueSensor
+from .remote_value import RemoteValueScaling5001
+
+
+class ExposeSensor(Device):
+    """Class for managing a sensor."""
+
+    def __init__(self,
+                 xknx,
+                 name,
+                 group_address=None,
+                 value_type=None,
+                 device_updated_cb=None):
+        """Initialize Sensor class."""
+        # pylint: disable=too-many-arguments
+        Device.__init__(self, xknx, name, device_updated_cb)
+
+        self.sensor_value = None
+        if value_type == "percent":
+            self.sensor_value = RemoteValueScaling5001(
+                xknx,
+                group_address=group_address,
+                after_update_cb=self.after_update)
+        else:
+            self.sensor_value = RemoteValueSensor(
+                xknx,
+                group_address=group_address,
+                after_update_cb=self.after_update,
+                value_type=value_type)
+
+    @classmethod
+    def from_config(cls, xknx, name, config):
+        """Initialize object from configuration structure."""
+        group_address = \
+            config.get('group_address')
+        value_type = \
+            config.get('value_type')
+
+        return cls(xknx,
+                   name,
+                   group_address=group_address,
+                   value_type=value_type)
+
+    def has_group_address(self, group_address):
+        """Test if device has given group address."""
+        return self.sensor_value.has_group_address(group_address)
+
+    def state_addresses(self):
+        """Return group addresses which should be requested to sync state."""
+        return []
+
+    async def process_group_read(self, telegram):
+        """Process incoming GROUP READ telegram."""
+        await self.sensor_value.send(response=True)
+
+    async def set(self, value):
+        """Set new value."""
+        await self.sensor_value.set(value)
+
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self.sensor_value.unit_of_measurement
+
+    def resolve_state(self):
+        """Return the current state of the sensor as a human readable string."""
+        return self.sensor_value.value
+
+    def __str__(self):
+        """Return object as readable string."""
+        return '<ExposeSensor name="{0}" ' \
+               'sensor="{1}" value="{2}" unit="{3}"/>' \
+            .format(self.name,
+                    self.sensor_value.group_addr_str(),
+                    self.resolve_state(),
+                    self.unit_of_measurement())
+
+    def __eq__(self, other):
+        """Equal operator."""
+        return self.__dict__ == other.__dict__

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -50,10 +50,9 @@ class RemoteValue():
             return [self.group_address, ]
         return []
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed - to be implemented in derived class.."""
-        # pylint: disable=unused-argument
+        # pylint: disable=unused-argument, no-self-use
         return True
 
     def from_knx(self, payload):
@@ -105,6 +104,11 @@ class RemoteValue():
         if updated and self.after_update_cb is not None:
             await self.after_update_cb()
 
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return None
+
     def group_addr_str(self):
         """Return object as readable string."""
         return '{0}/{1}/{2}/{3}' \
@@ -152,8 +156,7 @@ class RemoteValueSwitch1001(RemoteValue):
         super(RemoteValueSwitch1001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return isinstance(payload, DPTBinary)
 
@@ -204,8 +207,7 @@ class RemoteValueUpDown1008(RemoteValue):
         super(RemoteValueUpDown1008, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return isinstance(payload, DPTBinary)
 
@@ -255,8 +257,7 @@ class RemoteValueStep1007(RemoteValue):
         super(RemoteValueStep1007, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return isinstance(payload, DPTBinary)
 
@@ -299,8 +300,7 @@ class RemoteValueScaling5001(RemoteValue):
         super(RemoteValueScaling5001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
         self.invert = invert
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return (isinstance(payload, DPTArray)
                 and len(payload.value) == 1)
@@ -318,12 +318,16 @@ class RemoteValueScaling5001(RemoteValue):
             value = 100 - value
         return value
 
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return "%"
+
 
 class RemoteValue1Count(RemoteValue):
     """Abstraction for remote value of KNX 6.010 (DPT_Value_1_Count)."""
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return (isinstance(payload, DPTArray)
                 and len(payload.value) == 1)
@@ -340,8 +344,7 @@ class RemoteValue1Count(RemoteValue):
 class RemoteValueTemp(RemoteValue):
     """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
 
-    @staticmethod
-    def payload_valid(payload):
+    def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return (isinstance(payload, DPTArray)
                 and len(payload.value) == 2)

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -9,7 +9,7 @@ from enum import Enum
 
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.knx import (DPTArray, DPTBinary, DPTScaling, DPTTemperature,
-                      DPTValue1Count, GroupAddress, Telegram)
+                      DPTValue1Count, GroupAddress, Telegram, TelegramType)
 
 
 class RemoteValue():
@@ -84,10 +84,12 @@ class RemoteValue():
             return None
         return self.from_knx(self.payload)
 
-    async def send(self):
+    async def send(self, response=False):
         """Send payload as telegram to KNX bus."""
         telegram = Telegram()
         telegram.group_address = self.group_address
+        telegram.telegramtype = TelegramType.GROUP_RESPONSE \
+            if response else TelegramType.GROUP_WRITE
         telegram.payload = self.payload
         await self.xknx.telegrams.put(telegram)
 

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -1,0 +1,82 @@
+"""
+Module for managing a remote valeue typically used within a sensor.
+
+The module maps a given value_type to a DPT class and uses this class
+for serialization and deserialization of the KNX value.
+"""
+from xknx.knx import (DPTArray, DPTHumidity, DPTLux,
+                      DPTTemperature, DPTElectricPotential,
+                      DPTElectricCurrent, DPTPower, DPTUElCurrentmA, DPTWsp,
+                      DPTBrightness, DPTEnergy, DPTHeatFlowRate, DPTFrequency, DPTPhaseAngleRad, DPTPhaseAngleDeg,
+                      DPTPowerFactor, DPTSpeed,
+                      DPT2ByteUnsigned, DPT2ByteFloat, DPT4ByteUnsigned, DPT4ByteSigned, DPT4ByteFloat)
+from xknx.exceptions import ConversionError
+from .remote_value import RemoteValue
+
+
+class RemoteValueSensor(RemoteValue):
+    """Abstraction for many different sensor DPT types."""
+
+    DPTMAP = {
+        'temperature': DPTTemperature,
+        'humidity': DPTHumidity,
+        'illuminance': DPTLux,
+        'brightness': DPTBrightness,
+        'speed_ms': DPTWsp,
+        'current': DPTUElCurrentmA,
+        'power': DPTPower,
+        'electric_current': DPTElectricCurrent,
+        'electric_potential': DPTElectricPotential,
+        'energy': DPTEnergy,
+        'frequency': DPTFrequency,
+        'heatflowrate': DPTHeatFlowRate,
+        'phaseanglerad': DPTPhaseAngleRad,
+        'phaseangledeg': DPTPhaseAngleDeg,
+        'powerfactor': DPTPowerFactor,
+        'speed': DPTSpeed,
+
+        #  Generic DPT Without Min/Max and Unit.
+        'DPT-7': DPT2ByteUnsigned,
+        '2byte_unsigned': DPT2ByteUnsigned,
+        'DPT-9': DPT2ByteFloat,
+
+        'DPT-12': DPT4ByteUnsigned,
+        '4byte_unsigned': DPT4ByteUnsigned,
+
+        'DPT-13': DPT4ByteSigned,
+        '4byte_signed': DPT4ByteSigned,
+        'DPT-14': DPT4ByteFloat,
+        '4byte_float': DPT4ByteFloat
+    }
+
+    def __init__(self,
+                 xknx,
+                 group_address=None,
+                 group_address_state=None,
+                 value_type=None,
+                 after_update_cb=None):
+        """Initialize RemoteValueSensor class."""
+        # pylint: disable=too-many-arguments
+        super(RemoteValueSensor, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        if value_type not in self.DPTMAP:
+            raise ConversionError(value_type)
+        self.value_type = value_type
+
+    def payload_valid(self, payload):
+        """Test if telegram payload may be parsed."""
+        print(len(payload.value) == self.DPTMAP[self.value_type].payload_length)
+        return (isinstance(payload, DPTArray) and
+                len(payload.value) == self.DPTMAP[self.value_type].payload_length)
+
+    def to_knx(self, value):
+        """Convert value to payload."""
+        return DPTArray(self.DPTMAP[self.value_type].to_knx(value))
+
+    def from_knx(self, payload):
+        """Convert current payload to value."""
+        return self.DPTMAP[self.value_type].from_knx(payload.value)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement."""
+        return self.DPTMAP[self.value_type].unit

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -64,9 +64,9 @@ class RemoteValueSensor(RemoteValue):
 
     def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
-        print(len(payload.value) == self.DPTMAP[self.value_type].payload_length)
-        return (isinstance(payload, DPTArray) and
-                len(payload.value) == self.DPTMAP[self.value_type].payload_length)
+        return (
+            isinstance(payload, DPTArray) and
+            len(payload.value) == self.DPTMAP[self.value_type].payload_length)
 
     def to_knx(self, value):
         """Convert value to payload."""

--- a/xknx/knx/dpt_2byte.py
+++ b/xknx/knx/dpt_2byte.py
@@ -18,6 +18,7 @@ class DPT2ByteUnsigned(DPTBase):
     value_max = 65535
     unit = ""
     resolution = 1
+    payload_length = 2
 
     @classmethod
     def from_knx(cls, raw):

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -24,6 +24,7 @@ class DPT4ByteUnsigned(DPTBase):
     value_max = 4294967295
     unit = ""
     resolution = 1
+    payload_length = 4
 
     _struct_format = ">I"
 

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -24,6 +24,7 @@ class DPT2ByteFloat(DPTBase):
     value_max = 670760.96
     unit = ""
     resolution = 1
+    payload_length = 2
 
     @classmethod
     def from_knx(cls, raw):
@@ -92,6 +93,7 @@ class DPT4ByteFloat(DPTBase):
     """
 
     unit = ""
+    payload_length = 4
 
     @classmethod
     def from_knx(cls, raw):


### PR DESCRIPTION
New device class ExposeSensor
---------------------------------

ExposeSensors may be used to expose a local, virtual sensor value to the KNX bus. A virtual sensor value may be e.g. the outside temperature obtained from the internet. 

If a value is changed via the `.set` method the value is broadcasted a `GROUP_WRITE` to the KNX bus.  The devices answers with `GROUP_RESPONSE` after `GROUP_READ` to the given group address. 

