### PR TITLE
Climate setpoint shift fix

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -57,8 +57,8 @@ OPERATION_MODES_INV = dict((
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
-    vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
+    vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STEP,
@@ -211,12 +211,12 @@ class KNXClimate(ClimateDevice):
     @property
     def target_temperature_step(self):
         """Return the supported step of target temperature."""
-        return self.device.setpoint_shift_step
+        return self.device.temperature_step
 
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self.device.target_temperature
+        return self.device.target_temperature.value
 
     @property
     def min_temp(self):

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -246,9 +246,10 @@ class KNXClimate(ClimateDevice):
     @property
     def operation_list(self):
         """Return the list of available operation modes."""
-        return [OPERATION_MODES.get(operation_mode.value) for
-                operation_mode in
-                self.device.mode.operation_modes]
+        _operations = [OPERATION_MODES.get(operation_mode.value) for
+                       operation_mode in
+                       self.device.mode.operation_modes]
+        return list(filter(None, _operations))
 
     async def async_set_operation_mode(self, operation_mode):
         """Set operation mode."""

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -216,7 +216,7 @@ class KNXClimate(ClimateDevice):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
-        return self.device.target_temperature.value
+        return self.device.target_temperature
 
     @property
     def min_temp(self):

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -56,11 +56,6 @@ OPERATION_MODES_INV = dict((
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
-    vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
-    vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
-    vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
-    vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_SETPOINT_SHIFT_STEP,
                  default=DEFAULT_SETPOINT_SHIFT_STEP): vol.All(
                      float, vol.Range(min=0, max=2)),
@@ -68,6 +63,11 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
         vol.All(int, vol.Range(min=0, max=32)),
     vol.Optional(CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN):
         vol.All(int, vol.Range(min=-32, max=0)),
+    vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
+    vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
+    vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
+    vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
     vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -664,16 +664,19 @@ class TestClimate(unittest.TestCase):
             xknx,
             'TestClimate',
             group_address_target_temperature_state='1/2/1',
-            group_address_target_temperature='1/2/2',
-            group_address_setpoint_shift='1/2/3')
+            group_address_target_temperature='1/2/2')
 
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
         # default temperature_step for non setpoint_shift
         self.assertEqual(climate.temperature_step, 0.1)
 
-        # initialize setpoint_shift
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(1)))
-        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_target_temperature_state='1/2/1',
+            group_address_target_temperature='1/2/2',
+            group_address_setpoint_shift='1/2/3')
+        # default temperature_step for setpoint_shift
         self.assertEqual(climate.temperature_step, 0.5)
 
         climate = Climate(
@@ -683,11 +686,8 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
             setpoint_shift_step=0.3)
-        self.assertEqual(climate.temperature_step, 0.1)
-        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(0)))
-        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.temperature_step, 0.3)
+
 
     #
     # TEST SYNC

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -654,6 +654,42 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(climate.target_temperature.value, 22)
 
     #
+    # TEST TEMPERATURE STEP
+    #
+    def test_temperature_step(self):
+        """Test base temperature step."""
+        # pylint: disable=no-self-use
+        xknx = XKNX(loop=self.loop)
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_target_temperature_state='1/2/1',
+            group_address_target_temperature='1/2/2',
+            group_address_setpoint_shift='1/2/3')
+
+        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
+        # default temperature_step for non setpoint_shift
+        self.assertEqual(climate.temperature_step, 0.1)
+
+        # initialize setpoint_shift
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(1)))
+        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
+        self.assertEqual(climate.temperature_step, 0.5)
+
+        climate = Climate(
+            xknx,
+            'TestClimate',
+            group_address_target_temperature_state='1/2/1',
+            group_address_target_temperature='1/2/2',
+            group_address_setpoint_shift='1/2/3',
+            setpoint_shift_step=0.3)
+        self.assertEqual(climate.temperature_step, 0.1)
+        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(0)))
+        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
+        self.assertEqual(climate.temperature_step, 0.3)
+
+    #
     # TEST SYNC
     #
     def test_sync(self):

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -688,7 +688,6 @@ class TestClimate(unittest.TestCase):
             setpoint_shift_step=0.3)
         self.assertEqual(climate.temperature_step, 0.3)
 
-
     #
     # TEST SYNC
     #

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -20,7 +20,7 @@ class TestClimate(unittest.TestCase):
     """Test class for Climate objects."""
 
     # pylint: disable=invalid-name,too-many-public-methods
