### PR TITLE
Improved Exceptions

### DIFF
--- a/test/str_test.py
+++ b/test/str_test.py
@@ -40,14 +40,15 @@ class TestStringRepresentations(unittest.TestCase):
         remote_value = RemoteValue(
             xknx,
             group_address='1/2/3',
+            device_name="MyDevice",
             group_address_state='1/2/4')
         self.assertEqual(
             str(remote_value),
-            '<RemoteValue GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None/>')
+            '<RemoteValue device_name="MyDevice" GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None/>')
         remote_value.payload = DPTArray([0x01, 0x02])
         self.assertEqual(
             str(remote_value),
-            '<RemoteValue GroupAddress("1/2/3")/GroupAddress("1/2/4")/<DPTArray value="[0x1,0x2]" />/None/>')
+            '<RemoteValue device_name="MyDevice" GroupAddress("1/2/3")/GroupAddress("1/2/4")/<DPTArray value="[0x1,0x2]" />/None/>')
 
     def test_binary_sensor(self):
         """Test string representation of binary sensor object."""
@@ -241,6 +242,13 @@ class TestStringRepresentations(unittest.TestCase):
             str(exception),
             '<CouldNotParseTelegram description="Fnord" />')
 
+    def test_could_not_parse_telegramn_exception_parameter(self):
+        """Test string representation of CouldNotParseTelegram exception."""
+        exception = CouldNotParseTelegram(description='Fnord', one="one", two="two")
+        self.assertEqual(
+            str(exception),
+            '<CouldNotParseTelegram description="Fnord" one="one" two="two"/>')
+
     def test_could_not_parse_knxip_exception(self):
         """Test string representation of CouldNotParseKNXIP exception."""
         exception = CouldNotParseKNXIP(description='Fnord')
@@ -250,10 +258,17 @@ class TestStringRepresentations(unittest.TestCase):
 
     def test_conversion_error_exception(self):
         """Test string representation of ConversionError exception."""
