### PR TITLE
read binary sensors on startup

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -14,12 +14,12 @@ The logic within switches can further handle if a button is pressed once or twic
 ## [](#header-2)Overview
 
 ```python
-binarysensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3', device_class='motion')
+binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', device_class='motion')
 ```
 
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
-* `group_address` is the KNX group address of the sensor device.
+* `group_address_state` is the KNX group address of the sensor device.
 * `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
 ## [](#header-2)Example
@@ -28,7 +28,7 @@ binarysensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3', device_cla
 outlet = Outlet(xknx, 'TestOutlet', group_address='1/2/3')
 xknx.devices.devices.append(outlet)
 
-binarysensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
+binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
 action_on = Action(
     xknx,
     hook='on',
@@ -53,26 +53,26 @@ groups:
 
     binary_sensor:
         Livingroom.Switch_1:
-            group_address: "1/2/7"
+            group_address_state: "1/2/7"
             actions:
               - {target: Livingroom.Outlet_1, method: "on"}
               - {target: Livingroom.Outlet_2, method: "on"}
 
         Livingroom.Switch_2:
-            group_address: "1/2/8"
+            group_address_state: "1/2/8"
             actions:
               - {target: Livingroom.Outlet_1, method: "off"}
               - {target: Livingroom.Outlet_2, method: "off"}
 
         Livingroom.Switch_3:
-            group_address: "1/2/5"
+            group_address_state: "1/2/5"
             actions:
               - {target: Livingroom.Shutter_1, method: up}
               # Only executed if the button was switched twice:
               - {counter: 2, target: Livingroom.Shutter_1, method: short_up}
 
         Livingroom.Switch_4:
-            group_address: "1/2/6"
+            group_address_state: "1/2/6"
             actions:
               - {target: Livingroom.Shutter_1, method: down}
               # Only executed if the button was switched twice:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -51,39 +51,39 @@ groups:
     binary_sensor:
 
         Livingroom.Switch_1:
-            group_address: '1/2/7'
+            group_address_state: '1/2/7'
             actions:
               - {target: Livingroom.Outlet_1, method: 'on'}
               - {target: Livingroom.Outlet_2, counter: 2, method: 'on'}
 
         Livingroom.Switch_2:
-            group_address: '1/2/8'
+            group_address_state: '1/2/8'
             actions:
               - {target: Livingroom.Outlet_1, method: 'off'}
               - {target: Livingroom.Outlet_2, counter: 2, method: 'off'}
 
 
         Livingroom.Switch_3:
-            group_address: '1/2/2'
+            group_address_state: '1/2/2'
             actions:
               - {hook: 'off', target: Livingroom.Shutter_1, method: short_up}
               - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: up} # Pressing more then 2 seconds
 
         Livingroom.Switch_4:
-            group_address: '1/2/3'
+            group_address_state: '1/2/3'
             actions:
               - {hook: 'off', target: Livingroom.Shutter_1, method: short_down}
               - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: down} # Pressing more then 2 seconds
 
 
     binary_sensor_motion_dection:
-        Kitchen.Motion.Sensor: {group_address: '3/0/0', device_class: 'motion'}
-        DiningRoom.Motion.Sensor: {group_address: '3/0/1', device_class: 'motion'}
+        Kitchen.Motion.Sensor: {group_address_state: '3/0/0', device_class: 'motion'}
+        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', device_class: 'motion'}
 
         # Some states are encoded into different bits of the same group_address
         # Defining which bit should be relevant for the binary state via the "significant_bit" option
-        Kitchen.Presence: {group_address: '3/0/2', device_class: 'motion', significant_bit: 2}
-        Kitchen.ThermostatNightMode: {group_address: '3/0/2', device_class: 'motion', significant_bit: 1}
+        Kitchen.Presence: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 2}
+        Kitchen.ThermostatNightMode: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 1}
 
 
     switch:
@@ -125,8 +125,8 @@ groups:
 
 
     sensor:
-        Heating.Valve1: {group_address: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address: '2/0/1', value_type: 'percent'}
-        Some.Other.Value: {group_address: '2/0/2'}
+        Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
+        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
+        Some.Other.Value: {group_address_state: '2/0/2'}
 
 ```

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -41,19 +41,6 @@ Delete automatically installed version:
 rm .homeassistant/deps/lib/python3.5/site-packages/xknx*
 ```
 
-Comment out dependency from xknx.py, otherwise hass would reinstall the xknx library when startup:
-
-````diff
-julius@xxx ~/xknx:$ git diff -U0 home-assistant-plugin/custom_components/xknx.py 
-diff --git a/home-assistant-plugin/custom_components/xknx.py b/home-assistant-plugin/custom_components/xknx.py
-index 7f26c43..0b1e046 100644
---- a/home-assistant-plugin/custom_components/xknx.py
-+++ b/home-assistant-plugin/custom_components/xknx.py
-@@ -39 +39 @@ _LOGGER = logging.getLogger(__name__)
--REQUIREMENTS = ['xknx==0.7.18']
-+# REQUIREMENTS = ['xknx==0.7.18']
-```
-
 Ideally start hass from command line. Export the environment variable PYTHONPATH to your local xknx checkout:
 
 ```bash

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -34,7 +34,7 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
     sensor:
         Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
         Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
-	Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
+	    Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
         Some.Other.Value: {group_address_state: '2/0/3'}
 ```
 

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -12,7 +12,7 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
     sensor = Sensor(
         xknx=xknx,
         name='DiningRoom.Temperatur.Sensor',
-        group_address='6/2/1',
+        group_address_state='6/2/1',
         value_type='float',
         device_class='temperature')
     await sensor2.sync()