-
+    # TODO: test base_temperature
     def setUp(self):
         """Set up test class."""
         self.loop = asyncio.new_event_loop()
@@ -42,7 +42,7 @@ class TestClimate(unittest.TestCase):
             group_address_temperature='1/2/3')
 
         self.assertTrue(climate.temperature.initialized)
-        self.assertFalse(climate.target_temperature.initialized)
+        self.assertFalse(climate._target_temperature.initialized)
 
     def test_support_target_temperature(self):
         """Test supports_target__temperature flag."""
@@ -53,7 +53,7 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/3')
 
         self.assertFalse(climate.temperature.initialized)
-        self.assertTrue(climate.target_temperature.initialized)
+        self.assertTrue(climate._target_temperature.initialized)
 
     def test_support_operation_mode(self):
         """Test supports_supports_operation_mode flag. One group address for all modes."""
@@ -84,6 +84,7 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_temperature='1/2/1',
             group_address_target_temperature='1/2/2',
+            group_address_base_temperature_state='1/2/16',
             group_address_setpoint_shift='1/2/3',
             group_address_setpoint_shift_state='1/2/4',
             group_address_on_off='1/2/11',
@@ -94,6 +95,7 @@ class TestClimate(unittest.TestCase):
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/4')))
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/11')))
         self.assertTrue(climate.has_group_address(GroupAddress('1/2/12')))
+        self.assertTrue(climate.has_group_address(GroupAddress('1/2/16')))
         self.assertFalse(climate.has_group_address(GroupAddress('1/2/99')))
 
     #
@@ -142,6 +144,7 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_temperature='1/2/1',
             group_address_target_temperature='1/2/2',
+            group_address_base_temperature_state='1/2/16',
             group_address_setpoint_shift='1/2/3',
             group_address_setpoint_shift_state='1/2/4',
             group_address_on_off='1/2/11',
@@ -150,6 +153,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             climate.state_addresses(),
             [GroupAddress("1/2/1"),
+             GroupAddress("1/2/16"),
              GroupAddress("1/2/4"),
              GroupAddress("1/2/12"),
              GroupAddress("1/2/5"),
@@ -177,12 +181,12 @@ class TestClimate(unittest.TestCase):
         climate.register_device_updated_cb(async_after_update_callback)
 
         self.loop.run_until_complete(asyncio.Task(
-            climate.target_temperature.set(23.00)))
+            climate._target_temperature.set(23.00)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
         self.loop.run_until_complete(asyncio.Task(
-            climate.setpoint_shift.set(-2)))
+            climate.set_setpoint_shift(-2)))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
@@ -397,7 +401,7 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_setpoint_shift='1/2/3')
         self.assertFalse(climate2.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(asyncio.Task(climate2.setpoint_shift.set(4)))
+        self.loop.run_until_complete(asyncio.Task(climate2.set_setpoint_shift(4)))
         self.assertFalse(climate2.initialized_for_setpoint_shift_calculations)
 
         climate3 = Climate(
@@ -405,9 +409,9 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3')
-        self.loop.run_until_complete(asyncio.Task(climate3.setpoint_shift.set(4)))
+        self.loop.run_until_complete(asyncio.Task(climate3.set_setpoint_shift(4)))
         self.assertFalse(climate3.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(asyncio.Task(climate3.target_temperature.set(23.00)))
+        self.loop.run_until_complete(asyncio.Task(climate3._target_temperature.set(23.00)))
         self.assertTrue(climate3.initialized_for_setpoint_shift_calculations)
 
     #
@@ -449,9 +453,9 @@ class TestClimate(unittest.TestCase):
             group_address_setpoint_shift='1/2/3',
             max_temp='42',
             min_temp='3')
-        self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(4)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(4)))
         self.assertFalse(climate.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
+        self.loop.run_until_complete(asyncio.Task(climate._target_temperature.set(23.00)))
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
 
         self.assertEqual(climate.target_temperature_min, '3')
@@ -470,46 +474,49 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3')
 
-        self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(4)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(3)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(4)))
+            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
 
-        self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
+        self.loop.run_until_complete(asyncio.Task(climate._target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
+        # Base temperature is 20.00°
 
         # First change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(8)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
-        self.assertEqual(climate.target_temperature.value, 24.00)
+        self.assertEqual(climate._target_temperature.value, 24.00)
 
         # Second change
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(23.50)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(5)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(7)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.50))))
-        self.assertEqual(climate.target_temperature.value, 23.50)
+        self.assertEqual(climate._target_temperature.value, 23.50)
 
         # Test max target temperature
