### PR TITLE
Add support for KNX DPT 20.105

### DIFF
--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -7,8 +7,13 @@ from xknx import XKNX
 from xknx.devices import Climate
 from xknx.exceptions import DeviceIllegalValue, CouldNotParseTelegram
 from xknx.knx import (DPT2ByteFloat, DPTArray, DPTBinary, DPTControllerStatus,
-                      DPTHVACMode, DPTTemperature, DPTValue1Count,
+                      DPTHVACMode, DPTHVACContrMode, DPTTemperature, DPTValue1Count,
                       GroupAddress, HVACOperationMode, Telegram, TelegramType)
+
+
+DPT_20102_MODES = [HVACOperationMode.AUTO, HVACOperationMode.COMFORT,
+                   HVACOperationMode.STANDBY, HVACOperationMode.NIGHT,
+                   HVACOperationMode.FROST_PROTECTION]
 
 
 class TestClimate(unittest.TestCase):
@@ -92,7 +97,11 @@ class TestClimate(unittest.TestCase):
             group_address_operation_mode='1/2/5',
             group_address_operation_mode_protection='1/2/6',
             group_address_operation_mode_night='1/2/7',
-            group_address_operation_mode_comfort='1/2/8')
+            group_address_operation_mode_comfort='1/2/8',
+            group_address_controller_mode='1/2/9',
+            group_address_controller_mode_state='1/2/10',
+            group_address_on_off='1/2/11',
+            group_address_on_off_state='1/2/12')
 
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/1')))
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/2')))
@@ -101,7 +110,11 @@ class TestClimate(unittest.TestCase):
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/6')))
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/7')))
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/8')))
-        self.assertFalse(climate.has_group_address(GroupAddress('1/2/9')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/9')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/10')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/11')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/12')))
+        self.assertFalse(climate.has_group_address(GroupAddress('1/2/99')))
 
     #
     # TEST CALLBACK
@@ -201,7 +214,7 @@ class TestClimate(unittest.TestCase):
             group_address_temperature='1/2/1',
             group_address_operation_mode='1/2/4')
 
-        for operation_mode in HVACOperationMode:
+        for operation_mode in DPT_20102_MODES:
             self.loop.run_until_complete(asyncio.Task(climate.set_operation_mode(operation_mode)))
             self.assertEqual(xknx.telegrams.qsize(), 1)
             telegram = xknx.telegrams.get_nowait()
@@ -210,6 +223,25 @@ class TestClimate(unittest.TestCase):
                 Telegram(
                     GroupAddress('1/2/4'),
                     payload=DPTArray(DPTHVACMode.to_knx(operation_mode))))
+
+    def test_set_controller_operation_mode(self):
+        """Test set_operation_mode with DPT20.105 controller."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_temperature='1/2/1',
+            group_address_controller_mode='1/2/4')
+
+        for _, operation_mode in DPTHVACContrMode.SUPPORTED_MODES.items():
+            self.loop.run_until_complete(asyncio.Task(climate.set_operation_mode(operation_mode)))
+            self.assertEqual(xknx.telegrams.qsize(), 1)
+            telegram = xknx.telegrams.get_nowait()
+            self.assertEqual(
+                telegram,
+                Telegram(
+                    GroupAddress('1/2/4'),
+                    payload=DPTArray(DPTHVACContrMode.to_knx(operation_mode))))
 
     def test_set_operation_mode_not_supported(self):
         """Test set_operation_mode but not supported."""
@@ -230,7 +262,7 @@ class TestClimate(unittest.TestCase):
             group_address_temperature='1/2/1',
             group_address_controller_status='1/2/4')
 
-        for operation_mode in HVACOperationMode:
+        for operation_mode in DPT_20102_MODES:
             if operation_mode == HVACOperationMode.AUTO:
                 continue
             self.loop.run_until_complete(asyncio.Task(climate.set_operation_mode(operation_mode)))
@@ -548,16 +580,29 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_operation_mode='1/2/5',
             group_address_controller_status='1/2/3')
-        for operation_mode in HVACOperationMode:
+        for operation_mode in DPT_20102_MODES:
             telegram = Telegram(GroupAddress('1/2/5'))
             telegram.payload = DPTArray(DPTHVACMode.to_knx(operation_mode))
             self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
             self.assertEqual(climate.operation_mode, operation_mode)
-        for operation_mode in HVACOperationMode:
+        for operation_mode in DPT_20102_MODES:
             if operation_mode == HVACOperationMode.AUTO:
                 continue
             telegram = Telegram(GroupAddress('1/2/3'))
             telegram.payload = DPTArray(DPTControllerStatus.to_knx(operation_mode))
+            self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
+            self.assertEqual(climate.operation_mode, operation_mode)
+
+    def test_process_controller_mode(self):
+        """Test process / reading telegrams from telegram queue. Test if DPT20.105 controller mode is set correctly."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_controller_mode='1/2/5')
+        for _v, operation_mode in DPTHVACContrMode.SUPPORTED_MODES.items():
+            telegram = Telegram(GroupAddress('1/2/5'))
+            telegram.payload = DPTArray(DPTHVACContrMode.to_knx(operation_mode))
             self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
             self.assertEqual(climate.operation_mode, operation_mode)
 