@@ -21,7 +21,7 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
-* `group_address` is the KNX group address of the sensor device.
+* `group_address_state` is the KNX group address of the sensor device.
 * `value_type` controls how the value should be rendered in a human readable representation. The attribut may have may have the values `percent`, `temperature`, `illuminance`, `speed_ms` or `current`.
 * `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
@@ -32,10 +32,10 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
 
 ```yaml
     sensor:
-        Heating.Valve1: {group_address: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address: '2/0/1', value_type: 'percent'}
-	Kitchen.Temperature: {group_address: '2/0/2', value_type: 'temperature'}
-        Some.Other.Value: {group_address: '2/0/3'}
+        Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
+        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
+	Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
+        Some.Other.Value: {group_address_state: '2/0/3'}
 ```
 
 ## [](#header-2)Interface
@@ -44,7 +44,7 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
 sensor = Sensor(
         xknx=xknx,
         name='DiningRoom.Temperatur.Sensor',
-        group_address='6/2/1')
+        group_address_state='6/2/1')
 
 await sensor.sync() # Syncs the state. Tries to read the corresponding value from the bus.
 

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -34,7 +34,7 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
     sensor:
         Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
         Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
-	    Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
+        Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
         Some.Other.Value: {group_address_state: '2/0/3'}
 ```
 

--- a/examples/example_powermeter_mqtt.py
+++ b/examples/example_powermeter_mqtt.py
@@ -132,54 +132,54 @@ async def main():
 
     # Generic Types not specifically supported by XKNX
     el_meter_reading_active_energy = Sensor(
-        xknx, 'EL-T-O_MeterReading_ActiveEnergy', group_address='5/6/11', value_type="DPT-13")
+        xknx, 'EL-T-O_MeterReading_ActiveEnergy', group_address_state='5/6/11', value_type="DPT-13")
     xknx.devices.add(el_meter_reading_active_energy)
     el_meter_reading_reactive_energy = Sensor(
-        xknx, 'EL-T-O_MeterReading_ReactiveEnergy', group_address='5/6/16', value_type="DPT-13")
+        xknx, 'EL-T-O_MeterReading_ReactiveEnergy', group_address_state='5/6/16', value_type="DPT-13")
     xknx.devices.add(el_meter_reading_reactive_energy)
 
     # Active Power
     el_total_active_power = Sensor(
-        xknx, 'EL-T-O_TotalActivePower', group_address='5/6/24', value_type="power")
+        xknx, 'EL-T-O_TotalActivePower', group_address_state='5/6/24', value_type="power")
     xknx.devices.add(el_total_active_power)
     el_active_power_l1 = Sensor(
-        xknx, 'EL-T-O_ActivePower_L1', group_address='5/6/25', value_type="power")
+        xknx, 'EL-T-O_ActivePower_L1', group_address_state='5/6/25', value_type="power")
     xknx.devices.add(el_active_power_l1)
     # ...
 
     # Reactive Power
     el_total_reactive_power = Sensor(
-        xknx, 'EL-T-O_TotalReactivePower', group_address='5/6/28', value_type="power")
+        xknx, 'EL-T-O_TotalReactivePower', group_address_state='5/6/28', value_type="power")
     xknx.devices.add(el_total_reactive_power)
     el_reactive_power_l1 = Sensor(
-        xknx, 'EL-T-O_ReactivePower_L1', group_address='5/6/29', value_type="power")
+        xknx, 'EL-T-O_ReactivePower_L1', group_address_state='5/6/29', value_type="power")
     xknx.devices.add(el_reactive_power_l1)
     # ...
 
     # Apparent Power
     el_total_apparent_power = Sensor(
-        xknx, 'EL-T-O_TotalReactivePower', group_address='5/6/32', value_type="power")
+        xknx, 'EL-T-O_TotalReactivePower', group_address_state='5/6/32', value_type="power")
     xknx.devices.add(el_total_apparent_power)
     el_apparent_power_l1 = Sensor(
-        xknx, 'EL-T-O_ApparentPower_L1', group_address='5/6/33', value_type="power")
+        xknx, 'EL-T-O_ApparentPower_L1', group_address_state='5/6/33', value_type="power")
     xknx.devices.add(el_apparent_power_l1)
     # ...
 
     # Current
     el_current_l1 = Sensor(
-        xknx, 'EL-T-O_Current_L1', group_address='5/6/45', value_type="electric_current")
+        xknx, 'EL-T-O_Current_L1', group_address_state='5/6/45', value_type="electric_current")
     xknx.devices.add(el_current_l1)
     # ...
 
     # Voltage
     el_voltage_l1 = Sensor(
-        xknx, 'EL-T-O_Voltage_L1-N', group_address='5/6/48', value_type="electric_potential")
+        xknx, 'EL-T-O_Voltage_L1-N', group_address_state='5/6/48', value_type="electric_potential")
     xknx.devices.add(el_voltage_l1)
     # ...
 
     # Frequency
     el_frequency = Sensor(
-        xknx, 'EL-T-O_Frequency', group_address='5/6/53', value_type="frequency")
+        xknx, 'EL-T-O_Frequency', group_address_state='5/6/53', value_type="frequency")
     xknx.devices.add(el_frequency)
 
     mqttc.connect(BROKER_ADDRESS, 8883, 60)