-        exception = ConversionError(value='Fnord')
+        exception = ConversionError(description='Fnord')
         self.assertEqual(
             str(exception),
-            '<ConversionError value="Fnord" />')
+            '<ConversionError description="Fnord" />')
+
+    def test_conversion_error_exception_parameter(self):
+        """Test string representation of ConversionError exception."""
+        exception = ConversionError(description='Fnord', one="one", two="two")
+        self.assertEqual(
+            str(exception),
+            '<ConversionError description="Fnord" one="one" two="two"/>')
 
     def test_could_not_parse_address_exception(self):
         """Test string representation of CouldNotParseAddress exception."""

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -12,6 +12,7 @@ from xknx.devices import (BinarySensor, Climate, Cover, DateTime, Light,
 from xknx.knx import PhysicalAddress
 from xknx.exceptions import XKNXException
 
+
 class Config:
     """Class for parsing xknx.yaml."""
 

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -146,7 +146,7 @@ class BinarySensor(Device):
                 await asyncio.sleep(self.reset_after/1000)
                 await self._set_internal_state(BinarySensorState.OFF)
         else:
-            raise CouldNotParseTelegram()
+            raise CouldNotParseTelegram("Illegal payload", payload=telegram.payload, device_name=self.name)
 
     def is_on(self):
         """Return if binary sensor is 'on'."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -70,15 +70,18 @@ class Climate(Device):
         self.temperature = RemoteValueTemp(
             xknx,
             group_address_temperature,
+            device_name=self.name,
             after_update_cb=self.after_update)
         self.target_temperature = RemoteValueTemp(
             xknx,
             group_address_target_temperature,
+            device_name=self.name,
             after_update_cb=self.after_update)
         self.setpoint_shift = RemoteValue1Count(
             xknx,
             group_address_setpoint_shift,
             group_address_setpoint_shift_state,
+            device_name=self.name,
             after_update_cb=self.after_update)
 
         self.setpoint_shift_step = setpoint_shift_step
@@ -284,7 +287,7 @@ class Climate(Device):
         """Process incoming telegram for operation mode."""
         if not isinstance(telegram.payload, DPTArray) \
                 or len(telegram.payload.value) != 1:
-            raise CouldNotParseTelegram()
+            raise CouldNotParseTelegram("invalid payload", payload=telegram.payload, device_name=self.name)
         operation_mode = DPTHVACMode.from_knx(telegram.payload.value)
         await self._set_internal_operation_mode(operation_mode)
 
@@ -292,7 +295,7 @@ class Climate(Device):
         """Process incoming telegram for controller status."""
         if not isinstance(telegram.payload, DPTArray) \
                 or len(telegram.payload.value) != 1:
-            raise CouldNotParseTelegram()
+            raise CouldNotParseTelegram("invalid payload", payload=telegram.payload, device_name=self.name)
         operation_mode = DPTControllerStatus.from_knx(telegram.payload.value)
         await self._set_internal_operation_mode(operation_mode)
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -44,12 +44,14 @@ class Cover(Device):
         self.updown = RemoteValueUpDown1008(
             xknx,
             group_address_long,
+            device_name=self.name,
             after_update_cb=self.after_update,
             invert=invert_position)
 
         self.step = RemoteValueStep1007(
             xknx,
             group_address_short,
+            device_name=self.name,
             after_update_cb=self.after_update,
             invert=invert_position)
 
@@ -57,6 +59,7 @@ class Cover(Device):
             xknx,
             group_address_position,
             group_address_position_state,
+            device_name=self.name,
             after_update_cb=self.after_update,
             invert=invert_position)
 
@@ -64,6 +67,7 @@ class Cover(Device):
             xknx,
             group_address_angle,
             group_address_angle_state,
+            device_name=self.name,
             after_update_cb=self.after_update,
             invert=invert_angle)
 

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -34,11 +34,13 @@ class ExposeSensor(Device):
             self.sensor_value = RemoteValueScaling5001(
                 xknx,
                 group_address=group_address,
+                device_name=self.name,
                 after_update_cb=self.after_update)
         else:
             self.sensor_value = RemoteValueSensor(
                 xknx,
                 group_address=group_address,
+                device_name=self.name,
                 after_update_cb=self.after_update,
                 value_type=value_type)
 

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -37,6 +37,7 @@ class Light(Device):
             xknx,
             group_address_switch,
             group_address_switch_state,
+            device_name=self.name,
             after_update_cb=self.after_update)
 
         self.group_address_brightness = group_address_brightness
@@ -151,9 +152,10 @@ class Light(Device):
 
     async def _process_brightness(self, telegram):
         """Process incoming telegram for brightness state."""
-        if not isinstance(telegram.payload, DPTArray) or \
-                len(telegram.payload.value) != 1:
-            raise CouldNotParseTelegram()
+        if not isinstance(telegram.payload, DPTArray):
+            raise CouldNotParseTelegram("payload not of type DPTArray", payload=telegram.payload, device_name=self.name)
+        if len(telegram.payload.value) != 1:
+            raise CouldNotParseTelegram("payload has invalid length!=1", length=len(telegram.payload.value), device_name=self.name)
 
         await self._set_internal_brightness(telegram.payload.value[0])
 

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -77,7 +77,7 @@ class Notification(Device):
     async def _process_message(self, telegram):
         """Process incoming telegram for on/off state."""
         if not isinstance(telegram.payload, DPTString):
-            raise CouldNotParseTelegram()
+            raise CouldNotParseTelegram("payload not of type DPTString", payload=telegram.payload, device_name=self.name)
         await self._set_internal_message(telegram.payload.value)
 
     def __eq__(self, other):

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -74,7 +74,10 @@ class RemoteValue():
         if not self.has_group_address(telegram.group_address):
             return False
         if not self.payload_valid(telegram.payload):
-            raise CouldNotParseTelegram("payload invalid", payload=telegram.payload, device_name=self.device_name)
+            raise CouldNotParseTelegram("payload invalid",
+                                        payload=telegram.payload,
+                                        group_address=telegram.group_address,
+                                        device_name=self.device_name)
         if self.payload != telegram.payload:
             self.payload = telegram.payload
             if self.after_update_cb is not None:

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -19,8 +19,10 @@ class RemoteValue():
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 device_name=None,
                  after_update_cb=None):
         """Initialize RemoteValue class."""
+        # pylint: disable=too-many-arguments
         self.xknx = xknx
         if isinstance(group_address, (str, int)):
             group_address = GroupAddress(group_address)
@@ -30,6 +32,8 @@ class RemoteValue():
         self.group_address = group_address
         self.group_address_state = group_address_state
         self.after_update_cb = after_update_cb
+        self.device_name = "Unknown" \
+            if device_name is None else device_name
         self.payload = None
 
     @property
@@ -70,7 +74,7 @@ class RemoteValue():
         if not self.has_group_address(telegram.group_address):
             return False
         if not self.payload_valid(telegram.payload):
-            raise CouldNotParseTelegram()
+            raise CouldNotParseTelegram("payload invalid", payload=telegram.payload, device_name=self.device_name)
         if self.payload != telegram.payload:
             self.payload = telegram.payload
             if self.after_update_cb is not None:
@@ -121,8 +125,9 @@ class RemoteValue():
 
     def __str__(self):
         """Return object as string representation."""
-        return "<{} {}/>".format(
+        return '<{} device_name="{}" {}/>'.format(
             self.__class__.__name__,
+            self.device_name,
             self.group_addr_str())
 
     def __eq__(self, other):
@@ -151,11 +156,14 @@ class RemoteValueSwitch1001(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 device_name=None,
                  after_update_cb=None,
                  invert=False):
         """Initialize remote value of KNX DPT 1.001."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueSwitch1001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(RemoteValueSwitch1001, self).__init__(
+            xknx, group_address, group_address_state,
+            device_name=device_name, after_update_cb=after_update_cb)
         self.invert = invert
 
     def payload_valid(self, payload):
