### PR TITLE
HA plugin - color temp: changed white_value for color_temperature_mode

### DIFF
--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -61,8 +61,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_COLOR_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_COLOR_TEMP_ADDRESS): cv.string,
     vol.Optional(CONF_COLOR_TEMP_STATE_ADDRESS): cv.string,
-    # TODO: enum for mode with default
-    vol.Optional(CONF_COLOR_TEMP_MODE, default=DEFAULT_COLOR_TEMP_MODE): \
+    vol.Optional(CONF_COLOR_TEMP_MODE, default=DEFAULT_COLOR_TEMP_MODE):
     cv.enum(ColorTempModes),
     vol.Optional(CONF_MIN_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_MAX_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1)),
@@ -95,7 +94,6 @@ def async_add_entities_config(hass, config, async_add_entities):
 
     # switch group address for selected color_temperature_mode
     ga_tw, ga_tw_s, ga_ct, ga_ct_s = None, None, None, None
-    print(config.get(CONF_COLOR_TEMP_MODE))
     if config.get(CONF_COLOR_TEMP_MODE).value == 'DPT-7.600':
         ga_ct = config.get(CONF_COLOR_TEMP_ADDRESS)
         ga_ct_s = config.get(CONF_COLOR_TEMP_STATE_ADDRESS)

--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -94,11 +94,11 @@ def async_add_entities_config(hass, config, async_add_entities):
 
     group_address_tunable_white = None
     group_address_tunable_white_state = None
-    group_address_color_temperature = None
-    group_address_color_temperature_state = None
+    group_address_color_temp = None
+    group_address_color_temp_state = None
     if config.get(CONF_COLOR_TEMP_MODE) == ColorTempModes.absolute:
-        group_address_color_temperature = config.get(CONF_COLOR_TEMP_ADDRESS)
-        group_address_color_temperature_state = \
+        group_address_color_temp = config.get(CONF_COLOR_TEMP_ADDRESS)
+        group_address_color_temp_state = \
             config.get(CONF_COLOR_TEMP_STATE_ADDRESS)
     elif config.get(CONF_COLOR_TEMP_MODE) == ColorTempModes.relative:
         group_address_tunable_white = config.get(CONF_COLOR_TEMP_ADDRESS)
@@ -117,9 +117,8 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address_color_state=config.get(CONF_COLOR_STATE_ADDRESS),
         group_address_tunable_white=group_address_tunable_white,
         group_address_tunable_white_state=group_address_tunable_white_state,
-        group_address_color_temperature=group_address_color_temperature,
-        group_address_color_temperature_state=\
-            group_address_color_temperature_state,
+        group_address_color_temperature=group_address_color_temp,
+        group_address_color_temperature_state=group_address_color_temp_state,
         min_kelvin=config.get(CONF_MIN_KELVIN),
         max_kelvin=config.get(CONF_MAX_KELVIN))
     hass.data[DATA_XKNX].xknx.devices.add(light)

--- a/home-assistant-plugin/custom_components/light/xknx.py
+++ b/home-assistant-plugin/custom_components/light/xknx.py
@@ -8,9 +8,10 @@ https://home-assistant.io/components/light.knx/
 import voluptuous as vol
 
 from custom_components.xknx import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from enum import Enum
 from homeassistant.components.light import (
-    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_WHITE_VALUE, PLATFORM_SCHEMA,
-    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_WHITE_VALUE,
+    ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_HS_COLOR, PLATFORM_SCHEMA,
+    SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP,
     Light)
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
@@ -23,10 +24,9 @@ CONF_BRIGHTNESS_ADDRESS = 'brightness_address'
 CONF_BRIGHTNESS_STATE_ADDRESS = 'brightness_state_address'
 CONF_COLOR_ADDRESS = 'color_address'
 CONF_COLOR_STATE_ADDRESS = 'color_state_address'
-CONF_KELVIN_ADDRESS = 'color_temperature_address'
-CONF_KELVIN_STATE_ADDRESS = 'color_temperature_state_address'
-CONF_WHITE_VALUE_ADDRESS = 'white_value_address'
-CONF_WHITE_VALUE_STATE_ADDRESS = 'white_value_state_address'
+CONF_COLOR_TEMP_ADDRESS = 'color_temperature_address'
+CONF_COLOR_TEMP_STATE_ADDRESS = 'color_temperature_state_address'
+CONF_COLOR_TEMP_MODE = 'color_temperature_mode'
 CONF_MIN_KELVIN = 'min_kelvin'
 CONF_MAX_KELVIN = 'max_kelvin'
 