-        self.assertEqual(climate.target_temperature_max, 24.00)
+        # Base (20) - setpoint_shift_max (6)
+        self.assertEqual(climate.target_temperature_max, 26.00)
 
         # third change - limit exceeded, setting to max
         with self.assertRaises(DeviceIllegalValue):
-            self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.50)))
+            self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(26.50)))
 
     def test_target_temperature_down(self):
         """Test decrease target temperature."""
@@ -521,46 +528,49 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3')
 
-        self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(1)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(1)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(1)))
+            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(2)))
 
-        self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
+        self.loop.run_until_complete(asyncio.Task(climate._target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
+        # Base temperature is 22.00°
 
         # First change
-        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(21.00)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(20.50)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFD)))  # -3
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(21.00))))
-        self.assertEqual(climate.target_temperature.value, 21.00)
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(20.50))))
+        self.assertEqual(climate._target_temperature.value, 20.50)
 
         # Second change
-        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(19.50)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(19.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFA)))  # -3
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFA)))  # -6
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(19.50))))
-        self.assertEqual(climate.target_temperature.value, 19.50)
+            Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(19.00))))
+        self.assertEqual(climate._target_temperature.value, 19.00)
 
         # Test min target temperature
-        self.assertEqual(climate.target_temperature_min, 19.50)
+        # Base (22) - setpoint_shift_min (6)
+        self.assertEqual(climate.target_temperature_min, 16.00)
 
         # third change - limit exceeded, setting to max
         with self.assertRaises(DeviceIllegalValue):
-            self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(19.00)))
+            self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(15.50)))
 
     def test_target_temperature_modified_step(self):
         """Test increase target temperature with modified step size."""
@@ -572,34 +582,35 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
             setpoint_shift_step=0.1,
-            setpoint_shift_max=20,
-            setpoint_shift_min=-20)
+            setpoint_shift_max=10,
+            setpoint_shift_min=-10)
 
-        self.loop.run_until_complete(asyncio.Task(climate.setpoint_shift.set(10)))
+        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(3)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(10)))
+            # setpoint_shift_step is 0.1 -> payload = setpoint_shift * 10
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(30)))
 
-        self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
+        self.loop.run_until_complete(asyncio.Task(climate._target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))))
-
+        # Base temperature is 20.00°
         self.loop.run_until_complete(asyncio.Task(climate.set_target_temperature(24.00)))
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(20)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(40)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
-        self.assertEqual(climate.target_temperature.value, 24.00)
+        self.assertEqual(climate._target_temperature.value, 24.00)
 
         # Test max/min target temperature
-        self.assertEqual(climate.target_temperature_max, 24.00)
-        self.assertEqual(climate.target_temperature_min, 20.00)
+        self.assertEqual(climate.target_temperature_max, 30.00)
+        self.assertEqual(climate.target_temperature_min, 10.00)
 
     #
     # TEST SYNC

--- a/test/devices_tests/remote_value_test.py
+++ b/test/devices_tests/remote_value_test.py
@@ -59,7 +59,7 @@ class TestRemoteValue(unittest.TestCase):
         remote_value = RemoteValue(xknx, group_address_state=GroupAddress('1/2/3'))
         with patch('logging.Logger.warning') as mock_info:
             self.loop.run_until_complete(asyncio.Task(remote_value.set(23)))
-            mock_info.assert_called_with('Atempted to set value for non-writable device: %s (value: %s)', 'Unknown', 23)
+            mock_info.assert_called_with('Attempted to set value for non-writable device: %s (value: %s)', 'Unknown', 23)
 
     def test_default_value_unit(self):
         """Test for the default value of unit_of_measurement."""

--- a/test/devices_tests/remote_value_test.py
+++ b/test/devices_tests/remote_value_test.py
@@ -46,12 +46,20 @@ class TestRemoteValue(unittest.TestCase):
             mock_warn.assert_called_with('from_knx not implemented for %s', 'RemoteValue')
 
     def test_info_set_uninitialized(self):
-        """Test for warning if from_knx is not implemented."""
+        """Test for info if RemoteValue is not initialized."""
         xknx = XKNX(loop=self.loop)
         remote_value = RemoteValue(xknx)
         with patch('logging.Logger.info') as mock_info:
             self.loop.run_until_complete(asyncio.Task(remote_value.set(23)))
