### PR TITLE
Tunnel: Use the bus address assigned by the server

### DIFF
--- a/xknx/io/connect.py
+++ b/xknx/io/connect.py
@@ -34,3 +34,5 @@ class Connect(RequestResponse):
         """Set communication channel and identifier after having received a valid answer."""
         self.communication_channel = knxipframe.body.communication_channel
         self.identifier = knxipframe.body.identifier
+        # Use the address they gave us
+        self.xknx.own_address.raw = self.identifier


### PR DESCRIPTION
Connecting to a tunnel server assigns a physical bus address to us. Use it.

There probably is a better way to do this, and the configured address should override the one from the server, but there are enough gateways which limit you to the dynamic address which they assign to force this to be the default.