--- a/examples/example_sensor.py
+++ b/examples/example_sensor.py
@@ -21,7 +21,7 @@ async def main():
     sensor2 = Sensor(
         xknx,
         'DiningRoom.Temperatur.Sensor',
-        group_address='6/2/1',
+        group_address_state='6/2/1',
         value_type='float')
     await sensor2.sync()
     print(sensor2)

--- a/examples/example_sensor.py
+++ b/examples/example_sensor.py
@@ -13,7 +13,7 @@ async def main():
     sensor1 = BinarySensor(
         xknx,
         'DiningRoom.Motion.Sensor',
-        group_address='6/0/2',
+        group_address_state='6/0/2',
         device_class='motion')
     await sensor1.sync()
     print(sensor1)

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -36,12 +36,12 @@ ATTR_DISCOVER_DEVICES = 'devices'
 
 TUNNELING_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_XKNX_LOCAL_IP): cv.string,
+    vol.Optional(CONF_XKNX_LOCAL_IP): cv.string,
     vol.Optional(CONF_PORT): cv.port,
 })
 
 ROUTING_SCHEMA = vol.Schema({
-    vol.Required(CONF_XKNX_LOCAL_IP): cv.string,
+    vol.Optional(CONF_XKNX_LOCAL_IP): cv.string,
 })
 
 EXPOSE_SCHEMA = vol.Schema({

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -11,8 +11,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change
 from homeassistant.helpers.script import Script
 
-REQUIREMENTS = ['xknx==0.10.0']
-
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "xknx"
@@ -38,12 +36,12 @@ ATTR_DISCOVER_DEVICES = 'devices'
 
 TUNNELING_SCHEMA = vol.Schema({
     vol.Required(CONF_HOST): cv.string,
+    vol.Required(CONF_XKNX_LOCAL_IP): cv.string,
     vol.Optional(CONF_PORT): cv.port,
-    vol.Optional(CONF_XKNX_LOCAL_IP): cv.string,
 })
 
 ROUTING_SCHEMA = vol.Schema({
-    vol.Optional(CONF_XKNX_LOCAL_IP): cv.string,
+    vol.Required(CONF_XKNX_LOCAL_IP): cv.string,
 })
 
 EXPOSE_SCHEMA = vol.Schema({

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -22,8 +22,6 @@ CONF_RESET_AFTER = 'reset_after'
 CONF__ACTION = 'turn_off_action'
 
 DEFAULT_NAME = 'XKNX Binary Sensor'
-DEPENDENCIES = ['xknx']
-
 AUTOMATION_SCHEMA = vol.Schema({
     vol.Optional(CONF_HOOK, default=CONF_DEFAULT_HOOK): cv.string,
     vol.Optional(CONF_COUNTER, default=CONF_DEFAULT_COUNTER): cv.port,

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -68,7 +68,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     binary_sensor = xknx.devices.BinarySensor(
         hass.data[DATA_XKNX].xknx,
         name=name,
-        group_address=config.get(CONF_ADDRESS),
+        group_address_state=config.get(CONF_ADDRESS),
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config.get(CONF_SIGNIFICANT_BIT),
         reset_after=config.get(CONF_RESET_AFTER))

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -39,8 +39,6 @@ DEFAULT_NAME = 'XKNX Climate'
 DEFAULT_SETPOINT_SHIFT_STEP = 0.5
 DEFAULT_SETPOINT_SHIFT_MAX = 6
 DEFAULT_SETPOINT_SHIFT_MIN = -6
-DEPENDENCIES = ['xknx']
-
 # Map KNX operation modes to HA modes. This list might not be full.
 OPERATION_MODES = {
     # Map DPT 201.100 HVAC operating modes

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -25,8 +25,6 @@ CONF_INVERT_ANGLE = 'invert_angle'
 
 DEFAULT_TRAVEL_TIME = 25
 DEFAULT_NAME = 'XKNX Cover'
-DEPENDENCIES = ['xknx']
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_MOVE_LONG_ADDRESS): cv.string,

--- a/home-assistant-plugin/custom_components/xknx/light.py
+++ b/home-assistant-plugin/custom_components/xknx/light.py
@@ -30,7 +30,6 @@ DEFAULT_BRIGHTNESS = 255
 DEFAULT_COLOR_TEMP_MODE = 'absolute'
 DEFAULT_MIN_KELVIN = 2700  # 370 mireds
 DEFAULT_MAX_KELVIN = 6000  # 166 mireds
-DEPENDENCIES = ['xknx']
 
 
 class ColorTempModes(Enum):

--- a/home-assistant-plugin/custom_components/xknx/manifest.json
+++ b/home-assistant-plugin/custom_components/xknx/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "knx",
+  "name": "Knx",
+  "documentation": "https://www.home-assistant.io/components/knx",
+  "requirements": [
+    "xknx==0.10.0"
+  ],
+  "dependencies": [],
+  "codeowners": [
+    "@Julius2342"
+  ]
+}

--- a/home-assistant-plugin/custom_components/xknx/manifest.json
+++ b/home-assistant-plugin/custom_components/xknx/manifest.json
@@ -1,5 +1,5 @@
 {
-  "domain": "knx",
+  "domain": "xknx",
   "name": "Knx",
   "documentation": "https://www.home-assistant.io/components/knx",
   "requirements": [

--- a/home-assistant-plugin/custom_components/xknx/notify.py
+++ b/home-assistant-plugin/custom_components/xknx/notify.py
@@ -11,8 +11,6 @@ from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 
 DEFAULT_NAME = 'XKNX Notify'
 
-DEPENDENCIES = ['xknx']
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string

--- a/home-assistant-plugin/custom_components/xknx/scene.py
+++ b/home-assistant-plugin/custom_components/xknx/scene.py
@@ -11,8 +11,6 @@ from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 CONF_SCENE_NUMBER = 'scene_number'
 
 DEFAULT_NAME = 'XKNX SCENE'
-DEPENDENCIES = ['xknx']
-
 PLATFORM_SCHEMA = vol.Schema({
     vol.Required(CONF_PLATFORM): 'knx',
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -43,7 +43,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     sensor = xknx.devices.Sensor(
         hass.data[DATA_XKNX].xknx,
         name=config.get(CONF_NAME),
-        group_address=config.get(CONF_ADDRESS),
+        group_address_state=config.get(CONF_ADDRESS),
         value_type=config.get(CONF_TYPE))
     hass.data[DATA_XKNX].xknx.devices.add(sensor)
     async_add_entities([KNXSensor(sensor)])

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -10,8 +10,6 @@ from homeassistant.helpers.entity import Entity
 from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 
 DEFAULT_NAME = 'XKNX Sensor'
-DEPENDENCIES = ['xknx']
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/home-assistant-plugin/custom_components/xknx/switch.py
+++ b/home-assistant-plugin/custom_components/xknx/switch.py
@@ -11,8 +11,6 @@ from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 CONF_STATE_ADDRESS = 'state_address'
 
 DEFAULT_NAME = 'XKNX Switch'
-DEPENDENCIES = ['xknx']
-
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,

--- a/test/binary_sensor_test.py
+++ b/test/binary_sensor_test.py
@@ -88,7 +88,7 @@ class TestBinarySensor(unittest.TestCase):
         switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
         xknx.devices.add(switch)
 
-        binary_sensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
+        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
         action_on = Action(
             xknx,
             hook='on',
@@ -135,7 +135,7 @@ class TestBinarySensor(unittest.TestCase):
     def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
         xknx = XKNX(loop=self.loop)
-        binary_sensor = BinarySensor(xknx, 'Warning', group_address='1/2/3')
+        binary_sensor = BinarySensor(xknx, 'Warning', group_address_state='1/2/3')
         telegram = Telegram(GroupAddress('1/2/3'), payload=DPTArray((0x1, 0x2, 0x3)))
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram)))
@@ -171,7 +171,7 @@ class TestBinarySensor(unittest.TestCase):
         """Test after_update_callback after state of switch was changed."""
         # pylint: disable=no-self-use
         xknx = XKNX(loop=self.loop)
-        switch = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
+        switch = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
 
         after_update_callback = Mock()
 
@@ -191,7 +191,7 @@ class TestBinarySensor(unittest.TestCase):
     def test_counter(self):
         """Test counter functionality."""
         xknx = XKNX(loop=self.loop)
-        switch = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
+        switch = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
         with patch('time.time') as mock_time:
             mock_time.return_value = 1517000000.0
             self.assertEqual(switch.bump_and_get_counter(BinarySensorState.ON), 1)
@@ -218,9 +218,7 @@ class TestBinarySensor(unittest.TestCase):
     # STATE ADDRESSES
     #
     def test_state_addresses(self):
-        """Test expose sensor returns empty list as state addresses."""
+        """Test binary sensor returns state address as list."""
         xknx = XKNX(loop=self.loop)
-        binary_sensor = BinarySensor(xknx, 'TestInput', group_address='1/2/3', group_address_state='1/2/4')
+        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/4')
         self.assertEqual(binary_sensor.state_addresses(), [GroupAddress('1/2/4')])
-        binary_sensor2 = BinarySensor(xknx, 'TestInput', group_address='1/2/3')
-        self.assertEqual(binary_sensor2.state_addresses(), [])

--- a/test/binary_sensor_test.py
+++ b/test/binary_sensor_test.py
@@ -222,3 +222,6 @@ class TestBinarySensor(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/4')
         self.assertEqual(binary_sensor.state_addresses(), [GroupAddress('1/2/4')])
+
+        binary_sensor2 = BinarySensor(xknx, 'TestInput')
+        self.assertEqual(binary_sensor2.state_addresses(), [])

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -345,7 +345,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Heating.Valve1'],
             Sensor(TestConfig.xknx,
                    'Heating.Valve1',
-                   group_address='2/0/0',
+                   group_address_state='2/0/0',
                    value_type='percent',
                    device_updated_cb=TestConfig.xknx.devices.device_updated))
 
@@ -355,7 +355,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Kitchen.Temperature'],
             Sensor(TestConfig.xknx,
                    'Kitchen.Temperature',
-                   group_address='2/0/2',
+                   group_address_state='2/0/2',
                    value_type='temperature',
                    device_updated_cb=TestConfig.xknx.devices.device_updated))
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -328,7 +328,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Livingroom.Switch_1'],
             BinarySensor(TestConfig.xknx,
                          'Livingroom.Switch_1',
-                         group_address='1/2/7',
+                         group_address_state='1/2/7',
                          actions=[
                              Action(TestConfig.xknx,
                                     target="Livingroom.Outlet_1",
@@ -376,7 +376,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['DiningRoom.Motion.Sensor'],
             BinarySensor(TestConfig.xknx,
                          'DiningRoom.Motion.Sensor',
-                         group_address='3/0/1',
+                         group_address_state='3/0/1',
                          device_class='motion',
                          device_updated_cb=TestConfig.xknx.devices.device_updated))
 
@@ -386,7 +386,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Kitchen.Presence'],
             BinarySensor(TestConfig.xknx,
                          'Kitchen.Presence',
-                         group_address='3/0/2',
+                         group_address_state='3/0/2',
                          significant_bit=2,
                          device_class='motion',
                          device_updated_cb=TestConfig.xknx.devices.device_updated))

--- a/test/devices_test.py
+++ b/test/devices_test.py
@@ -77,13 +77,13 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=2)
         devices.add(sensor1)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=3)
         devices.add(sensor2)
 
@@ -114,13 +114,13 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=2)
         devices.add(sensor1)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=3)
         devices.add(sensor2)
 
@@ -148,14 +148,14 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=2)
         devices.add(sensor1)
         self.assertEqual(len(devices), 2)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address='3/0/1',
+                               group_address_state='3/0/1',
                                significant_bit=3)
         devices.add(sensor2)
         self.assertEqual(len(devices), 3)

--- a/test/sensor_expose_loop_test.py
+++ b/test/sensor_expose_loop_test.py
@@ -77,7 +77,7 @@ class SensorExposeLoopTest(unittest.TestCase):
                 sensor = Sensor(
                     xknx,
                     'TestSensor_%s' % value_type,
-                    group_address='1/1/1',
+                    group_address_state='1/1/1',
                     value_type=value_type
                 )
                 expose = ExposeSensor(

--- a/test/sensor_expose_loop_test.py
+++ b/test/sensor_expose_loop_test.py
@@ -124,7 +124,7 @@ class SensorExposeLoopTest(unittest.TestCase):
                 sensor = BinarySensor(
                     xknx,
                     'TestSensor_%s' % value_type,
-                    group_address='1/1/1'
+                    group_address_state='1/1/1'
                 )
                 expose = ExposeSensor(
                     xknx,

--- a/test/sensor_test.py
+++ b/test/sensor_test.py
@@ -29,7 +29,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="percent")
         sensor.sensor_value.payload = DPTArray((0x40,))
 
@@ -43,7 +43,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="speed_ms")
         sensor.sensor_value.payload = DPTArray((0x00, 0x1b,))
 
@@ -57,7 +57,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="temperature")
         sensor.sensor_value.payload = DPTArray((0x0c, 0x1a))
 