-            mock_info.assert_called_with('Setting value of uninitialized device %s (value %s)', 'Unknown', 23)
+            mock_info.assert_called_with('Setting value of uninitialized device: %s (value: %s)', 'Unknown', 23)
+
+    def test_info_set_unwritable(self):
+        """Test for warning if RemoteValue is read only."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValue(xknx, group_address_state=GroupAddress('1/2/3'))
+        with patch('logging.Logger.warning') as mock_info:
+            self.loop.run_until_complete(asyncio.Task(remote_value.set(23)))
+            mock_info.assert_called_with('Atempted to set value for non-writable device: %s (value: %s)', 'Unknown', 23)
 
     def test_default_value_unit(self):
         """Test for the default value of unit_of_measurement."""

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -70,7 +70,6 @@ class TestStringRepresentations(unittest.TestCase):
             name="Wohnzimmer",
             group_address_temperature='1/2/1',
             group_address_target_temperature='1/2/2',
-            group_address_base_temperature_state='1/2/16',
             group_address_setpoint_shift='1/2/3',
             group_address_setpoint_shift_state='1/2/4',
             setpoint_shift_step=0.1,
@@ -82,7 +81,6 @@ class TestStringRepresentations(unittest.TestCase):
             str(climate),
             '<Climate name="Wohnzimmer" temperature="None/GroupAddress("1/2/1")/None/None" '
             'target_temperature="GroupAddress("1/2/2")/None/None/None" '
-            'base_temperature="None/GroupAddress("1/2/16")/None/None" '
             'setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" '
             'setpoint_shift_step="0.1" setpoint_shift_max="20" setpoint_shift_min="-20" '
             'group_address_on_off="GroupAddress("1/2/14")/GroupAddress("1/2/15")/None/None" />')

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -12,7 +12,8 @@ from xknx.exceptions import (
     CouldNotParseTelegram, DeviceIllegalValue)
 from xknx.io.gateway_scanner import GatewayDescriptor
 from xknx.knx import (
-    DPTArray, DPTBinary, GroupAddress, PhysicalAddress, Telegram)
+    DPTArray, DPTBinary, GroupAddress, PhysicalAddress, Telegram,
+    TelegramDirection)
 from xknx.knxip import (
     HPAI, CEMIFrame, ConnectionStateRequest, ConnectionStateResponse,
     ConnectRequest, ConnectRequestType, ConnectResponse, DIBDeviceInformation,
@@ -222,7 +223,11 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(sensor),
             '<Sensor name="MeinSensor" sensor="None/GroupAddress("1/2/3")/None/None" value="None" unit="%"/>')
-        self.loop.run_until_complete(asyncio.Task(sensor.sensor_value.set(25)))
+        # self.loop.run_until_complete(asyncio.Task(sensor.sensor_value.set(25)))
+        telegram = Telegram(group_address=GroupAddress('1/2/3'),
+                            direction=TelegramDirection.INCOMING,
+                            payload=DPTArray((0x40)))
+        self.loop.run_until_complete(asyncio.Task(sensor.process_group_write(telegram)))
         self.assertEqual(
             str(sensor),
             '<Sensor name="MeinSensor" sensor="None/GroupAddress("1/2/3")/<DPTArray value="[0x40]" />/25" value="25" unit="%"/>')

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -70,6 +70,7 @@ class TestStringRepresentations(unittest.TestCase):
             name="Wohnzimmer",
             group_address_temperature='1/2/1',
             group_address_target_temperature='1/2/2',
+            group_address_base_temperature_state='1/2/16',
             group_address_setpoint_shift='1/2/3',
             group_address_setpoint_shift_state='1/2/4',
             setpoint_shift_step=0.1,
@@ -79,9 +80,12 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_on_off_state='1/2/15')
         self.assertEqual(
             str(climate),
-            '<Climate name="Wohnzimmer" temperature="None/GroupAddress("1/2/1")/None/None"  target_temperature="GroupAddress("1/2/2")/None/None/'
-            'None"  setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" setpoint_shift_step="0.1" setpoint_shift_max="20" set'
-            'point_shift_min="-20" group_address_on_off="GroupAddress("1/2/14")/GroupAddress("1/2/15")/None/None" />')
+            '<Climate name="Wohnzimmer" temperature="None/GroupAddress("1/2/1")/None/None" '
+            'target_temperature="GroupAddress("1/2/2")/None/None/None" '
+            'base_temperature="None/GroupAddress("1/2/16")/None/None" '
+            'setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" '
+            'setpoint_shift_step="0.1" setpoint_shift_max="20" setpoint_shift_min="-20" '
+            'group_address_on_off="GroupAddress("1/2/14")/GroupAddress("1/2/15")/None/None" />')
 
     def test_climate_mode(self):
         """Test string representation of climate mode object."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -12,9 +12,10 @@ from .remote_value_1count import RemoteValue1Count
 from .remote_value_switch import RemoteValueSwitch
 from .remote_value_temp import RemoteValueTemp
 