@@ -168,7 +176,7 @@ class RemoteValueSwitch1001(RemoteValue):
             return DPTBinary(1) if self.invert else DPTBinary(0)
         elif value == self.Value.ON:
             return DPTBinary(0) if self.invert else DPTBinary(1)
-        raise ConversionError(value)
+        raise ConversionError("value invalid", value=value, device_name=self.device_name)
 
     def from_knx(self, payload):
         """Convert current payload to value."""
@@ -176,7 +184,7 @@ class RemoteValueSwitch1001(RemoteValue):
             return self.Value.ON if self.invert else self.Value.OFF
         elif payload == DPTBinary(1):
             return self.Value.OFF if self.invert else self.Value.ON
-        raise ConversionError(payload)
+        raise ConversionError("payload invalid", payload=payload, device_name=self.device_name)
 
     async def off(self):
         """Set value to down."""
@@ -202,11 +210,14 @@ class RemoteValueUpDown1008(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 device_name=None,
                  after_update_cb=None,
                  invert=False):
         """Initialize remote value of KNX DPT 1.008."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueUpDown1008, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(RemoteValueUpDown1008, self).__init__(
+            xknx, group_address, group_address_state,
+            device_name=device_name, after_update_cb=after_update_cb)
         self.invert = invert
 
     def payload_valid(self, payload):
@@ -219,7 +230,7 @@ class RemoteValueUpDown1008(RemoteValue):
             return DPTBinary(1) if self.invert else DPTBinary(0)
         elif value == self.Direction.DOWN:
             return DPTBinary(0) if self.invert else DPTBinary(1)
-        raise ConversionError(value)
+        raise ConversionError("value invalid", value=value, device_name=self.device_name)
 
     def from_knx(self, payload):
         """Convert current payload to value."""
@@ -227,7 +238,7 @@ class RemoteValueUpDown1008(RemoteValue):
             return self.Direction.DOWN if self.invert else self.Direction.UP
         elif payload == DPTBinary(1):
             return self.Direction.UP if self.invert else self.Direction.DOWN
-        raise ConversionError(payload)
+        raise ConversionError("payload invalid", payload=payload, device_name=self.device_name)
 
     async def down(self):
         """Set value to down."""
@@ -252,11 +263,14 @@ class RemoteValueStep1007(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 device_name=None,
                  after_update_cb=None,
                  invert=False):
         """Initialize remote value of KNX DPT 1.007."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueStep1007, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(RemoteValueStep1007, self).__init__(
+            xknx, group_address, group_address_state,
+            device_name=device_name, after_update_cb=after_update_cb)
         self.invert = invert
 
     def payload_valid(self, payload):
@@ -269,7 +283,7 @@ class RemoteValueStep1007(RemoteValue):
             return DPTBinary(1) if self.invert else DPTBinary(0)
         elif value == self.Direction.DECREASE:
             return DPTBinary(0) if self.invert else DPTBinary(1)
-        raise ConversionError(value)
+        raise ConversionError("value invalid", value=value, device_name=self.device_name)
 
     def from_knx(self, payload):
         """Convert current payload to value."""
@@ -277,7 +291,7 @@ class RemoteValueStep1007(RemoteValue):
             return self.Direction.DECREASE if self.invert else self.Direction.INCREASE
         elif payload == DPTBinary(1):
             return self.Direction.INCREASE if self.invert else self.Direction.DECREASE