@@ -71,7 +71,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="humidity")
         sensor.sensor_value.payload = DPTArray((0x0e, 0x73))
 
@@ -85,7 +85,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="power")
         sensor.sensor_value.payload = DPTArray((0x43, 0xC6, 0x80, 00))
 
@@ -99,7 +99,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="electric_potential")
         sensor.sensor_value.payload = DPTArray((0x43, 0x65, 0xE3, 0xD7))
 
@@ -116,7 +116,7 @@ class TestSensor(unittest.TestCase):
             xknx,
             'TestSensor',
             value_type="temperature",
-            group_address='1/2/3')
+            group_address_state='1/2/3')
 
         self.loop.run_until_complete(asyncio.Task(sensor.sync(False)))
 
@@ -136,7 +136,7 @@ class TestSensor(unittest.TestCase):
             xknx,
             'TestSensor',
             value_type='temperature',
-            group_address='1/2/3')
+            group_address_state='1/2/3')
         self.assertTrue(sensor.has_group_address(GroupAddress('1/2/3')))
         self.assertFalse(sensor.has_group_address(GroupAddress('1/2/4')))
 
@@ -150,7 +150,7 @@ class TestSensor(unittest.TestCase):
             xknx,
             'TestSensor',
             value_type='temperature',
-            group_address='1/2/3')
+            group_address_state='1/2/3')
         self.assertEqual(sensor.state_addresses(), [GroupAddress('1/2/3')])
 
     #