-DEFAULT_SETPOINT_SHIFT_STEP = 0.5
 DEFAULT_SETPOINT_SHIFT_MAX = 6
 DEFAULT_SETPOINT_SHIFT_MIN = -6
+DEFAULT_SETPOINT_SHIFT_STEP = 0.5
+DEFAULT_TEMPERATUE_STEP = 0.1
 
 
 class SetpointShiftValue(RemoteValue1Count):
@@ -222,9 +223,9 @@ class Climate(Device):
     @property
     def temperature_step(self):
         """Return smallest possible temperature step."""
-        if self.initialized_for_setpoint_shift_calculations:
+        if self._setpoint_shift.initialized:
             return self._setpoint_shift.setpoint_shift_step
-        return 0.1
+        return DEFAULT_TEMPERATUE_STEP
 
     async def set_target_temperature(self, target_temperature):
         """Send new target temperature or setpoint_shift to KNX bus."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -42,13 +42,6 @@ class SetpointShiftValue(RemoteValue1Count):
         self.min_kelvin = min_kelvin
         self.max_kelvin = max_kelvin
 
-        if self.setpoint_shift_step is None:
-            self.setpoint_shift_step = DEFAULT_SETPOINT_SHIFT_STEP
-        if self.min_kelvin is None:
-            self.min_kelvin = DEFAULT_SETPOINT_SHIFT_MIN
-        if self.max_kelvin is None:
-            self.max_kelvin = DEFAULT_SETPOINT_SHIFT_MAX
-
     @property
     def value(self):
         """Return current value in Kelvin."""
@@ -64,7 +57,6 @@ class SetpointShiftValue(RemoteValue1Count):
         elif value < self.min_kelvin:
             raise DeviceIllegalValue("setpoint_shift_min exceeded", value)
             # value = self.min_kelvin
-
         raw_value = int(value / self.setpoint_shift_step)
         await super().set(raw_value)
 
@@ -82,9 +74,9 @@ class Climate(Device):
                  group_address_base_temperature_state=None,
                  group_address_setpoint_shift=None,
                  group_address_setpoint_shift_state=None,
-                 setpoint_shift_step=None,
-                 setpoint_shift_max=None,
-                 setpoint_shift_min=None,
+                 setpoint_shift_step=DEFAULT_SETPOINT_SHIFT_STEP,
+                 setpoint_shift_max=DEFAULT_SETPOINT_SHIFT_MAX,
+                 setpoint_shift_min=DEFAULT_SETPOINT_SHIFT_MIN,
                  group_address_on_off=None,
                  group_address_on_off_state=None,
                  min_temp=None,
@@ -162,11 +154,11 @@ class Climate(Device):
         group_address_setpoint_shift_state = \
             config.get('group_address_setpoint_shift_state')
         setpoint_shift_step = \
-            config.get('setpoint_shift_step')
+            config.get('setpoint_shift_step', DEFAULT_SETPOINT_SHIFT_STEP)
         setpoint_shift_max = \
-            config.get('setpoint_shift_max')
+            config.get('setpoint_shift_max', DEFAULT_SETPOINT_SHIFT_MAX)
         setpoint_shift_min = \
-            config.get('setpoint_shift_min')
+            config.get('setpoint_shift_min', DEFAULT_SETPOINT_SHIFT_MIN)
         group_address_on_off = \
             config.get('group_address_on_off')
         group_address_on_off_state = \

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -251,16 +251,10 @@ class ClimateMode(Device):
         if self.supports_operation_mode:
             if self.group_address_operation_mode_state:
                 state_addresses.append(self.group_address_operation_mode_state)
-            elif self.group_address_operation_mode:
-                state_addresses.append(self.group_address_operation_mode)
             if self.group_address_controller_status_state:
                 state_addresses.append(self.group_address_controller_status_state)
-            elif self.group_address_controller_status:
-                state_addresses.append(self.group_address_controller_status)
             if self.group_address_controller_mode_state:
                 state_addresses.append(self.group_address_controller_mode_state)
-            elif self.group_address_controller_mode:
-                state_addresses.append(self.group_address_controller_mode)
             # Note: telegrams setting splitted up operation modes are not yet implemented
         return state_addresses
 

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -103,8 +103,12 @@ class RemoteValue():
     async def set(self, value):
         """Set new value."""
         if not self.initialized:
-            self.xknx.logger.info("Setting value of uninitialized device %s (value %s)", self.device_name, value)
+            self.xknx.logger.info("Setting value of uninitialized device: %s (value: %s)", self.device_name, value)
             return
+        if not self.writable:
+            self.xknx.logger.warning("Atempted to set value for non-writable device: %s (value: %s)", self.device_name, value)
+            return
+
         payload = self.to_knx(value)  # pylint: disable=assignment-from-no-return
         updated = False
         if self.payload is None or payload != self.payload:

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -38,6 +38,11 @@ class RemoteValue():
         """Evaluate if remote value is initialized with group address."""
         return bool(self.group_address_state or self.group_address)
 
+    @property
+    def writable(self):
+        """Evaluate if remote value has a group_address set."""
+        return isinstance(self.group_address, GroupAddress)
+
     def has_group_address(self, group_address):
         """Test if device has given group address."""
         return group_address in [self.group_address, self.group_address_state]

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -106,7 +106,7 @@ class RemoteValue():
             self.xknx.logger.info("Setting value of uninitialized device: %s (value: %s)", self.device_name, value)
             return
         if not self.writable:
-            self.xknx.logger.warning("Atempted to set value for non-writable device: %s (value: %s)", self.device_name, value)
+            self.xknx.logger.warning("Attempted to set value for non-writable device: %s (value: %s)", self.device_name, value)
             return
 
         payload = self.to_knx(value)  # pylint: disable=assignment-from-no-return

--- a/xknx/knx/dpt_hvac_contr_mode.py
+++ b/xknx/knx/dpt_hvac_contr_mode.py
@@ -8,7 +8,7 @@ from .dpt_hvac_mode import HVACOperationMode
 
 class DPTHVACContrMode(DPTBase):
     """
