### PR TITLE
Implemented override features for min and max temperatures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ xknx.egg-info/
 .DS_Store
 .coverage
 venv
+.idea/

--- a/home-assistant-plugin/custom_components/climate/xknx.py
+++ b/home-assistant-plugin/custom_components/climate/xknx.py
@@ -35,6 +35,8 @@ CONF_OPERATION_MODE_COMFORT_ADDRESS = 'operation_mode_comfort_address'
 CONF_OVERRIDE_SUPPORTED_OPERATION_MODES = 'override_supported_operation_modes'
 CONF_ON_OFF_ADDRESS = 'on_off_address'
 CONF_ON_OFF_STATE_ADDRESS = 'on_off_state_address'
+CONF_OVERRIDE_MIN_TEMP = 'override_min_temp'
+CONF_OVERRIDE_MAX_TEMP = 'override_max_temp'
 
 DEFAULT_NAME = 'XKNX Climate'
 DEFAULT_SETPOINT_SHIFT_STEP = 0.5
@@ -67,6 +69,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
     vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_OVERRIDE_SUPPORTED_OPERATION_MODES): cv.ensure_list_csv,
+    vol.Optional(CONF_OVERRIDE_MIN_TEMP): cv.string,
+    vol.Optional(CONF_OVERRIDE_MAX_TEMP): cv.string,
     })
 
 
@@ -128,13 +132,36 @@ def async_add_devices_config(hass, config, async_add_devices):
         group_address_on_off_state=config.get(
             CONF_ON_OFF_STATE_ADDRESS),
         override_supported_operation_modes=config.get(
-            CONF_OVERRIDE_SUPPORTED_OPERATION_MODES))
+            CONF_OVERRIDE_SUPPORTED_OPERATION_MODES),
+        override_min_temp=config.get(CONF_OVERRIDE_MIN_TEMP),
+        override_max_temp=config.get(CONF_OVERRIDE_MAX_TEMP))
     hass.data[DATA_XKNX].xknx.devices.add(climate)
     async_add_devices([KNXClimate(hass, climate)])
 
 
 class KNXClimate(ClimateDevice):
     """Representation of a KNX climate device."""
+
+    operationModeMapping = {
+        """Mapping between the frontend and the backend representation"""
+        "auto": "Auto",
+        "comfort": "Comfort",
+        "standby": "Standby",
+        "night": "Night",
+        "frost_protection": "Frost Protection",
+        "heat": "Heat",
+        "morning_warmup": "Morning Warmup",
+        "cool": "Cool",
+        "night_purge": "Night Purge",
+        "precool": "Precool",
+        "off": "Off",
+        "test": "Test",
+        "emergency_heat": "Emergency Heat",
+        "fan_only": "Fan only",
+        "ice": "Ice",
+        "dry": "Dry",
+        "nodem": "NoDem"
+    }
 
     def __init__(self, hass, device):
         """Initialize of a KNX climate device."""
@@ -233,7 +260,7 @@ class KNXClimate(ClimateDevice):
         """Set operation mode."""
         if self.device.supports_operation_mode:
             from xknx.knx import HVACOperationMode
-            knx_operation_mode = HVACOperationMode(operation_mode)
+            knx_operation_mode = HVACOperationMode(self.operationModeMapping.get(operation_mode, operation_mode))
             await self.device.set_operation_mode(knx_operation_mode)
 
     @property

--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -364,8 +364,8 @@ class TestClimate(unittest.TestCase):
         climate = Climate(
             xknx,
             'TestClimate',
-            override_min_temp='7',
-            override_max_temp='35')
+            min_temp='7',
+            max_temp='35')
         self.assertEqual(climate.target_temperature_min, '7')
         self.assertEqual(climate.target_temperature_max, '35')
 
@@ -380,8 +380,8 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
-            override_max_temp='42',
-            override_min_temp='3')
+            max_temp='42',
+            min_temp='3')
         self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(4)))
         self.assertFalse(climate.initialized_for_setpoint_shift_calculations)
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))

--- a/test/climate_test.py
+++ b/test/climate_test.py
@@ -356,6 +356,41 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(climate.target_temperature_max, None)
 
     #
