### PR TITLE
Color temperature for lights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ xknx.egg-info/
 .coverage
 venv
 .idea/
+.vscode/

--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -9,8 +9,9 @@ import voluptuous as vol
 
 from custom_components.xknx import ATTR_DISCOVER_DEVICES, DATA_XKNX
 from homeassistant.components.light import (
-    Light, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_HS_COLOR,
-    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, ATTR_COLOR_TEMP, SUPPORT_WHITE_VALUE)
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_WHITE_VALUE,
+    PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
+    SUPPORT_WHITE_VALUE, Light)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -245,7 +246,7 @@ class KNXLight(Light):
                 color_util.color_hsv_to_RGB(*hs_color, brightness * 100 / 255))
         elif self.device.supports_color_temperature and \
                 update_color_temp:
-            # change color temperature without ON command
+            # change color temperature without ON telegram
             mireds = kwargs[ATTR_COLOR_TEMP]
             if mireds > self.max_mireds:
                 mireds = self.max_mireds

--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -10,8 +10,7 @@ import voluptuous as vol
 from custom_components.xknx import ATTR_DISCOVER_DEVICES, DATA_XKNX
 from homeassistant.components.light import (
     Light, PLATFORM_SCHEMA, ATTR_BRIGHTNESS, SUPPORT_BRIGHTNESS, ATTR_HS_COLOR,
-    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, ATTR_COLOR_TEMP,
-    ATTR_WHITE_VALUE, SUPPORT_WHITE_VALUE)
+    SUPPORT_COLOR, SUPPORT_COLOR_TEMP, ATTR_COLOR_TEMP, SUPPORT_WHITE_VALUE)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv

--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -9,9 +9,9 @@ import voluptuous as vol
 
 from custom_components.xknx import ATTR_DISCOVER_DEVICES, DATA_XKNX
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_WHITE_VALUE,
-    PLATFORM_SCHEMA, SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
-    SUPPORT_WHITE_VALUE, Light)
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_WHITE_VALUE,
+    Light)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv

--- a/test/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_dpt_2_byte_unsigned_test.py
@@ -3,9 +3,9 @@ import asyncio
 import unittest
 
 from xknx import XKNX
-from xknx.knx import DPTArray, DPTBinary, Telegram, GroupAddress
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.devices import RemoteValueDpt2ByteUnsigned
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.knx import DPTArray, DPTBinary, GroupAddress, Telegram
 
 
 class TestRemoteValueDptValue1Ucount(unittest.TestCase):