-    Abstraction for KNX KNX HVAC mod.
+    Abstraction for KNX HVAC controller mode.
 
     DPT 20.105
     """
@@ -37,11 +37,11 @@ class DPTHVACContrMode(DPTBase):
         cls.test_bytesarray(raw, 1)
         if raw[0] in DPTHVACContrMode.SUPPORTED_MODES:
             return DPTHVACContrMode.SUPPORTED_MODES[raw[0]]
-        raise CouldNotParseKNXIP("Could not parse HVACOperationMode")
+        raise CouldNotParseKNXIP("Could not parse DPTHVACContrMode")
 
     @classmethod
     def to_knx(cls, value):
         """Serialize to KNX/IP raw data."""
         if value in DPTHVACContrMode.SUPPORTED_MODES_INV:
             return (DPTHVACContrMode.SUPPORTED_MODES_INV[value],)
-        raise ConversionError("Could not parse HVACOperationMode", value=value)
+        raise ConversionError("Could not parse DPTHVACContrMode", value=value)

--- a/xknx/knx/dpt_hvac_mode.py
+++ b/xknx/knx/dpt_hvac_mode.py
@@ -107,4 +107,4 @@ class DPTControllerStatus(DPTBase):
             return (0x24,)
         if value == HVACOperationMode.FROST_PROTECTION:
             return (0x28,)
-        raise ConversionError("Could not parse HVACOperationMode", value=value)
+        raise ConversionError("Could not parse DPTControllerStatus", value=value)

--- a/xknx/knx/dpt_hvac_mode.py
+++ b/xknx/knx/dpt_hvac_mode.py
@@ -32,7 +32,7 @@ class HVACOperationMode(Enum):
 
 class DPTHVACMode(DPTBase):
     """
-    Abstraction for KNX KNX HVAC mod.
+    Abstraction for KNX HVAC mode.
 
     DPT 20.102
     """


### PR DESCRIPTION
- Climate().target_temperature is now a property. Its implementation abstracts the usage of a writeable _target_temperature RemoteValueTemp() or a read only one with setpoint_shift.
- ~_base_temperature RemoteValueTemp() is introduced to reflect an immutable base temperature used together with setpoint_shift. It can be read from the bus if the actor supports it.~ (removed - no  known actor supports this)
- Climate().base_temperature property reflects the default temperature (setpoint-shift=0) for the active climate mode.
 
This PR should 
- resolve #183
- resolve #148 

In HA target_temperature_state_address is needed for this PR to work properly. 
Also the corresponding state addresses for climate-modes need to be set now.
https://github.com/home-assistant/home-assistant/pull/21541 