@@ -163,7 +163,7 @@ class TestSensor(unittest.TestCase):
             xknx,
             'TestSensor',
             value_type='temperature',
-            group_address='1/2/3')
+            group_address_state='1/2/3')
 
         telegram = Telegram(GroupAddress('1/2/3'))
         telegram.payload = DPTArray((0x06, 0xa0))
@@ -178,7 +178,7 @@ class TestSensor(unittest.TestCase):
         sensor = Sensor(
             xknx,
             'TestSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type="temperature")
 
         after_update_callback = Mock()

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -56,11 +56,11 @@ class TestStringRepresentations(unittest.TestCase):
         binary_sensor = BinarySensor(
             xknx,
             name='Fnord',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             device_class='motion')
         self.assertEqual(
             str(binary_sensor),
-            '<BinarySensor group_address="GroupAddress("1/2/3")" name="Fnord" state="BinarySensorState.OFF"/>')
+            '<BinarySensor group_address_state="GroupAddress("1/2/3")" name="Fnord" state="BinarySensorState.OFF"/>')
 
     def test_climate(self):
         """Test string representation of climate object."""

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -203,7 +203,7 @@ class TestStringRepresentations(unittest.TestCase):
         sensor = Sensor(
             xknx,
             name='MeinSensor',
-            group_address='1/2/3',
+            group_address_state='1/2/3',
             value_type='percent')
         self.assertEqual(
             str(sensor),

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -118,9 +118,9 @@ groups:
         AlarmWindow: {group_address: '2/7/1', group_address_state: '2/7/2'}
 
     sensor:
-        Heating.Valve1: {group_address: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address: '2/0/1', value_type: 'percent'}
-        Kitchen.Temperature: {group_address: '2/0/2', value_type: 'temperature'}
+        Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
+        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
+        Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
 
     expose_sensor:
         Outside.Temperature: {group_address: '2/0/3', value_type: 'temperature'}

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -11,39 +11,39 @@ groups:
     binary_sensor:
 
         Livingroom.Switch_1:
-            group_address: '1/2/7'
+            group_address_state: '1/2/7'
             actions:
               - {target: Livingroom.Outlet_1, method: 'on'}
               - {target: Livingroom.Outlet_2, counter: 2, method: 'on'}
 
         Livingroom.Switch_2:
-            group_address: '1/2/8'
+            group_address_state: '1/2/8'
             actions:
               - {target: Livingroom.Outlet_1, method: 'off'}
               - {target: Livingroom.Outlet_2, counter: 2, method: 'off'}
 
 
         Livingroom.Switch_3:
-            group_address: '1/2/2'
+            group_address_state: '1/2/2'
             actions:
               - {hook: 'off', target: Livingroom.Shutter_1, method: short_up}
               - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: up} # Pressing more then 2 seconds
 
         Livingroom.Switch_4:
-            group_address: '1/2/3'
+            group_address_state: '1/2/3'
             actions:
               - {hook: 'off', target: Livingroom.Shutter_1, method: short_down}
               - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: down} # Pressing more then 2 seconds
 
 
     binary_sensor_motion_dection:
-        Kitchen.Motion.Sensor: {group_address: '3/0/0', device_class: 'motion'}
-        DiningRoom.Motion.Sensor: {group_address: '3/0/1', device_class: 'motion'}
+        Kitchen.Motion.Sensor: {group_address_state: '3/0/0', device_class: 'motion'}
+        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', device_class: 'motion'}
 
         # Some states are encoded into different bits of the same group_address
         # Defining which bit should be relevant for the binary state via the "significant_bit" option
-        Kitchen.Presence: {group_address: '3/0/2', device_class: 'motion', significant_bit: 2}
-        Kitchen.ThermostatNightMode: {group_address: '3/0/2', device_class: 'motion', significant_bit: 1}
+        Kitchen.Presence: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 2}
+        Kitchen.ThermostatNightMode: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 1}
 
 
     switch:

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -37,7 +37,6 @@ class BinarySensor(Device):
     def __init__(self,
                  xknx,
                  name,
-                 group_address=None,
                  group_address_state=None,
                  device_class=None,
                  significant_bit=1,
@@ -47,8 +46,6 @@ class BinarySensor(Device):
         """Initialize BinarySensor class."""
         # pylint: disable=too-many-arguments
         super(BinarySensor, self).__init__(xknx, name, device_updated_cb)
-        if isinstance(group_address, (str, int)):
-            group_address = GroupAddress(group_address)
         if isinstance(group_address_state, (str, int)):
             group_address_state = GroupAddress(group_address_state)
         if not isinstance(significant_bit, int):
@@ -56,7 +53,6 @@ class BinarySensor(Device):
         if actions is None:
             actions = []
 
-        self.group_address = group_address
         self.group_address_state = group_address_state
         self.device_class = device_class
         self.significant_bit = significant_bit
@@ -71,8 +67,6 @@ class BinarySensor(Device):
     @classmethod
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
-        group_address = \
-            config.get('group_address')
         group_address_state = \
             config.get('group_address_state')
         device_class = \
@@ -88,7 +82,6 @@ class BinarySensor(Device):
 
         return cls(xknx,
                    name,
-                   group_address=group_address,
                    group_address_state=group_address_state,
                    device_class=device_class,
                    significant_bit=significant_bit,
@@ -96,7 +89,7 @@ class BinarySensor(Device):
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""
-        return group_address in [self.group_address, self.group_address_state]
+        return group_address in [self.group_address_state]
 
     def state_addresses(self):
         """Return group addresses which should be requested to sync state."""
@@ -166,8 +159,8 @@ class BinarySensor(Device):
 
     def __str__(self):
         """Return object as readable string."""
-        return '<BinarySensor group_address="{0}" name="{1}" state="{2}"/>' \
-            .format(self.group_address.__repr__(), self.name, self.state)
+        return '<BinarySensor group_address_state="{0}" name="{1}" state="{2}"/>' \
+            .format(self.group_address_state.__repr__(), self.name, self.state)
 
     def __eq__(self, other):
         """Equal operator."""

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -16,7 +16,7 @@ class Sensor(Device):
     def __init__(self,
                  xknx,
                  name,
-                 group_address=None,
+                 group_address_state=None,
                  value_type=None,
                  device_updated_cb=None):
         """Initialize Sensor class."""
@@ -26,7 +26,7 @@ class Sensor(Device):
         self.sensor_value = None
         self.sensor_value = RemoteValueSensor(
             xknx,
-            group_address_state=group_address,
+            group_address_state=group_address_state,
             device_name=self.name,
             after_update_cb=self.after_update,
             value_type=value_type)
@@ -34,14 +34,14 @@ class Sensor(Device):
     @classmethod
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
-        group_address = \
-            config.get('group_address')
+        group_address_state = \
+            config.get('group_address_state')
         value_type = \
             config.get('value_type')
 
         return cls(xknx,
                    name,
-                   group_address=group_address,
+                   group_address_state=group_address_state,
                    value_type=value_type)
 
     def has_group_address(self, group_address):


### PR DESCRIPTION
- rebased HA plugin from HA 0.92.0 (mainfest.json)
- removed group_address form BinarySensor in favor for group_address_state
- replaced group_address in Sensor with group_address_state

Sensor and BinarySensor now have `group_address_state` as their only group address attributes as they are read only devices. With this change binary sensors are read on startup ( #140 ).

This resolves #103 