@@ -34,11 +34,22 @@ DEFAULT_NAME = 'XKNX Light'
 DEFAULT_COLOR = [255, 255, 255]
 DEFAULT_BRIGHTNESS = 255
 DEFAULT_COLOR_TEMPERATURE = 333  # 3000 K
+DEFAULT_COLOR_TEMP_MODE = 'absolute'
 DEFAULT_MIN_MIREDS = 166  # 6000 K
 DEFAULT_MAX_MIREDS = 370  # 2700 K
 DEFAULT_MIN_KELVIN = 2700
 DEFAULT_MAX_KELVIN = 6000
 DEPENDENCIES = ['xknx']
+
+
+class ColorTempModes(Enum):
+    """Color temperature modes for config validation"""
+
+    absolute = "DPT-7.600"
+    kelvin = "DPT-7.600"
+    relative = "DPT-5.001"
+    percent = "DPT-5.001"
+
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
@@ -48,10 +59,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_BRIGHTNESS_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_COLOR_ADDRESS): cv.string,
     vol.Optional(CONF_COLOR_STATE_ADDRESS): cv.string,
-    vol.Optional(CONF_KELVIN_ADDRESS): cv.string,
-    vol.Optional(CONF_KELVIN_STATE_ADDRESS): cv.string,
-    vol.Optional(CONF_WHITE_VALUE_ADDRESS): cv.string,
-    vol.Optional(CONF_WHITE_VALUE_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_COLOR_TEMP_ADDRESS): cv.string,
+    vol.Optional(CONF_COLOR_TEMP_STATE_ADDRESS): cv.string,
+    # TODO: enum for mode with default
+    vol.Optional(CONF_COLOR_TEMP_MODE, default=DEFAULT_COLOR_TEMP_MODE): \
+    cv.enum(ColorTempModes),
     vol.Optional(CONF_MIN_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1)),
     vol.Optional(CONF_MAX_KELVIN): vol.All(vol.Coerce(int), vol.Range(min=1)),
 })
@@ -80,6 +92,17 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
 def async_add_entities_config(hass, config, async_add_entities):
     """Set up light for KNX platform configured within platform."""
     import xknx
+
+    # switch group address for selected color_temperature_mode
+    ga_tw, ga_tw_s, ga_ct, ga_ct_s = None, None, None, None
+    print(config.get(CONF_COLOR_TEMP_MODE))
+    if config.get(CONF_COLOR_TEMP_MODE).value == 'DPT-7.600':
+        ga_ct = config.get(CONF_COLOR_TEMP_ADDRESS)
+        ga_ct_s = config.get(CONF_COLOR_TEMP_STATE_ADDRESS)
+    elif config.get(CONF_COLOR_TEMP_MODE).value == 'DPT-5.001':
+        ga_tw = config.get(CONF_COLOR_TEMP_ADDRESS)
+        ga_tw_s = config.get(CONF_COLOR_TEMP_STATE_ADDRESS)
+
     light = xknx.devices.Light(
         hass.data[DATA_XKNX].xknx,
         name=config.get(CONF_NAME),
@@ -90,10 +113,10 @@ def async_add_entities_config(hass, config, async_add_entities):
             CONF_BRIGHTNESS_STATE_ADDRESS),
         group_address_color=config.get(CONF_COLOR_ADDRESS),
         group_address_color_state=config.get(CONF_COLOR_STATE_ADDRESS),
-        group_address_tunable_white=config.get(CONF_WHITE_VALUE_ADDRESS),
-        group_address_tunable_white_state=config.get(CONF_WHITE_VALUE_STATE_ADDRESS),
-        group_address_color_temperature=config.get(CONF_KELVIN_ADDRESS),
-        group_address_color_temperature_state=config.get(CONF_KELVIN_STATE_ADDRESS),
+        group_address_tunable_white=ga_tw,
+        group_address_tunable_white_state=ga_tw_s,
+        group_address_color_temperature=ga_ct,
+        group_address_color_temperature_state=ga_ct_s,
         min_kelvin=config.get(CONF_MIN_KELVIN),
         max_kelvin=config.get(CONF_MAX_KELVIN))
     hass.data[DATA_XKNX].xknx.devices.add(light)
@@ -162,19 +185,18 @@ class KNXLight(Light):
             kelvin = self.device.current_color_temperature
             return color_util.color_temperature_kelvin_to_mired(kelvin) \
                 if kelvin is not None else DEFAULT_COLOR_TEMPERATURE
