### PR TITLE
[Request for feedback] [Breaking change] Do not read from write addresses?

### DIFF
--- a/test/binary_sensor_test.py
+++ b/test/binary_sensor_test.py
@@ -220,5 +220,5 @@ class TestBinarySensor(unittest.TestCase):
     def test_state_addresses(self):
         """Test expose sensor returns empty list as state addresses."""
         xknx = XKNX(loop=self.loop)
-        switch = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
-        self.assertEqual(switch.state_addresses(), [GroupAddress('1/2/3')])
+        binary_sensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3', group_address_state='1/2/4')
+        self.assertEqual(binary_sensor.state_addresses(), [GroupAddress('1/2/4')])

--- a/test/cover_test.py
+++ b/test/cover_test.py
@@ -79,7 +79,7 @@ class TestCover(unittest.TestCase):
             'TestCover',
             group_address_long='1/2/1',
             group_address_short='1/2/2',
-            group_address_position='1/2/3')
+            group_address_position_state='1/2/3')
         self.loop.run_until_complete(asyncio.Task(cover.sync(False)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
@@ -110,8 +110,8 @@ class TestCover(unittest.TestCase):
             'TestCover',
             group_address_long='1/2/1',
             group_address_short='1/2/2',
-            group_address_position='1/2/3',
-            group_address_angle='1/2/4')
+            group_address_position_state='1/2/3',
+            group_address_angle_state='1/2/4')
         self.loop.run_until_complete(asyncio.Task(cover.sync(False)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         telegram1 = xknx.telegrams.get_nowait()

--- a/test/light_test.py
+++ b/test/light_test.py
@@ -73,9 +73,9 @@ class TestLight(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         light = Light(xknx,
                       name="TestLight",
-                      group_address_switch='1/2/3',
-                      group_address_brightness='1/2/5',
-                      group_address_color='1/2/6')
+                      group_address_switch_state='1/2/3',
+                      group_address_brightness_state='1/2/5',
+                      group_address_color_state='1/2/6')
         self.loop.run_until_complete(asyncio.Task(light.sync(False)))
 
         self.assertEqual(xknx.telegrams.qsize(), 3)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -88,7 +88,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_on_off_state='1/2/15')
         self.assertEqual(
             str(climate),
-            '<Climate name="Wohnzimmer" temperature="GroupAddress("1/2/1")/None/None/None"  target_temperature="GroupAddress("1/2/2")/None/None/'
+            '<Climate name="Wohnzimmer" temperature="None/GroupAddress("1/2/1")/None/None"  target_temperature="GroupAddress("1/2/2")/None/None/'
             'None"  setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" setpoint_shift_step="0.1" setpoint_shift_max="20" set'
             'point_shift_min="-20" group_address_operation_mode="GroupAddress("1/2/5")" group_address_operation_mode_state="GroupAddress("1/2/6")'
             '" group_address_controller_status="GroupAddress("1/2/10")" group_address_controller_status_state="GroupAddress("1/2/11")" '

--- a/test/switch_test.py
+++ b/test/switch_test.py
@@ -26,7 +26,7 @@ class TestSwitch(unittest.TestCase):
     def test_sync(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX(loop=self.loop)
-        switch = Switch(xknx, "TestOutlet", group_address='1/2/3')
+        switch = Switch(xknx, "TestOutlet", group_address_state='1/2/3')
         self.loop.run_until_complete(asyncio.Task(switch.sync(False)))
 
         self.assertEqual(xknx.telegrams.qsize(), 1)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -38,6 +38,7 @@ class BinarySensor(Device):
                  xknx,
                  name,
                  group_address=None,
+                 group_address_state=None,
                  device_class=None,
                  significant_bit=1,
                  reset_after=None,
@@ -48,12 +49,15 @@ class BinarySensor(Device):
         super(BinarySensor, self).__init__(xknx, name, device_updated_cb)
         if isinstance(group_address, (str, int)):
             group_address = GroupAddress(group_address)
+        if isinstance(group_address_state, (str, int)):
+            group_address_state = GroupAddress(group_address_state)
         if not isinstance(significant_bit, int):
             raise TypeError()
         if actions is None:
             actions = []
 
         self.group_address = group_address
+        self.group_address_state = group_address_state
         self.device_class = device_class
         self.significant_bit = significant_bit
         self.reset_after = reset_after
@@ -69,6 +73,8 @@ class BinarySensor(Device):
         """Initialize object from configuration structure."""
         group_address = \
             config.get('group_address')
+        group_address_state = \
+            config.get('group_address_state')
         device_class = \
             config.get('device_class')
         significant_bit = \
@@ -83,17 +89,19 @@ class BinarySensor(Device):
         return cls(xknx,
                    name,
                    group_address=group_address,
+                   group_address_state=group_address_state,
                    device_class=device_class,
                    significant_bit=significant_bit,
                    actions=actions)
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""
-        return self.group_address == group_address
+        return (self.group_address == group_address) or \
+               (self.group_address_state == group_address)
 
     def state_addresses(self):
         """Return group addresses which should be requested to sync state."""
-        return [self.group_address, ]
+        return [self.group_address_state, ]
 
     async def _set_internal_state(self, state):
         """Set the internal state of the device. If state was changed after update hooks and connected Actions are executed."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -96,7 +96,7 @@ class Climate(Device):
 
         self.temperature = RemoteValueTemp(
             xknx,
-            group_address_temperature,
+            group_address_state=group_address_temperature,
             device_name=self.name,
             after_update_cb=self.after_update)
         self.target_temperature = RemoteValueTemp(

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -47,8 +47,6 @@ class RemoteValue():
         """Return group addresses which should be requested to sync state."""
         if self.group_address_state:
             return [self.group_address_state, ]
-        if self.group_address:
-            return [self.group_address, ]
         return []
 
     def payload_valid(self, payload):


### PR DESCRIPTION
Background
=========

When i implemented XKNX, my first devices only had one address for reading and writing a state. I therefore thought this would be the default behavior for KNX in general. My original approach was, that XKNX took the same address for reading and writing - the state addresses were later introduced.

This causes the problem, that the state updater is trying read addresses which are not readable (and do not have a dedicated read address). This is the case e.g. many binary sensors. This leads to unnecessary traffic on the bus - and ugly log/warn messages in the log file.

```syslog
2018-09-02 22:21:13 WARNING (MainThread) [xknx.log] Could not read value of <BinarySensor group_address="GroupAddress("5/2/7")" name="DiningButton12" state="BinarySensorState.OFF"/> 5/2/7
```

Change
======

My suggested change is, to no longer fallback to the write address, if no state address is specified.

Side effects
=========

This change has the side effect, that all configurations, which rely on this fallback have to be changed. An additional state-address has to be introduced:

xknx.yaml
----------

```yaml
    light-switch-5:
        Children-L2:  {group_address_switch: '1/1/37'}
```

has to be changed to:

```yaml
    light-switch-5:
        Children-L2:  {group_address_switch: '1/1/37',  group_address_switch_state: '1/1/37'}
```


Hass config
------------

```yaml
light:
  - platform: knx
    name: Kitchen-L-1
    address: '1/0/9'
```

has to be changed to:

```yaml
light:
  - platform: knx
    name: Kitchen-L-1
    address: '1/0/9'
    state_address: '1/0/9'
```

Request for feedback
================

I'm uncertain if I should merge this PR, please leave your thumbs-up or thumbs-down. I will decide in a few weeks :-)
