### PR TITLE
Make rate limit configurable

### DIFF
--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -20,8 +20,10 @@ The `XKNX()` object is the core element of any XKNX installation. It should be o
 xknx = XKNX(config='xknx.yaml',
             loop=loop,
             own_address=Address,
-            telegram_received_cb=function1,
-            device_updated_cb=function2):
+            address_format=GroupAddressType.LONG
+            telegram_received_cb=None,
+            device_updated_cb=None,
+            rate_limit=DEFAULT_RATE_LIMIT):
 ```
 
 The constructor of the XKNX object takes several parameters:
@@ -29,8 +31,13 @@ The constructor of the XKNX object takes several parameters:
 * `config` defines a path to the local [XKNX.yaml](/configuration).
 * `loop` points to the asyncio.loop object. Of not specified it uses `asyncio.get_event_loop()`.
 * `own_address` may be used to specify the physical KNX address of the XKNX daemon. If not speficied it uses `15.15.250`.
+* `address_format` may be used to specify the type of group addresses to use. Possible values are:
+** FREE: integer or hex representation
+** SHORT: representation like '1/34' without middle groups
+** LONG: representation like '1/2/34' with middle groups
 * `telegram_received_cb` is a callback which is called after every received KNX telegram. See [callbacks](#callbacks) documentation for details.
 * `device_updated_cb` is an async callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
+* `rate_limit` can be used to limit the outgoing traffic to the KNX/IP interface. The default value is 0.05 meaning that we allow 20 packets per second to send to the bus.
 
 # [](#header-2)Starting
 

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -37,7 +37,7 @@ The constructor of the XKNX object takes several parameters:
 ** LONG: representation like '1/2/34' with middle groups
 * `telegram_received_cb` is a callback which is called after every received KNX telegram. See [callbacks](#callbacks) documentation for details.
 * `device_updated_cb` is an async callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
-* `rate_limit` can be used to limit the outgoing traffic to the KNX/IP interface. The default value is 0.05 meaning that we allow 20 packets per second to send to the bus.
+* `rate_limit` in telegrams per second - can be used to limit the outgoing traffic to the KNX/IP interface. The default value is 20 packets per second.
 
 # [](#header-2)Starting
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -29,6 +29,7 @@ CONF_XKNX_LOCAL_IP = "local_ip"
 CONF_XKNX_FIRE_EVENT = "fire_event"
 CONF_XKNX_FIRE_EVENT_FILTER = "fire_event_filter"
 CONF_XKNX_STATE_UPDATER = "state_updater"
+CONF_XKNX_RATE_LIMIT = "rate_limit"
 CONF_XKNX_EXPOSE = "expose"
 CONF_XKNX_EXPOSE_TYPE = "type"
 CONF_XKNX_EXPOSE_ADDRESS = "address"
@@ -68,6 +69,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Inclusive(CONF_XKNX_FIRE_EVENT_FILTER, 'fire_ev'):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_XKNX_STATE_UPDATER, default=True): cv.boolean,
+        vol.Optional(CONF_XKNX_RATE_LIMIT, default=0.05): cv.float,
         vol.Optional(CONF_XKNX_EXPOSE):
             vol.All(
                 cv.ensure_list,
@@ -144,7 +146,8 @@ class KNXModule:
     def init_xknx(self):
         """Initialize of KNX object."""
         from xknx import XKNX
-        self.xknx = XKNX(config=self.config_file(), loop=self.hass.loop)
+        self.xknx = XKNX(config=self.config_file(), loop=self.hass.loop,
+                         rate_limit=self.config[DOMAIN][CONF_XKNX_RATE_LIMIT])
 
     async def start(self):
         """Start KNX object. Connect to tunneling or Routing device."""

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -69,7 +69,8 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Inclusive(CONF_XKNX_FIRE_EVENT_FILTER, 'fire_ev'):
             vol.All(cv.ensure_list, [cv.string]),
         vol.Optional(CONF_XKNX_STATE_UPDATER, default=True): cv.boolean,
-        vol.Optional(CONF_XKNX_RATE_LIMIT, default=0.05): cv.float,
+        vol.Optional(CONF_XKNX_RATE_LIMIT, default=20):
+            vol.All(vol.Coerce(int), vol.Range(min=1, max=100)),
         vol.Optional(CONF_XKNX_EXPOSE):
             vol.All(
                 cv.ensure_list,

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -1,7 +1,7 @@
 
 general:
     own_address: '15.15.249'
-    rate_limit: 0.05
+    rate_limit: 20
 
 groups:
 

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -1,6 +1,7 @@
 
 general:
     own_address: '15.15.249'
+    rate_limit: 0.05
 
 groups:
 

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -38,6 +38,9 @@ class Config:
             if "own_address" in doc["general"]:
                 self.xknx.own_address = \
                     PhysicalAddress(doc["general"]["own_address"])
+            if "rate_limit" in doc["general"]:
+                self.xknx.rate_limit = \
+                    doc["general"]["rate_limit"]
 
     def parse_groups(self, doc):
         """Parse the group section of xknx.yaml."""

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -68,8 +68,8 @@ class TelegramQueue():
             self.xknx.telegrams.task_done()
 
             if telegram.direction == TelegramDirection.OUTGOING:
-                # limit rate to knx bus to 20 per second
-                await asyncio.sleep(1/20)
+                # limit rate to knx bus - defaults to 20 per second
+                await asyncio.sleep(self.xknx.rate_limit)
 
         self.queue_stopped.set()
 

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -69,7 +69,7 @@ class TelegramQueue():
 
             if telegram.direction == TelegramDirection.OUTGOING:
                 # limit rate to knx bus - defaults to 20 per second
-                await asyncio.sleep(self.xknx.rate_limit)
+                await asyncio.sleep(1 / self.xknx.rate_limit)
 
         self.queue_stopped.set()
 

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -16,7 +16,7 @@ class XKNX:
     # pylint: disable=too-many-instance-attributes
 
     DEFAULT_ADDRESS = '15.15.250'
-    DEFAULT_RATE_LIMIT = 0.05
+    DEFAULT_RATE_LIMIT = 20
 
     def __init__(self,
                  config=None,

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -16,6 +16,7 @@ class XKNX:
     # pylint: disable=too-many-instance-attributes
 
     DEFAULT_ADDRESS = '15.15.250'
+    DEFAULT_RATE_LIMIT = 0.05
 
     def __init__(self,
                  config=None,
@@ -23,7 +24,8 @@ class XKNX:
                  own_address=PhysicalAddress(DEFAULT_ADDRESS),
                  address_format=GroupAddressType.LONG,
                  telegram_received_cb=None,
-                 device_updated_cb=None):
+                 device_updated_cb=None,
+                 rate_limit=DEFAULT_RATE_LIMIT):
         """Initialize XKNX class."""
         # pylint: disable=too-many-arguments
         self.devices = Devices()
@@ -36,6 +38,7 @@ class XKNX:
         self.started = False
         self.address_format = address_format
         self.own_address = own_address
+        self.rate_limit = rate_limit
         self.logger = logging.getLogger('xknx.log')
         self.knx_logger = logging.getLogger('xknx.knx')
         self.telegram_logger = logging.getLogger('xknx.telegram')


### PR DESCRIPTION
Make rate limit configurable.

Leave default to 20 packets per second.

Closes #120