-        return None
-
-    @property
-    def white_value(self):
-        """Return the white value of this light between 0..255."""
-        if self.device.supports_tunable_white:
-            return self.device.current_tunable_white
+        elif self.device.supports_tunable_white:
+            relative_ct = self.device.current_tunable_white
+            return self.min_mireds + (((255 - relative_ct) / 255) *
+                                      (self.max_mireds - self.min_mireds)) \
+                if relative_ct is not None else DEFAULT_COLOR_TEMPERATURE
         return None
 
     @property
     def min_mireds(self):
         """Return the coldest color temperature this light supports in mireds."""
-        if self.device.supports_color_temperature:
+        if self.device.supports_color_temperature or \
+                self.device.supports_tunable_white:
             kelvin = self.device.max_kelvin
             return color_util.color_temperature_kelvin_to_mired(kelvin) \
                 if kelvin is not None else DEFAULT_MIN_MIREDS
@@ -183,7 +205,8 @@ class KNXLight(Light):
     @property
     def max_mireds(self):
         """Return the warmest color temperature this light supports in mireds."""
-        if self.device.supports_color_temperature:
+        if self.device.supports_color_temperature or \
+                self.device.supports_tunable_white:
             kelvin = self.device.min_kelvin
             return color_util.color_temperature_kelvin_to_mired(kelvin) \
                 if kelvin is not None else DEFAULT_MAX_MIREDS
@@ -192,7 +215,8 @@ class KNXLight(Light):
     @property
     def min_kelvin(self):
         """Return the warmest color temperature this light supports in kelvin."""
-        if self.device.supports_color_temperature:
+        if self.device.supports_color_temperature or \
+                self.device.supports_tunable_white:
             kelvin = self.device.min_kelvin
             return kelvin \
                 if kelvin is not None else DEFAULT_MIN_KELVIN
@@ -201,7 +225,8 @@ class KNXLight(Light):
     @property
     def max_kelvin(self):
         """Return the coldest color temperature this light supports in kelvin."""
-        if self.device.supports_color_temperature:
+        if self.device.supports_color_temperature or \
+                self.device.supports_tunable_white:
             kelvin = self.device.max_kelvin
             return kelvin \
                 if kelvin is not None else DEFAULT_MAX_KELVIN
@@ -230,18 +255,16 @@ class KNXLight(Light):
             flags |= SUPPORT_BRIGHTNESS
         if self.device.supports_color:
             flags |= SUPPORT_COLOR | SUPPORT_BRIGHTNESS
-        if self.device.supports_color_temperature:
+        if self.device.supports_color_temperature or \
+                self.device.supports_tunable_white:
             flags |= SUPPORT_COLOR_TEMP
-        if self.device.supports_tunable_white:
-            flags |= SUPPORT_WHITE_VALUE
         return flags
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
-        brightness = int(kwargs.get(ATTR_BRIGHTNESS, self.brightness))
+        brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)
         hs_color = kwargs.get(ATTR_HS_COLOR, self.hs_color)
         mireds = kwargs.get(ATTR_COLOR_TEMP, self.color_temp)
-        tunable_white = int(kwargs.get(ATTR_WHITE_VALUE, self.white_value))
 
         # fall back to default values, if required
         if brightness is None:
@@ -252,7 +275,6 @@ class KNXLight(Light):
         update_brightness = ATTR_BRIGHTNESS in kwargs
         update_color = ATTR_HS_COLOR in kwargs
         update_color_temp = ATTR_COLOR_TEMP in kwargs
-        update_tunable_white = ATTR_WHITE_VALUE in kwargs
 
         # always only go one path for turning on (avoid conflicting changes
         # and weird effects)
@@ -277,8 +299,10 @@ class KNXLight(Light):
                 kelvin = self.min_kelvin
             await self.device.set_color_temperature(kelvin)
         elif self.device.supports_tunable_white and \
-                update_tunable_white:
-            await self.device.set_tunable_white(tunable_white)
+                update_color_temp:
+            relative_ct = 255 - int(255 * (mireds - self.min_mireds) /
+                                    (self.max_mireds - self.min_mireds))
+            await self.device.set_tunable_white(relative_ct)
         else:
             # no color/brightness change requested, so just turn it on
             await self.device.set_on()


### PR DESCRIPTION
- as ATTR_WHITE_VALUE is intended for RGBW absolute and relative color temperature group addresses are distinguished by a new config variable `color_temperature_mode`. Only one mode can be used from the HA plugin. Default is DPT-7.600 absolute color temperature in Kelvin.

- [FIX] casting to int failed if brightness is not used -> None (in `async_turn_on()`)