@@ -703,3 +748,54 @@ class TestClimate(unittest.TestCase):
             climate.get_supported_operation_modes(),
             [HVACOperationMode.STANDBY,
              HVACOperationMode.NIGHT])
+
+    def test_custom_supported_operation_modes(self):
+        """Test get_supported_operation_modes with custom mode override."""
+        modes = [HVACOperationMode.STANDBY, HVACOperationMode.NIGHT]
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_temperature='1/2/1',
+            group_address_operation_mode='1/2/7',
+            override_supported_operation_modes=modes)
+        self.assertEqual(
+            climate.get_supported_operation_modes(), modes)
+
+    def test_custom_supported_operation_modes_as_str(self):
+        """Test get_supported_operation_modes with custom mode override as str list."""
+        str_modes = ['STANDBY', 'FROST_PROTECTION']
+        modes = [HVACOperationMode.STANDBY, HVACOperationMode.FROST_PROTECTION]
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_temperature='1/2/1',
+            group_address_operation_mode='1/2/7',
+            override_supported_operation_modes=str_modes)
+        self.assertEqual(
+            climate.get_supported_operation_modes(), modes)
+
+    def test_process_power_status(self):
+        """Test process / reading telegrams from telegram queue. Test if DPT20.105 controller mode is set correctly."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_on_off='1/2/2')
+        telegram = Telegram(GroupAddress('1/2/2'))
+        telegram.payload = DPTBinary(1)
+        self.loop.run_until_complete(asyncio.Task(climate.process(telegram)))
+        self.assertEqual(climate.is_on, True)
+
+    def test_power_on_off(self):
+        """Test turn_on and turn_off functions."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_on_off='1/2/2')
+        self.loop.run_until_complete(asyncio.Task(climate.turn_on()))
+        self.assertEqual(climate.is_on, True)
+        self.loop.run_until_complete(asyncio.Task(climate.turn_off()))
+        self.assertEqual(climate.is_on, False)

--- a/test/remote_value_switch_test.py
+++ b/test/remote_value_switch_test.py
@@ -89,7 +89,22 @@ class TestRemoteValueSwitch(unittest.TestCase):
             payload=DPTBinary(1))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        self.assertIsNotNone(remote_value.payload)
         self.assertEqual(remote_value.value, RemoteValueSwitch.Value.ON)
