### PR TITLE
check if xknx object is available before accessing it.

### DIFF
--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -55,12 +55,14 @@ class UDPClient:
                 self.data_received_callback(data)
 
         def error_received(self, exc):
-            """Handel errors. Callback for error received."""
-            self.xknx.logger.warning('Error received: %s', exc)
+            """Handle errors. Callback for error received."""
+            if 'xknx' in self:
+                self.xknx.logger.warning('Error received: %s', exc)
 
         def connection_lost(self, exc):
             """Log error. Callback for connection lost."""
-            self.xknx.logger.info('closing transport %s', exc)
+            if 'xknx' in self:
+                self.xknx.logger.info('closing transport %s', exc)
 
     def __init__(self, xknx, local_addr, remote_addr, multicast=False, bind_to_multicast_addr=False):
         """Initialize UDPClient class."""


### PR DESCRIPTION
This should fix issue #94

I actually don't know if this behaviour also exists in python. But the problem could be, that the function, where the xknx object is used, is already called by the base class during construction of the instance. so before the part of the constructor is reached where the xknx object is copied to the instance, the member function is already called (e.g. by the base class constructor).

a simple check if it already exists solves the problem (tested in my environment)  