### PR TITLE
index scene numbers with 1 instead of 0

### DIFF
--- a/test/dpt_scene_number_test.py
+++ b/test/dpt_scene_number_test.py
@@ -1,4 +1,4 @@
-"""Unit test for KNX scaling value."""
+"""Unit test for KNX scene number."""
 import unittest
 
 from xknx.exceptions import ConversionError
@@ -12,18 +12,18 @@ class TestDPTSceneNumber(unittest.TestCase):
 
     def test_value_50(self):
         """Test parsing and streaming of DPTSceneNumber 50."""
-        self.assertEqual(DPTSceneNumber().to_knx(50), (0x32,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x32,)), 50)
+        self.assertEqual(DPTSceneNumber().to_knx(50), (0x31,))
+        self.assertEqual(DPTSceneNumber().from_knx((0x31,)), 50)
 
     def test_value_max(self):
-        """Test parsing and streaming of DPTSceneNumber 63."""
-        self.assertEqual(DPTSceneNumber().to_knx(63), (0x3F,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x3F,)), 63)
+        """Test parsing and streaming of DPTSceneNumber 64."""
+        self.assertEqual(DPTSceneNumber().to_knx(64), (0x3F,))
+        self.assertEqual(DPTSceneNumber().from_knx((0x3F,)), 64)
 
     def test_value_min(self):
         """Test parsing and streaming of DPTSceneNumber 0."""