-        raise ConversionError(payload)
+        raise ConversionError("payload invalid", payload=payload, device_name=self.device_name)
 
     async def increase(self):
         """Increase value."""
@@ -295,11 +309,14 @@ class RemoteValueScaling5001(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 device_name=None,
                  after_update_cb=None,
                  invert=False):
         """Initialize remote value of KNX DPT 5.001 (DPT_Scaling)."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueScaling5001, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(RemoteValueScaling5001, self).__init__(
+            xknx, group_address, group_address_state,
+            device_name=device_name, after_update_cb=after_update_cb)
         self.invert = invert
 
     def payload_valid(self, payload):

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -54,12 +54,15 @@ class RemoteValueSensor(RemoteValue):
                  group_address=None,
                  group_address_state=None,
                  value_type=None,
+                 device_name=None,
                  after_update_cb=None):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
-        super(RemoteValueSensor, self).__init__(xknx, group_address, group_address_state, after_update_cb)
+        super(RemoteValueSensor, self).__init__(
+            xknx, group_address, group_address_state,
+            device_name=device_name, after_update_cb=after_update_cb)
         if value_type not in self.DPTMAP:
-            raise ConversionError(value_type)
+            raise ConversionError("invalid value type", value_type=value_type, device_name=device_name)
         self.value_type = value_type
 
     def payload_valid(self, payload):

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -29,11 +29,13 @@ class Sensor(Device):
             self.sensor_value = RemoteValueScaling5001(
                 xknx,
                 group_address_state=group_address,
+                device_name=self.name,
                 after_update_cb=self.after_update)
         else:
             self.sensor_value = RemoteValueSensor(
                 xknx,
                 group_address_state=group_address,
+                device_name=self.name,
                 after_update_cb=self.after_update,
                 value_type=value_type)
 

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -27,6 +27,7 @@ class Switch(Device):
             xknx,
             group_address,
             group_address_state,
+            device_name=self.name,
             after_update_cb=self.after_update)
 
     @classmethod

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -10,15 +10,19 @@ class XKNXException(Exception):
 class CouldNotParseTelegram(XKNXException):
     """Could not parse telegram error."""
 
-    def __init__(self, description=""):
+    def __init__(self, description, **kwargs):
         """Initialize CouldNotParseTelegram class."""
         super(CouldNotParseTelegram, self).__init__("Could not parse Telegram")
         self.description = description
+        self.parameter = kwargs
+
+    def _format_parameter(self):
+        return " ".join(['%s="%s"' % (key, value) for (key, value) in sorted(self.parameter.items())])
 
     def __str__(self):
         """Return object as readable string."""
-        return '<CouldNotParseTelegram description="{0}" />' \
-            .format(self.description)
+        return '<CouldNotParseTelegram description="{0}" {1}/>' \
+            .format(self.description, self._format_parameter())
 
 
 class CouldNotParseKNXIP(XKNXException):
@@ -38,14 +42,18 @@ class CouldNotParseKNXIP(XKNXException):
 class ConversionError(XKNXException):
     """Exception class for error while converting one type to another."""
 
-    def __init__(self, value):
+    def __init__(self, description, **kwargs):
         """Initialize ConversionError class."""
         super(ConversionError, self).__init__("Conversion Error")
-        self.value = value
+        self.description = description
+        self.parameter = kwargs
+
+    def _format_parameter(self):
+        return " ".join(['%s="%s"' % (key, value) for (key, value) in sorted(self.parameter.items())])
 
     def __str__(self):
         """Return object as readable string."""
-        return '<ConversionError value="{0}" />'.format(self.value)
+        return '<ConversionError description="{0}" {1}/>'.format(self.description, self._format_parameter())
 
 
 class CouldNotParseAddress(XKNXException):

--- a/xknx/knx/address_filter.py
+++ b/xknx/knx/address_filter.py
@@ -39,10 +39,10 @@ class AddressFilter:
     def _parse_pattern(self, pattern):
         for part in pattern.split("/"):
             if not part:
-                raise ConversionError("Every part of pattern must be a string.")
+                raise ConversionError("Every part of pattern must be a string.", pattern=pattern)
             self.level_filters.append(AddressFilter.LevelFilter(part))
         if len(self.level_filters) > 3:
-            raise ConversionError("Too many parts within pattern.")
+            raise ConversionError("Too many parts within pattern.", pattern=pattern)
 
     def match(self, address):
         """Test if provided address matches Addressfilter."""
@@ -148,7 +148,7 @@ class AddressFilter:
         def _parse_pattern(self, pattern):
             for part in pattern.split(","):
                 if not part:
-                    raise ConversionError("Every part of LevelFilter must be a string")
+                    raise ConversionError("Every part of LevelFilter must be a string", pattern=pattern)
                 self.ranges.append(AddressFilter.Range(part))
 
         def match(self, digit):

--- a/xknx/knx/dpt.py
+++ b/xknx/knx/dpt.py
@@ -50,7 +50,7 @@ class DPTBase:
                 or any(not isinstance(byte, int) for byte in raw) \
                 or any(byte < 0 for byte in raw) \
                 or any(byte > 255 for byte in raw):
-            raise ConversionError(raw)
+            raise ConversionError("Invalid raw bytes", raw=raw)
 
 
 class DPTBinary(DPTBase):
@@ -67,7 +67,7 @@ class DPTBinary(DPTBase):
         if not isinstance(value, int):
             raise TypeError()
         if value > DPTBinary.APCI_BITMASK:
-            raise ConversionError(value)
+            raise ConversionError("Cant init DPTBinary", value=value)
 
         self.value = value
 

--- a/xknx/knx/dpt_2byte.py
+++ b/xknx/knx/dpt_2byte.py
@@ -30,7 +30,7 @@ class DPT2ByteUnsigned(DPTBase):
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT2ByteUnsigned", value=value)
         return value >> 8, value & 0xff
 
     @classmethod

--- a/xknx/knx/dpt_4byte.py
+++ b/xknx/knx/dpt_4byte.py
@@ -36,18 +36,18 @@ class DPT4ByteUnsigned(DPTBase):
         try:
             return struct.unpack(cls._struct_format, bytes(raw))[0]
         except struct.error:
-            raise ConversionError(raw)
+            raise ConversionError("Cant parse DPT4ByteUnsigned", raw=raw)
 
     @classmethod
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT4ByteUnsigned", value=value)
 
         try:
             return tuple(struct.pack(cls._struct_format, value))
         except struct.error:
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT4ByteUnsigned", value=value)
 
     @classmethod
     def _test_boundaries(cls, value):

--- a/xknx/knx/dpt_date.py
+++ b/xknx/knx/dpt_date.py
@@ -20,7 +20,7 @@ class DPTDate(DPTBase):
         year = raw[2] & 0x7F
 
         if not DPTDate._test_range(day, month, year):
-            raise ConversionError(raw)
+            raise ConversionError("Cant parse DPTDate", raw=raw)
 
         if year >= 90:
             year += 1900
@@ -37,7 +37,7 @@ class DPTDate(DPTBase):
     def to_knx(cls, values):
         """Serialize to KNX/IP raw data from dict with elements day,month,year."""
         if not isinstance(values, dict):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTDate", values=values)
         day = values.get('day', 0)
         month = values.get('month', 0)
         year = values.get('year', 0)
@@ -48,7 +48,7 @@ class DPTDate(DPTBase):
             year -= 1900
 
         if not DPTDate._test_range(day, month, year):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTDate", values=values)
 
         return day, month, year
 

--- a/xknx/knx/dpt_datetime.py
+++ b/xknx/knx/dpt_datetime.py
@@ -24,7 +24,7 @@ class DPTDateTime(DPTBase):
         seconds = raw[5] & 0x3F
 
         if not DPTDateTime._test_range(year, month, day, weekday, hours, minutes, seconds):
-            raise ConversionError(raw)
+            raise ConversionError("Could not parse DPTDateTime", raw=raw)
 
         return {
             'year': year,
@@ -40,7 +40,7 @@ class DPTDateTime(DPTBase):
     def to_knx(cls, values):
         """Serialize to KNX/IP raw data from dict with elements year,month,day,weekday,hours,minutes,seconds."""
         if not isinstance(values, dict):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTDateTime", values=values)
 
         year = values.get('year', 1900)
         month = values.get('month', 1)
@@ -51,7 +51,7 @@ class DPTDateTime(DPTBase):
         seconds = values.get('seconds', 0)
 
         if not DPTDateTime._test_range(year, month, day, weekday, hours, minutes, seconds):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTDateTime", values=values)
 
         return year - 1900, month, day, weekday << 5 | hours, minutes, seconds, 0, 0
 

--- a/xknx/knx/dpt_float.py
+++ b/xknx/knx/dpt_float.py
@@ -41,7 +41,7 @@ class DPT2ByteFloat(DPTBase):
         value = float(significand << exponent) / 100
 
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant parse DPT2ByteFloat", value=value)
 
         return value
 
@@ -49,9 +49,9 @@ class DPT2ByteFloat(DPTBase):
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not isinstance(value, (int, float)):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT2ByteFloat", value=value)
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT2ByteFloat", value=value)
         sign = 1 if value < 0 else 0
 
         def calc_exponent(value, sign):
@@ -102,7 +102,7 @@ class DPT4ByteFloat(DPTBase):
         try:
             return struct.unpack(">f", bytes(raw))[0]
         except struct.error:
-            raise ConversionError(raw)
+            raise ConversionError("Cant parse DPT4ByteFloat", raw=raw)
 
     @classmethod
     def to_knx(cls, value):
@@ -110,7 +110,7 @@ class DPT4ByteFloat(DPTBase):
         try:
             return tuple(struct.pack(">f", value))
         except struct.error:
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPT4ByteFloat", vlaue=value)
 
 
 class DPTTemperature(DPT2ByteFloat):

--- a/xknx/knx/dpt_hvac_mode.py
+++ b/xknx/knx/dpt_hvac_mode.py
@@ -86,7 +86,7 @@ class DPTControllerStatus(DPTBase):
         """Serialize to KNX/IP raw data."""
         if value == HVACOperationMode.AUTO:
             from xknx.exceptions import ConversionError
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTControllerStatus", value=value)
         elif value == HVACOperationMode.COMFORT:
             return (0x21,)
         elif value == HVACOperationMode.STANDBY:

--- a/xknx/knx/dpt_scaling.py
+++ b/xknx/knx/dpt_scaling.py
@@ -24,7 +24,7 @@ class DPTScaling(DPTBase):
         value = round((raw[0]/256)*100)
 
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant parse DPTScaling", value=value, raw=raw)
 
         return value
 
@@ -32,9 +32,9 @@ class DPTScaling(DPTBase):
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not isinstance(value, (int, float)):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTScaling", value=value)
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTScaling", value=value)
         knx_value = round(value/100*255.4)
         return (knx_value,)
 

--- a/xknx/knx/dpt_signed_relative_value.py
+++ b/xknx/knx/dpt_signed_relative_value.py
@@ -28,7 +28,7 @@ class DPTSignedRelativeValue(DPTBase):
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTSignedRelativeValue", value=value)
         if value < 0:
             value += 0x100
         return (value & 0xff,)

--- a/xknx/knx/dpt_string.py
+++ b/xknx/knx/dpt_string.py
@@ -27,9 +27,9 @@ class DPTString(DPTBase):
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if not isinstance(value, str):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTString", value=value)
         if not cls._test_boundaries(value):
-            raise ConversionError(value)
+            raise ConversionError("Cant serialize DPTString", value=value)
 
         raw = []
         for character in value:

--- a/xknx/knx/dpt_time.py
+++ b/xknx/knx/dpt_time.py
@@ -25,7 +25,7 @@ class DPTTime(DPTBase):
         seconds = raw[2] & 0x3F
 
         if not DPTTime._test_range(weekday, hours, minutes, seconds):
-            raise ConversionError(raw)
+            raise ConversionError("Cant parse DPTTime", raw=raw)
 
         return {'weekday': DPTWeekday(weekday),
                 'hours': hours,
@@ -36,14 +36,14 @@ class DPTTime(DPTBase):
     def to_knx(cls, values):
         """Serialize to KNX/IP raw data from dict with elements weekday,hours,minutes,seconds."""
         if not isinstance(values, dict):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTTime", values=values)
         weekday = values.get('weekday', DPTWeekday.NONE).value
         hours = values.get('hours', 0)
         minutes = values.get('minutes', 0)
         seconds = values.get('seconds', 0)
 
         if not DPTTime._test_range(weekday, hours, minutes, seconds):
-            raise ConversionError(values)
+            raise ConversionError("Cant serialize DPTTime", values=values)
 
         return weekday << 5 | hours, minutes, seconds
 


### PR DESCRIPTION
Background
------------

Exceptions within XKNX were not very expressive/informative. It was often impossible to determine what exactly went wrong when an exception was raised.

Implementation
---------------

The most common Exceptions ( `CouldNotParseTelegram` and `ConversionError` ) take now kwargs as parameter to add more information about the current values/payload/device-names/ . 

 
