### PR TITLE
treat DPT 5 (pulse) sensor like every other sensor

### DIFF
--- a/xknx/devices/remote_value_dpt_value_1_ucount.py
+++ b/xknx/devices/remote_value_dpt_value_1_ucount.py
@@ -11,17 +11,6 @@ from .remote_value import RemoteValue
 class RemoteValueDptValue1Ucount(RemoteValue):
     """Abstraction for remote value of KNX DPT 5.010."""
 
-    def __init__(self,
-                 xknx,
-                 group_address=None,
-                 device_name=None,
-                 after_update_cb=None):
-        """Initialize remote value of KNX DPT 5.010."""
-        # pylint: disable=too-many-arguments
-        super(RemoteValueDptValue1Ucount, self).__init__(
-            xknx, group_address, None,
-            device_name=device_name, after_update_cb=after_update_cb)
-
     def payload_valid(self, payload):
         """Test if telegram payload may be parsed."""
         return (isinstance(payload, DPTArray)

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -11,7 +11,7 @@ from xknx.knx import (
     DPTElectricCurrent, DPTElectricPotential, DPTEnergy, DPTEnthalpy,
     DPTFrequency, DPTHeatFlowRate, DPTHumidity, DPTLux, DPTPartsPerMillion,
     DPTPhaseAngleDeg, DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTSpeed,
-    DPTTemperature, DPTUElCurrentmA, DPTVoltage, DPTWsp)
+    DPTTemperature, DPTUElCurrentmA, DPTValue1Ucount, DPTVoltage, DPTWsp)
 
 from .remote_value import RemoteValue
 
@@ -36,12 +36,16 @@ class RemoteValueSensor(RemoteValue):
         'heatflowrate': DPTHeatFlowRate,
         'phaseanglerad': DPTPhaseAngleRad,
         'phaseangledeg': DPTPhaseAngleDeg,
+        'pulse': DPTValue1Ucount,
         'powerfactor': DPTPowerFactor,
         'speed': DPTSpeed,
         'enthalpy': DPTEnthalpy,
         'ppm': DPTPartsPerMillion,
 
         #  Generic DPT Without Min/Max and Unit.
+        'DPT-5': DPTValue1Ucount,
+        '1byte_unsigned': DPTValue1Ucount,
+
         'DPT-7': DPT2ByteUnsigned,
         '2byte_unsigned': DPT2ByteUnsigned,
         'DPT-9': DPT2ByteFloat,

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -7,7 +7,6 @@ It provides functionality for
 * watching for state updates from KNX bus.
 """
 from .device import Device
-from .remote_value_dpt_value_1_ucount import RemoteValueDptValue1Ucount
 from .remote_value_scaling import RemoteValueScaling
 from .remote_value_sensor import RemoteValueSensor
 
@@ -34,12 +33,6 @@ class Sensor(Device):
                 after_update_cb=self.after_update,
                 range_from=0,
                 range_to=100)
-        elif value_type == "pulse":
-            self.sensor_value = RemoteValueDptValue1Ucount(
-                xknx,
-                group_address=group_address,
-                device_name=self.name,
-                after_update_cb=self.after_update)
         else:
             self.sensor_value = RemoteValueSensor(
                 xknx,

--- a/xknx/knx/dpt_value_1_ucount.py
+++ b/xknx/knx/dpt_value_1_ucount.py
@@ -15,6 +15,7 @@ class DPTValue1Ucount(DPTBase):
     value_max = 255
     unit = ""
     resolution = 1
+    payload_length = 1
 
     @classmethod
     def from_knx(cls, raw):


### PR DESCRIPTION
I'm not sure why `pulse` was treated differently from every other sensor type. Is there something I didn't think about?

- removed __init__ from RemoteValueDptValue1Ucount() to inherit `group_address_state` 
- added 'pulse', 'DPT-5' and '1byte_unsigned' to DPTMap of RemoteValueSensor()

https://github.com/XKNX/xknx/issues/187