--- a/test/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_dpt_2_byte_unsigned_test.py
@@ -1,0 +1,99 @@
+"""Unit test for RemoteValueDpt2ByteUnsigned objects."""
+import asyncio
+import unittest
+
+from xknx import XKNX
+from xknx.knx import DPTArray, DPTBinary, Telegram, GroupAddress
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.devices import RemoteValueDpt2ByteUnsigned
+
+
+class TestRemoteValueDptValue1Ucount(unittest.TestCase):
+    """Test class for RemoteValueDpt2ByteUnsigned objects."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+    def test_to_knx(self):
+        """Test to_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(xknx)
+        self.assertEqual(remote_value.to_knx(2571), DPTArray((0x0A, 0x0B)))
+
+    def test_from_knx(self):
+        """Test from_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(xknx)
+        self.assertEqual(remote_value.from_knx(DPTArray((0x0A, 0x0B))), 2571)
+
+    def test_to_knx_error(self):
+        """Test to_knx function with wrong parametern."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(xknx)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx(65536)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx("256")
+
+    def test_set(self):
+        """Test setting value."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(
+            xknx,
+            group_address=GroupAddress("1/2/3"))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(2571)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTArray((0x0A, 0x0B))))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(5500)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTArray((0x15, 0x7C, ))))
+
+    def test_process(self):
+        """Test process telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(
+            xknx,
+            group_address=GroupAddress("1/2/3"))
+        telegram = Telegram(
+            group_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x0A, 0x0B)))
+        self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        self.assertEqual(remote_value.value, 2571)
+
+    def test_to_process_error(self):
+        """Test process errornous telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueDpt2ByteUnsigned(
+            xknx,
+            group_address=GroupAddress("1/2/3"))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x64, )))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x64, 0x53, 0x42, )))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 commands =
     py.test --cov --cov-report= {posargs}
+whitelist_externals = make
 deps = -rrequirements/testing.txt
 
 [testenv:flake8]

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -28,3 +28,4 @@ from .remote_value_scene_number import RemoteValueSceneNumber
 from .remote_value_temp import RemoteValueTemp
 from .remote_value_scaling import RemoteValueScaling
 from. remote_value_dpt_value_1_ucount import RemoteValueDptValue1Ucount
+from. remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -20,6 +20,8 @@ from .remote_value_switch import RemoteValueSwitch
 class Light(Device):
     """Class for managing a light."""
 
+    # pylint: disable=too-many-locals
+
     def __init__(self,
                  xknx,
                  name,

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -15,6 +15,7 @@ from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned
 from .remote_value_scaling import RemoteValueScaling
 from .remote_value_switch import RemoteValueSwitch
+from .remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned
 
 
 class Light(Device):

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -33,6 +33,8 @@ class Light(Device):
                  group_address_tunable_white_state=None,
                  group_address_color_temperature=None,
                  group_address_color_temperature_state=None,
+                 min_kelvin=None,
+                 max_kelvin=None,
                  device_updated_cb=None):
         """Initialize Light class."""
         # pylint: disable=too-many-arguments
@@ -77,6 +79,9 @@ class Light(Device):
             device_name=self.name,
             after_update_cb=self.after_update)
 
+        self.min_kelvin = min_kelvin
+        self.max_kelvin = max_kelvin
+
     @property
     def supports_brightness(self):
         """Return if light supports brightness."""
@@ -120,6 +125,10 @@ class Light(Device):
             config.get('group_address_color_temperature')
         group_address_color_temperature_state = \
             config.get('group_address_color_temperature_state')
+        min_kelvin = \
+            config.get('min_kelvin')
+        max_kelvin = \
+            config.get('max_kelvin')
 
         return cls(xknx,
                    name,
@@ -132,7 +141,9 @@ class Light(Device):
                    group_address_tunable_white=group_address_tunable_white,
                    group_address_tunable_white_state=group_address_tunable_white_state,
                    group_address_color_temperature=group_address_color_temperature,
-                   group_address_color_temperature_state=group_address_color_temperature_state,)
+                   group_address_color_temperature_state=group_address_color_temperature_state,
+                   min_kelvin=min_kelvin,
+                   max_kelvin=max_kelvin)
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -15,7 +15,6 @@ from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned
 from .remote_value_scaling import RemoteValueScaling
 from .remote_value_switch import RemoteValueSwitch
-from .remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned
 
 
 class Light(Device):

--- a/xknx/devices/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/devices/remote_value_dpt_2_byte_unsigned.py
@@ -3,7 +3,7 @@ Module for managing a DTP 7001 remote value.
 
 DPT 7.001.
 """
-from xknx.knx import DPTArray, DPT2ByteUnsigned
+from xknx.knx import DPT2ByteUnsigned, DPTArray
 
 from .remote_value import RemoteValue
 

--- a/xknx/devices/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/devices/remote_value_dpt_2_byte_unsigned.py
@@ -1,0 +1,36 @@
+"""
+Module for managing a DTP 7001 remote value.
+
+DPT 7.001.
+"""
+from xknx.knx import DPTArray, DPT2ByteUnsigned
+
+from .remote_value import RemoteValue
+
+
+class RemoteValueDpt2ByteUnsigned(RemoteValue):
+    """Abstraction for remote value of KNX DPT 7.001."""
+
+    def __init__(self,
+                 xknx,
+                 group_address=None,
+                 device_name=None,
+                 after_update_cb=None):
+        """Initialize remote value of KNX DPT 7.001."""
+        # pylint: disable=too-many-arguments
+        super(RemoteValueDpt2ByteUnsigned, self).__init__(
+            xknx, group_address, None,
+            device_name=device_name, after_update_cb=after_update_cb)
+
+    def payload_valid(self, payload):
+        """Test if telegram payload may be parsed."""
+        return (isinstance(payload, DPTArray)
+                and len(payload.value) == 2)
+
+    def to_knx(self, value):
+        """Convert value to payload."""
+        return DPTArray(DPT2ByteUnsigned.to_knx(value))
+
+    def from_knx(self, payload):
+        """Convert current payload to value."""
+        return DPT2ByteUnsigned.from_knx(payload.value)