+
+    def test_process_off(self):
+        """Test process OFF telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueSwitch(
+            xknx,
+            group_address=GroupAddress("1/2/3"))
+        telegram = Telegram(
+            group_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(0))
+        self.assertEqual(remote_value.value, None)
+        self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        self.assertIsNotNone(remote_value.payload)
+        self.assertEqual(remote_value.value, RemoteValueSwitch.Value.OFF)
 
     def test_to_process_error(self):
         """Test process errornous telegram."""

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -81,13 +81,19 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_operation_mode_night='1/2/8',
             group_address_operation_mode_comfort='1/2/9',
             group_address_controller_status='1/2/10',
-            group_address_controller_status_state='1/2/11')
+            group_address_controller_status_state='1/2/11',
+            group_address_controller_mode='1/2/12',
+            group_address_controller_mode_state='1/2/13',
+            group_address_on_off='1/2/14',
+            group_address_on_off_state='1/2/15')
         self.assertEqual(
             str(climate),
             '<Climate name="Wohnzimmer" temperature="GroupAddress("1/2/1")/None/None/None"  target_temperature="GroupAddress("1/2/2")/None/None/'
             'None"  setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" setpoint_shift_step="0.1" setpoint_shift_max="20" set'
             'point_shift_min="-20" group_address_operation_mode="GroupAddress("1/2/5")" group_address_operation_mode_state="GroupAddress("1/2/6")'
-            '" group_address_controller_status="GroupAddress("1/2/10")" group_address_controller_status_state="GroupAddress("1/2/11")" />')
+            '" group_address_controller_status="GroupAddress("1/2/10")" group_address_controller_status_state="GroupAddress("1/2/11")" '
+            'group_address_controller_mode="GroupAddress("1/2/12")" group_address_controller_mode_state="GroupAddress("1/2/13")" '
+            'group_address_on_off="GroupAddress("1/2/14")/GroupAddress("1/2/15")/None/None" />')
 
     def test_cover(self):
         """Test string representation of cover object."""

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -78,7 +78,7 @@ class RemoteValue():
                                         payload=telegram.payload,
                                         group_address=telegram.group_address,
                                         device_name=self.device_name)
-        if self.payload != telegram.payload:
+        if self.payload != telegram.payload or self.payload is None:
             self.payload = telegram.payload
             if self.after_update_cb is not None:
                 await self.after_update_cb()

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -17,6 +17,7 @@ from .dpt_float import DPT2ByteFloat, DPT4ByteFloat, DPTLux, DPTTemperature, \
     DPTPowerFactor, DPTSpeed
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus
+from .dpt_hvac_contr_mode import DPTHVACContrMode
 from .dpt_2byte import DPT2ByteUnsigned, DPTUElCurrentmA, DPT2Ucount, DPTBrightness
 from .dpt_4byte import DPT4ByteUnsigned, DPT4ByteSigned
 from .dpt_scene_number import DPTSceneNumber

--- a/xknx/knx/dpt_hvac_contr_mode.py
+++ b/xknx/knx/dpt_hvac_contr_mode.py
@@ -1,0 +1,47 @@
+"""Implementation of different KNX DPT HVAC Operation modes."""
+
+from xknx.exceptions import CouldNotParseKNXIP, ConversionError
+
+from .dpt import DPTBase
+from .dpt_hvac_mode import HVACOperationMode
+
+
+class DPTHVACContrMode(DPTBase):
+    """
+    Abstraction for KNX KNX HVAC mod.
+
+    DPT 20.105
+    """
+
+    SUPPORTED_MODES = {
+        0: HVACOperationMode.AUTO,
+        1: HVACOperationMode.HEAT,
+        2: HVACOperationMode.MORNING_WARMUP,
+        3: HVACOperationMode.COOL,
+        4: HVACOperationMode.NIGHT_PURGE,
+        5: HVACOperationMode.PRECOOL,
+        6: HVACOperationMode.OFF,
+        7: HVACOperationMode.TEST,
+        8: HVACOperationMode.EMERGENCY_HEAT,
+        9: HVACOperationMode.FAN_ONLY,
+        10: HVACOperationMode.FREE_COOL,
+        11: HVACOperationMode.ICE,
+        14: HVACOperationMode.DRY,
+        20: HVACOperationMode.NODEM}
+
+    SUPPORTED_MODES_INV = dict((reversed(item) for item in SUPPORTED_MODES.items()))
+
+    @classmethod
+    def from_knx(cls, raw):
+        """Parse/deserialize from KNX/IP raw data."""
+        cls.test_bytesarray(raw, 1)
+        if raw[0] in DPTHVACContrMode.SUPPORTED_MODES:
+            return DPTHVACContrMode.SUPPORTED_MODES[raw[0]]
+        raise CouldNotParseKNXIP("Could not parse HVACOperationMode")
+
+    @classmethod
+    def to_knx(cls, value):
+        """Serialize to KNX/IP raw data."""
+        if value in DPTHVACContrMode.SUPPORTED_MODES_INV:
+            return (DPTHVACContrMode.SUPPORTED_MODES_INV[value],)
+        raise ConversionError("Could not parse HVACOperationMode", value=value)

--- a/xknx/knx/dpt_hvac_mode.py
+++ b/xknx/knx/dpt_hvac_mode.py
@@ -15,6 +15,19 @@ class HVACOperationMode(Enum):
     STANDBY = "Standby"
     NIGHT = "Night"
     FROST_PROTECTION = "Frost Protection"
+    HEAT = "Heat"
+    MORNING_WARMUP = "Morning Warmup"
+    COOL = "Cool"
+    NIGHT_PURGE = "Night Purge"
+    PRECOOL = "Precool"
+    OFF = "Off"
+    TEST = "Test"
+    EMERGENCY_HEAT = "Emergency Heat"
+    FAN_ONLY = "Fan only"
+    FREE_COOL = "Free Cool"
+    ICE = "Ice"
+    DRY = "Dry"
+    NODEM = "NoDem"
 
 
 class DPTHVACMode(DPTBase):


### PR DESCRIPTION
I have added support for DPT 20.105.
This class introduces many more operation modes, therefore I have added a configuration option so that the configuration file can specify a list of supported modes as follows:

```
override_supported_operation_modes:
 - HEAT
 - COOL
 - DRY
 - FAN_ONLY
```