-        self.assertEqual(DPTSceneNumber().to_knx(0), (0x00,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x00,)), 0)
+        self.assertEqual(DPTSceneNumber().to_knx(1), (0x00,))
+        self.assertEqual(DPTSceneNumber().from_knx((0x00,)), 1)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTSceneNumber with wrong value (underflow)."""

--- a/test/dpt_value_1_ucount_test.py
+++ b/test/dpt_value_1_ucount_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 from xknx.exceptions import ConversionError
-from xknx.knx import DPTSceneNumber, DPTValue1Ucount
+from xknx.knx import DPTValue1Ucount
 
 
 class TestDPTValue1Ucount(unittest.TestCase):

--- a/test/dpt_value_1_ucount_test.py
+++ b/test/dpt_value_1_ucount_test.py
@@ -54,24 +54,3 @@ class TestDPTValue1Ucount(unittest.TestCase):
         """Test parsing of DPTValue1Ucount with wrong value (array containing string)."""
         with self.assertRaises(ConversionError):
             DPTValue1Ucount().from_knx(("0x23"))
-
-
-class TestDPTSceneNumber(unittest.TestCase):
-    """Test class for KNX scene number value."""
-
-    # pylint: disable=too-many-public-methods,invalid-name
-
-    def test_value_50(self):
-        """Test parsing and streaming of DPTSceneNumber 50."""
-        self.assertEqual(DPTSceneNumber().to_knx(50), (0x32,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x32,)), 50)
-
-    def test_value_max(self):
-        """Test parsing and streaming of DPTSceneNumber 63."""
-        self.assertEqual(DPTSceneNumber().to_knx(63), (0x3F,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x3F,)), 63)
-
-    def test_to_knx_max_exceeded(self):
-        """Test parsing of DPTSceneNumber with wrong value (overflow)."""
-        with self.assertRaises(ConversionError):
-            DPTSceneNumber().to_knx(64)

--- a/test/remote_value_scene_number_test.py
+++ b/test/remote_value_scene_number_test.py
@@ -24,13 +24,13 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         """Test to_knx function with normal operation."""
         xknx = XKNX(loop=self.loop)
         remote_value = RemoteValueSceneNumber(xknx)
-        self.assertEqual(remote_value.to_knx(10), DPTArray((0x0A, )))
+        self.assertEqual(remote_value.to_knx(11), DPTArray((0x0A, )))
 
     def test_from_knx(self):
         """Test from_knx function with normal operation."""
         xknx = XKNX(loop=self.loop)
         remote_value = RemoteValueSceneNumber(xknx)
-        self.assertEqual(remote_value.from_knx(DPTArray((0x0A, ))), 10)
+        self.assertEqual(remote_value.from_knx(DPTArray((0x0A, ))), 11)
 
     def test_to_knx_error(self):
         """Test to_knx function with wrong parametern."""
@@ -47,7 +47,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         remote_value = RemoteValueSceneNumber(
             xknx,
             group_address=GroupAddress("1/2/3"))
-        self.loop.run_until_complete(asyncio.Task(remote_value.set(10)))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(11)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
@@ -55,7 +55,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
             Telegram(
                 GroupAddress('1/2/3'),
                 payload=DPTArray((0x0A, ))))
-        self.loop.run_until_complete(asyncio.Task(remote_value.set(11)))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(12)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
@@ -74,7 +74,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
             group_address=GroupAddress("1/2/3"),
             payload=DPTArray((0x0A, )))
         self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
-        self.assertEqual(remote_value.value, 10)
+        self.assertEqual(remote_value.value, 11)
 
     def test_to_process_error(self):
         """Test process errornous telegram."""

--- a/test/scene_test.py
+++ b/test/scene_test.py
@@ -52,7 +52,7 @@ class TestScene(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/1'), payload=DPTArray(0x17)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTArray(0x16)))
 
     def test_do(self):
         """Test running scene with do command."""
@@ -66,7 +66,7 @@ class TestScene(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram,
-                         Telegram(GroupAddress('1/2/1'), payload=DPTArray(0x17)))
+                         Telegram(GroupAddress('1/2/1'), payload=DPTArray(0x16)))
 
     def test_wrong_do(self):
         """Test wrong do command."""

--- a/test/sensor_expose_loop_test.py
+++ b/test/sensor_expose_loop_test.py
@@ -48,7 +48,7 @@ class SensorExposeLoopTest(unittest.TestCase):
             ('ppm', DPTArray((0x00, 0x03)), 0.03),
             ('pressure', DPTArray((0x42, 0xA9, 0x6B, 0x85)), 84.71),
             ('pulse', DPTArray((0x11)), 17),
-            ('scene_number', DPTArray((0x00)), 0),
+            ('scene_number', DPTArray((0x00)), 1),
             ('speed', DPTArray((0x00, 0x00, 0x00, 0x00)), 0),
             ('speed_ms', DPTArray((0x0E, 0xA4)), 34),
             ('string',

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -10,7 +10,7 @@ class Scene(Device):
                  xknx,
                  name,
                  group_address=None,
-                 scene_number=0,
+                 scene_number=1,
                  device_updated_cb=None):
         """Initialize Sceneclass."""
         # pylint: disable=too-many-arguments
@@ -50,7 +50,7 @@ class Scene(Device):
                 self.scene_number)
 
     async def run(self):
-        """Move cover down."""
+        """Activate scene."""
         await self.scene_value.set(self.scene_number)
 
     async def do(self, action):

--- a/xknx/knx/dpt_value_1_ucount.py
+++ b/xknx/knx/dpt_value_1_ucount.py
@@ -63,5 +63,28 @@ class DPTSceneNumber(DPTValue1Ucount):
     DPT 17.001
     """
 
-    value_min = 0
-    value_max = 63
+    value_min = 1
+    value_max = 64
+
+    @classmethod
+    def from_knx(cls, raw):
+        """Parse/deserialize from KNX/IP raw data."""
+        cls.test_bytesarray(raw, 1)
+
+        value = raw[0] + 1
+
+        if not cls._test_boundaries(value):
+            raise ConversionError("Cant parse %s" % cls.__name__, value=value, raw=raw)
+
+        return value
+
+    @classmethod
+    def to_knx(cls, value):
+        """Serialize to KNX/IP raw data."""
+        try:
+            knx_value = int(value) - 1
+            if not cls._test_boundaries(knx_value + 1):
+                raise ValueError
+            return (knx_value,)
+        except ValueError:
+            raise ConversionError("Cant serialize %s" % cls.__name__, value=value)


### PR DESCRIPTION
From the KNX Specifications v2.1

> DPT_SceneControl allows numbering the scene from 0 to 63. KNX Association recommends displaying these scene numbers in ETS(TM), other software and controllers numbered from 1 to 64, this is, with an offset of 1 compared to the actual transmitted value.

It breaks current implementations of `Scene()` devices so I'm not sure if merging this is a good idea or if it would be better to just ignore this. I figured now that the `scene_number` sensor type is merged it is a good time to discuss this.