+    # TEST for unitialized target_temperature_min/target_temperature_max but with overridden max and min temperature
+    #
+    def test_uninitalized_for_target_temperature_min_max_can_be_overridden(self):
+        """Test if target_temperature_min/target_temperature_max return overridden value if specified."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            override_min_temp='7',
+            override_max_temp='35')
+        self.assertEqual(climate.target_temperature_min, '7')
+        self.assertEqual(climate.target_temperature_max, '35')
+
+    #
+    # TEST for overriden max and min temp do have precedence over setpoint shift calculations
+    #
+    def test_overridden_max_min_temperature_has_priority(self):
+        """Test that the overridden min and max temp always have precedence over setpoint shift calculations."""
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_target_temperature='1/2/2',
+            group_address_setpoint_shift='1/2/3',
+            override_max_temp='42',
+            override_min_temp='3')
+        self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(4)))
+        self.assertFalse(climate.initialized_for_setpoint_shift_calculations)
+        self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
+        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
+
+        self.assertEqual(climate.target_temperature_min, '3')
+        self.assertEqual(climate.target_temperature_max, '42')
+
+    #
     # TEST TARGET TEMPERATURE
     #
     def test_target_temperature_up(self):

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -46,8 +46,8 @@ class Climate(Device):
                  group_address_on_off_state=None,
                  device_updated_cb=None,
                  override_supported_operation_modes=None,
-                 override_min_temp=None,
-                 override_max_temp=None):
+                 min_temp=None,
+                 max_temp=None):
         """Initialize Climate class."""
         # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
         super(Climate, self).__init__(xknx, name, device_updated_cb)
@@ -87,8 +87,8 @@ class Climate(Device):
         self.group_address_on_off_state = group_address_on_off_state
 
         self.operation_mode = HVACOperationMode.STANDBY
-        self.override_min_temp = override_min_temp
-        self.override_max_temp = override_max_temp
+        self.min_temp = min_temp
+        self.max_temp = max_temp
         self.override_supported_operation_modes = []
 
         if override_supported_operation_modes:
@@ -274,8 +274,8 @@ class Climate(Device):
     @property
     def target_temperature_max(self):
         """Return the maxium possible target temperature."""
-        if self.override_max_temp is not None:
-            return self.override_max_temp
+        if self.max_temp is not None:
+            return self.max_temp
         if not self.initialized_for_setpoint_shift_calculations:
             return None
         return (self.target_temperature.value -
@@ -285,8 +285,8 @@ class Climate(Device):
     @property
     def target_temperature_min(self):
         """Return the minimum possible target temperature."""
-        if self.override_min_temp is not None:
-            return self.override_min_temp
+        if self.min_temp is not None:
+            return self.min_temp
         if not self.initialized_for_setpoint_shift_calculations:
             return None
         return (self.target_temperature.value -

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -45,7 +45,9 @@ class Climate(Device):
                  group_address_on_off=None,
                  group_address_on_off_state=None,
                  device_updated_cb=None,
-                 override_supported_operation_modes=None):
+                 override_supported_operation_modes=None,
+                 override_min_temp=None,
+                 override_max_temp=None):
         """Initialize Climate class."""
         # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
         super(Climate, self).__init__(xknx, name, device_updated_cb)
@@ -85,6 +87,8 @@ class Climate(Device):
         self.group_address_on_off_state = group_address_on_off_state
 
         self.operation_mode = HVACOperationMode.STANDBY
+        self.override_min_temp = override_min_temp
+        self.override_max_temp = override_max_temp
         self.override_supported_operation_modes = []
 
         if override_supported_operation_modes:
@@ -270,6 +274,8 @@ class Climate(Device):
     @property
     def target_temperature_max(self):
         """Return the maxium possible target temperature."""
+        if self.override_max_temp is not None:
+            return self.override_max_temp
         if not self.initialized_for_setpoint_shift_calculations:
             return None
         return (self.target_temperature.value -
@@ -279,6 +285,8 @@ class Climate(Device):
     @property
     def target_temperature_min(self):
         """Return the minimum possible target temperature."""
+        if self.override_min_temp is not None:
+            return self.override_min_temp
         if not self.initialized_for_setpoint_shift_calculations:
             return None
         return (self.target_temperature.value -


### PR DESCRIPTION
Background: Some devices do not have a setpoint shift address and get a flaky frontend because of it
This should also fix issues with increasing temperature in the classic UI if the new properties are set.

* Implemented mapping for operation modes to allow the frontend to set supposingly wrong operation list

Next steps: Implement the new operation modes in the frontend, I can do that after this PR makes it into HA.

Fixes https://github.com/home-assistant/home-assistant/issues/14531