--- a/xknx/devices/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/devices/remote_value_dpt_2_byte_unsigned.py
@@ -14,12 +14,13 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue):
     def __init__(self,
                  xknx,
                  group_address=None,
+                 group_address_state=None,
                  device_name=None,
                  after_update_cb=None):
         """Initialize remote value of KNX DPT 7.001."""
         # pylint: disable=too-many-arguments
         super(RemoteValueDpt2ByteUnsigned, self).__init__(
-            xknx, group_address, None,
+            xknx, group_address, group_address_state,
             device_name=device_name, after_update_cb=after_update_cb)
 
     def payload_valid(self, payload):

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -7,11 +7,11 @@ for serialization and deserialization of the KNX value.
 from xknx.exceptions import ConversionError
 from xknx.knx import (
     DPT2ByteFloat, DPT2ByteUnsigned, DPT4ByteFloat, DPT4ByteSigned,
-    DPT4ByteUnsigned, DPTArray, DPTBrightness, DPTElectricCurrent,
-    DPTElectricPotential, DPTEnergy, DPTEnthalpy, DPTFrequency,
-    DPTHeatFlowRate, DPTHumidity, DPTLux, DPTPartsPerMillion, DPTPhaseAngleDeg,
-    DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTSpeed, DPTTemperature,
-    DPTUElCurrentmA, DPTVoltage, DPTWsp)
+    DPT4ByteUnsigned, DPTArray, DPTBrightness, DPTColorTemperature,
+    DPTElectricCurrent, DPTElectricPotential, DPTEnergy, DPTEnthalpy,
+    DPTFrequency, DPTHeatFlowRate, DPTHumidity, DPTLux, DPTPartsPerMillion,
+    DPTPhaseAngleDeg, DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTSpeed,
+    DPTTemperature, DPTUElCurrentmA, DPTVoltage, DPTWsp)
 
 from .remote_value import RemoteValue
 
@@ -20,12 +20,13 @@ class RemoteValueSensor(RemoteValue):
     """Abstraction for many different sensor DPT types."""
 
     DPTMAP = {
-        'temperature': DPTTemperature,
-        'humidity': DPTHumidity,
-        'illuminance': DPTLux,
-        'brightness': DPTBrightness,
-        'speed_ms': DPTWsp,
         'current': DPTUElCurrentmA,
+        'brightness': DPTBrightness,
+        'color_temperature': DPTColorTemperature,
+        'temperature': DPTTemperature,
+        'illuminance': DPTLux,
+        'speed_ms': DPTWsp,
+        'humidity': DPTHumidity,
         'voltage': DPTVoltage,
         'power': DPTPower,
         'electric_current': DPTElectricCurrent,

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -18,7 +18,7 @@ from .dpt_float import DPT2ByteFloat, DPT4ByteFloat, DPTLux, DPTTemperature, \
 from .dpt_hvac_mode import HVACOperationMode, DPTHVACMode, \
     DPTControllerStatus
 from .dpt_hvac_contr_mode import DPTHVACContrMode
-from .dpt_2byte import DPT2ByteUnsigned, DPTUElCurrentmA, DPT2Ucount, DPTBrightness
+from .dpt_2byte import DPT2ByteUnsigned, DPTUElCurrentmA, DPT2Ucount, DPTBrightness, DPTColorTemperature
 from .dpt_4byte import DPT4ByteUnsigned, DPT4ByteSigned
 from .dpt_scene_number import DPTSceneNumber
 from .dpt_time import DPTTime

--- a/xknx/knx/dpt_2byte.py
+++ b/xknx/knx/dpt_2byte.py
@@ -57,3 +57,9 @@ class DPTBrightness(DPT2ByteUnsigned):
     """DPT 7.013 DPT_Brightness (lux)."""
 
     unit = "lx"
+
+
+class DPTColorTemperature(DPT2ByteUnsigned):
+    """DPT 7.600 DPT_Color_Temperature (K)."""
+
+    unit = "K"

--- a/xknx/knx/dpt_2byte.py
+++ b/xknx/knx/dpt_2byte.py
@@ -29,6 +29,8 @@ class DPT2ByteUnsigned(DPTBase):
     @classmethod
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
+        if not isinstance(value, (int)):
+            raise ConversionError("Cant serialize DPT2ByteUnsigned", value=value)
         if not cls._test_boundaries(value):
             raise ConversionError("Cant serialize DPT2ByteUnsigned", value=value)
         return value >> 8, value & 0xff


### PR DESCRIPTION
added support for absolute and relative color temperature functions of lights.

'tunable_white' sets the relative color temperature in %
'color_temperature' sets the absolute color temperature in Kelvin

this PR supersedes #153 