### PR TITLE
Implement support to automatically reconnect KNX/IP tunnel

### DIFF
--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -36,6 +36,8 @@ class ConnectionConfig:
     * local_ip: Local ip of the interface though which KNXIPInterface should connect.
     * gateway_ip: IP of KNX/IP tunneling device.
     * gateway_port: Port of KNX/IP tunneling device.
+    * auto_reconnect: Auto reconnect to KNX/IP tunneling device if connection cannot be established.
+    * auto_reconnect_wait: Wait n seconds before trying to reconnect to KNX/IP tunneling device.
     """
 
     # pylint: disable=too-few-public-methods
@@ -44,12 +46,16 @@ class ConnectionConfig:
                  connection_type=ConnectionType.AUTOMATIC,
                  local_ip=None,
                  gateway_ip=None,
-                 gateway_port=DEFAULT_MCAST_PORT):
+                 gateway_port=DEFAULT_MCAST_PORT,
+                 auto_reconnect=False,
+                 auto_reconnect_wait=3):
         """Initialize ConnectionConfig class."""
         self.connection_type = connection_type
         self.local_ip = local_ip
         self.gateway_ip = gateway_ip
         self.gateway_port = gateway_port
+        self.auto_reconnect = auto_reconnect
+        self.auto_reconnect_wait = auto_reconnect_wait
 
 
 class KNXIPInterface():
@@ -72,7 +78,9 @@ class KNXIPInterface():
             await self.start_tunnelling(
                 self.connection_config.local_ip,
                 self.connection_config.gateway_ip,
-                self.connection_config.gateway_port)
+                self.connection_config.gateway_port,
+                self.connection_config.auto_reconnect,
+                self.connection_config.auto_reconnect_wait)
 
     async def start_automatic(self):
         """Start GatewayScanner and connect to the found device."""
@@ -86,11 +94,14 @@ class KNXIPInterface():
         if gatewayscanner.supports_tunneling:
             await self.start_tunnelling(gatewayscanner.found_local_ip,
                                         gatewayscanner.found_ip_addr,
-                                        gatewayscanner.found_port)
+                                        gatewayscanner.found_port,
+                                        self.connection_config.auto_reconnect,
+                                        self.connection_config.auto_reconnect_wait)
         elif gatewayscanner.supports_routing:
             await self.start_routing(gatewayscanner.found_local_ip)
 
-    async def start_tunnelling(self, local_ip, gateway_ip, gateway_port):
+    async def start_tunnelling(self, local_ip, gateway_ip, gateway_port,
+                               auto_reconnect, auto_reconnect_wait):
         """Start KNX/IP tunnel."""
         self.xknx.logger.debug("Starting tunnel to %s:%s from %s", gateway_ip, gateway_port, local_ip)
         self.interface = Tunnel(
@@ -99,7 +110,9 @@ class KNXIPInterface():
             local_ip=local_ip,
             gateway_ip=gateway_ip,
             gateway_port=gateway_port,
-            telegram_received_callback=self.telegram_received)
+            telegram_received_callback=self.telegram_received,
+            auto_reconnect=auto_reconnect,
+            auto_reconnect_wait=auto_reconnect_wait)
         await self.interface.start()
 
     async def start_routing(self, local_ip):

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -193,6 +193,7 @@ class Tunnel():
         await self.reconnect()
 
     async def stop_reconnect(self):
+        """Stop reconnect task if running."""
         if self._reconnect_task is not None:
             self._reconnect_task.cancel()
             self._reconnect_task = None
@@ -213,6 +214,7 @@ class Tunnel():
         self._heartbeat_task = self.xknx.loop.create_task(self.do_heartbeat())
 
     async def stop_heartbeat(self):
+        """Stop heartbeat task if running."""
         if self._heartbeat_task is not None:
             self._heartbeat_task.cancel()
             self._heartbeat_task = None

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -170,6 +170,8 @@ class Tunnel():
         """Disconnect from tunnel device."""
         # only send disconnect request if we ever were connected
         if self.communication_channel is None:
+            # close udp client to prevent open file descriptors
+            await self.udp_client.stop()
             return
         disconnect = Disconnect(
             self.xknx,
@@ -180,6 +182,8 @@ class Tunnel():
             raise XKNXException("Could not disconnect channel")
         else:
             self.xknx.logger.debug("Tunnel disconnected (communication_channel: %s)", self.communication_channel)
+        # close udp client to prevent open file descriptors
+        await self.udp_client.stop()
 
     async def reconnect(self):
         """Reconnect to tunnel device."""
@@ -205,7 +209,6 @@ class Tunnel():
         #      we have no connection...
         # await self.disconnect()
         await self.disconnect(True)
-        await self.udp_client.stop()
         await self.stop_heartbeat()
         await self.stop_reconnect()
 

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -242,6 +242,7 @@ class Tunnel():
         self.number_heartbeat_failed = self.number_heartbeat_failed + 1
         if self.number_heartbeat_failed > 3:
             self.xknx.logger.warning("Heartbeat failed - reconnecting")
+            await self.stop_reconnect()
             await self.reconnect()
             self.number_heartbeat_failed = 0
             await self.stop_heartbeat()

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -48,7 +48,6 @@ class Tunnel():
 
     def init_udp_client(self):
         """Initialize udp_client."""
-        print('########### init udp client')
         self.udp_client = UDPClient(self.xknx,
                                     (self.local_ip, 0),
                                     (self.gateway_ip, self.gateway_port))
@@ -80,7 +79,6 @@ class Tunnel():
 
     async def start(self):
         """Start tunneling."""
-        print('########### start')
         await self.connect_udp()
         await self.connect()
 
@@ -90,7 +88,6 @@ class Tunnel():
 
     async def connect(self):
         """Connect/build tunnel."""
-        print('########### connect')
         connect = Connect(
             self.xknx,
             self.udp_client)
@@ -101,7 +98,6 @@ class Tunnel():
                     self.auto_reconnect_wait
                 )
                 self.xknx.logger.warning(msg)
-                print('########### create schedule_reconnect task')
                 task = self.xknx.loop.create_task(self.schedule_reconnect())
                 self._reconnect_task = task
                 return
@@ -114,7 +110,6 @@ class Tunnel():
         self._reconnect_task = None
         self.communication_channel = connect.communication_channel
         self.sequence_number = 0
-        print('########### connected')
         await self.start_heartbeat()
 
     async def send_telegram(self, telegram):
@@ -173,17 +168,14 @@ class Tunnel():
 
     async def disconnect(self, ignore_error=False):
         """Disconnect from tunnel device."""
-        print('########### disconnect')
         # only send disconnect request if we ever were connected
         if self.communication_channel is None:
-            print('######### no communication channel')
             return
         disconnect = Disconnect(
             self.xknx,
             self.udp_client,
             communication_channel_id=self.communication_channel)
         await disconnect.start()
-        print('######### disconnect done')
         if not disconnect.success and not ignore_error:
             raise XKNXException("Could not disconnect channel")
         else:
@@ -191,30 +183,22 @@ class Tunnel():
 
     async def reconnect(self):
         """Reconnect to tunnel device."""
-        print('########### reconnect')
         await self.disconnect(True)
         self.init_udp_client()
-        print('########### reconnect...')
         await self.start()
 
     async def schedule_reconnect(self):
         """Schedule reconnect to KNX."""
-        print('########### schedule reconnect')
         await asyncio.sleep(self.auto_reconnect_wait)
         await self.reconnect()
 
     async def stop_reconnect(self):
         if self._reconnect_task is not None:
-            print('######### cancel reconnect task')
             self._reconnect_task.cancel()
             self._reconnect_task = None
-            print('######### reconnect task cancelled')
-        else:
-            print('######### reconnect task not scheduled')
 
     async def stop(self):
         """Stop tunneling."""
-        print('########### stop')
         # XXX: set disconnect ignore_error True here. Is there actually anything
         #      which can happen if disconnect fails? normally this fails because
         #      we have no connection...
@@ -226,17 +210,12 @@ class Tunnel():
 
     async def start_heartbeat(self):
         """Start heartbeat for monitoring state of tunnel, as suggested by 03.08.02 KNX Core 5.4."""
-        print('########### start heartbeat')
         self._heartbeat_task = self.xknx.loop.create_task(self.do_heartbeat())
 
     async def stop_heartbeat(self):
         if self._heartbeat_task is not None:
-            print('######### cancel heartbeat task')
             self._heartbeat_task.cancel()
             self._heartbeat_task = None
-            print('######### heartbeat task cancelled')
-        else:
-            print('######### heartbeat task not scheduled')
 
     async def do_heartbeat(self):
         """Heartbeat: Worker 'thread', endless loop for sending heartbeat requests."""
@@ -254,15 +233,12 @@ class Tunnel():
 
     async def do_heartbeat_success(self):
         """Heartbeat: handling success."""
-        print('########### heartbeat success')
         self.number_heartbeat_failed = 0
 
     async def do_heartbeat_failed(self):
         """Heartbeat: handling error."""
-        print('########### heartbeat failed')
         self.number_heartbeat_failed = self.number_heartbeat_failed + 1
         if self.number_heartbeat_failed > 3:
-            print('########### heartbeat max failed reached')
             self.xknx.logger.warning("Heartbeat failed - reconnecting")
             await self.reconnect()
             self.number_heartbeat_failed = 0

--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -171,20 +171,11 @@ class UDPClient:
         self.xknx.knx_logger.debug("Sending: %s", knxipframe)
         if self.transport is None:
             raise XKNXException("Transport not connected")
-        try:
-            frame = bytes(knxipframe.to_knx())
-        except TypeError:
-            # happens on auto reconnect if very first connection fails.
-            # then knxipframe.body.communication_channel_id
-            # (xknx.knxip.disconnect_request.DisconnectRequest instance)
-            # is None
-            msg = "Failed to convert knxipframe to bytes: {}".format(knxipframe)
-            self.xknx.knx_logger.debug(msg)
-            return
+
         if self.multicast:
-            self.transport.sendto(frame, self.remote_addr)
+            self.transport.sendto(bytes(knxipframe.to_knx()), self.remote_addr)
         else:
-            self.transport.sendto(frame)
+            self.transport.sendto(bytes(knxipframe.to_knx()))
 
     def getsockname(self):
         """Return sockname."""


### PR DESCRIPTION
Hi,

this PR adds support to automatically reconnect to a KNX/IP tunnel if connection cannot be established.

This is useful if connection gets lost for some reason and reconnecting via the heartbeat mechanism fails because the connection cannot be established. If so, the service hangs in a broken state and will not come back up automatically.