### PR TITLE
Yaml safe load

### DIFF
--- a/test/config_test.py
+++ b/test/config_test.py
@@ -74,7 +74,7 @@ class TestConfig(unittest.TestCase):
              )
         ]
         for yaml_string, expected_conn in test_configs:
-            config = yaml.load(yaml_string)
+            config = yaml.safe_load(yaml_string)
             Config(TestConfig.xknx).parse_connection(config)
             self.assertEqual(TestConfig.xknx.connection_config, expected_conn)
 

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -27,7 +27,7 @@ class Config:
         self.xknx.logger.debug("Reading %s", file)
         try:
             with open(file, 'r') as filehandle:
-                doc = yaml.load(filehandle)
+                doc = yaml.safe_load(filehandle)
                 self.parse_general(doc)
                 self.parse_connection(doc)
                 self.parse_groups(doc)

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -77,17 +77,17 @@ class Device:
             await self.process_group_read(telegram)
 
     async def process_group_read(self, telegram):
-        """Process incoming GROUP RESPONSE telegram."""
+        """Process incoming GroupValueRead telegrams."""
         # The dafault is, that devices dont answer to group reads
 
     async def process_group_response(self, telegram):
-        """Process incoming GROUP RESPONSE telegram."""
+        """Process incoming GroupValueResponse telegrams."""
         # Per default mapped to group write.
         await self.process_group_write(telegram)
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
-        # The dafault is, that devices dont answer to group reads
+        """Process incoming GroupValueWrite telegrams."""
+        # The dafault is, that devices dont process group writes
 
     def get_name(self):
         """Return name of device."""


### PR DESCRIPTION
> from mvandenabeeleletzten on Discord - Montag um 20:07 Uhr:
> Today I started studying the code to implement a light with embedded state (sending state to a state group address instead of reading it), and I got a warning for  the yaml loader. There's an easy fix for this: change line 30 of core/config.py from 'doc = yaml.load(filehandle) ' tot 'doc = yaml.load(filehandle, Loader=yaml.SafeLoader)'. Just wanted to let you guys know...
> 

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation