### PR TITLE
require `type` for HA sensor configuration

### DIFF
--- a/docs/light.md
+++ b/docs/light.md
@@ -12,6 +12,7 @@ Expected datapoint types for light functions and their corresponding state addre
 - switch: DPT 1.001
 - brightness: DPT 5.001
 - color: DPT 232.600
+- rgbw: DPT 251.600
 - tunable_white: DPT 5.001
 - color_temperature: DPT 7.600
 
@@ -68,6 +69,8 @@ light = Light(xknx,
               group_address_brightness_state='1/2/6',
               group_address_color='1/2/7',
               group_address_color_state='1/2/8',
+              group_address_rgbw='1/2/13',
+              group_address_rgbw_state='1/2/14',
               group_address_tunable_white='1/2/9',
               group_address_tunable_white_state='1/2/10',
               group_address_color_temperature='1/2/11',
@@ -84,6 +87,9 @@ await light.set_brightness(23)
 
 # Set color
 await light.set_color((20, 70,200))
+
+# Set rgbw color
+await light.set_color((20,70,200), 30)
 
 # Set relative color temperature (percent)
 await set_tunable_white(25)
@@ -104,6 +110,7 @@ print(light.supports_brightness)
 print(light.current_brightness)
 print(light.supports_color)
 print(light.current_color)
+print(light.supports_rgbw)
 print(light.supports_tunable_white)
 print(light.current_tunable_white)
 print(light.supports_color_temperature)

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -63,14 +63,14 @@ def async_add_entities_discovery(hass, discovery_info, async_add_entities):
 @callback
 def async_add_entities_config(hass, config, async_add_entities):
     """Set up binary senor for KNX platform configured within platform."""
-    name = config.get(CONF_NAME)
+    name = config[CONF_NAME]
     import xknx
     binary_sensor = xknx.devices.BinarySensor(
         hass.data[DATA_XKNX].xknx,
         name=name,
-        group_address_state=config.get(CONF_ADDRESS),
+        group_address_state=config[CONF_ADDRESS],
         device_class=config.get(CONF_DEVICE_CLASS),
-        significant_bit=config.get(CONF_SIGNIFICANT_BIT),
+        significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER))
     hass.data[DATA_XKNX].xknx.devices.add(binary_sensor)
 
@@ -78,9 +78,9 @@ def async_add_entities_config(hass, config, async_add_entities):
     automations = config.get(CONF_AUTOMATION)
     if automations is not None:
         for automation in automations:
-            counter = automation.get(CONF_COUNTER)
-            hook = automation.get(CONF_HOOK)
-            action = automation.get(CONF_ACTION)
+            counter = automation[CONF_COUNTER]
+            hook = automation[CONF_HOOK]
+            action = automation[CONF_ACTION]
             entity.automations.append(KNXAutomation(
                 hass=hass, device=binary_sensor, hook=hook,
                 action=action, counter=counter))

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -112,7 +112,7 @@ def async_add_entities_config(hass, config, async_add_entities):
 
     climate_mode = xknx.devices.ClimateMode(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME) + " Mode",
+        name=config[CONF_NAME] + " Mode",
         group_address_operation_mode=config.get(CONF_OPERATION_MODE_ADDRESS),
         group_address_operation_mode_state=config.get(
             CONF_OPERATION_MODE_STATE_ADDRESS),
@@ -136,7 +136,7 @@ def async_add_entities_config(hass, config, async_add_entities):
 
     climate = xknx.devices.Climate(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
+        name=config[CONF_NAME],
         group_address_temperature=config[CONF_TEMPERATURE_ADDRESS],
         group_address_target_temperature=config.get(
             CONF_TARGET_TEMPERATURE_ADDRESS),
@@ -145,9 +145,9 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address_setpoint_shift=config.get(CONF_SETPOINT_SHIFT_ADDRESS),
         group_address_setpoint_shift_state=config.get(
             CONF_SETPOINT_SHIFT_STATE_ADDRESS),
-        setpoint_shift_step=config.get(CONF_SETPOINT_SHIFT_STEP),
-        setpoint_shift_max=config.get(CONF_SETPOINT_SHIFT_MAX),
-        setpoint_shift_min=config.get(CONF_SETPOINT_SHIFT_MIN),
+        setpoint_shift_step=config[CONF_SETPOINT_SHIFT_STEP],
+        setpoint_shift_max=config[CONF_SETPOINT_SHIFT_MAX],
+        setpoint_shift_min=config[CONF_SETPOINT_SHIFT_MIN],
         group_address_on_off=config.get(CONF_ON_OFF_ADDRESS),
         group_address_on_off_state=config.get(CONF_ON_OFF_STATE_ADDRESS),
         min_temp=config.get(CONF_MIN_TEMP),

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -67,7 +67,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     import xknx
     cover = xknx.devices.Cover(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
+        name=config[CONF_NAME],
         group_address_long=config.get(CONF_MOVE_LONG_ADDRESS),
         group_address_short=config.get(CONF_MOVE_SHORT_ADDRESS),
         group_address_position_state=config.get(
@@ -75,10 +75,10 @@ def async_add_entities_config(hass, config, async_add_entities):
         group_address_angle=config.get(CONF_ANGLE_ADDRESS),
         group_address_angle_state=config.get(CONF_ANGLE_STATE_ADDRESS),
         group_address_position=config.get(CONF_POSITION_ADDRESS),
-        travel_time_down=config.get(CONF_TRAVELLING_TIME_DOWN),
-        travel_time_up=config.get(CONF_TRAVELLING_TIME_UP),
-        invert_position=config.get(CONF_INVERT_POSITION),
-        invert_angle=config.get(CONF_INVERT_ANGLE))
+        travel_time_down=config[CONF_TRAVELLING_TIME_DOWN],
+        travel_time_up=config[CONF_TRAVELLING_TIME_UP],
+        invert_position=config[CONF_INVERT_POSITION],
+        invert_angle=config[CONF_INVERT_ANGLE])
 
     hass.data[DATA_XKNX].xknx.devices.add(cover)
     async_add_entities([KNXCover(cover)])

--- a/home-assistant-plugin/custom_components/xknx/notify.py
+++ b/home-assistant-plugin/custom_components/xknx/notify.py
@@ -43,8 +43,8 @@ def async_get_service_config(hass, config):
     import xknx
     notification = xknx.devices.Notification(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
-        group_address=config.get(CONF_ADDRESS))
+        name=config[CONF_NAME],
+        group_address=config[CONF_ADDRESS])
     hass.data[DATA_XKNX].xknx.devices.add(notification)
     return KNXNotificationService([notification, ])
 

--- a/home-assistant-plugin/custom_components/xknx/scene.py
+++ b/home-assistant-plugin/custom_components/xknx/scene.py
@@ -44,9 +44,9 @@ def async_add_entities_config(hass, config, async_add_entities):
     import xknx
     scene = xknx.devices.Scene(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
-        group_address=config.get(CONF_ADDRESS),
-        scene_number=config.get(CONF_SCENE_NUMBER))
+        name=config[CONF_NAME],
+        group_address=config[CONF_ADDRESS],
+        scene_number=config[CONF_SCENE_NUMBER])
     hass.data[DATA_XKNX].xknx.devices.add(scene)
     async_add_entities([KNXScene(scene)])
 

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -13,7 +13,7 @@ DEFAULT_NAME = 'XKNX Sensor'
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_TYPE): cv.string,
+    vol.Required(CONF_TYPE): cv.string,
 })
 
 
@@ -42,9 +42,9 @@ def async_add_entities_config(hass, config, async_add_entities):
     import xknx
     sensor = xknx.devices.Sensor(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
-        group_address_state=config.get(CONF_ADDRESS),
-        value_type=config.get(CONF_TYPE))
+        name=config[CONF_NAME],
+        group_address_state=config[CONF_ADDRESS],
+        value_type=config[CONF_TYPE])
     hass.data[DATA_XKNX].xknx.devices.add(sensor)
     async_add_entities([KNXSensor(sensor)])
 

--- a/home-assistant-plugin/custom_components/xknx/switch.py
+++ b/home-assistant-plugin/custom_components/xknx/switch.py
@@ -43,8 +43,8 @@ def async_add_entities_config(hass, config, async_add_entities):
     import xknx
     switch = xknx.devices.Switch(
         hass.data[DATA_XKNX].xknx,
-        name=config.get(CONF_NAME),
-        group_address=config.get(CONF_ADDRESS),
+        name=config[CONF_NAME],
+        group_address=config[CONF_ADDRESS],
         group_address_state=config.get(CONF_STATE_ADDRESS))
     hass.data[DATA_XKNX].xknx.devices.add(switch)
     async_add_entities([KNXSwitch(switch)])


### PR DESCRIPTION
- require `type` for HA sensor
- conf[] notation instead of conf.get() for required and default configuration fields

None for `type` is not supported (anymore?). We would get `raise ConversionError("invalid value type", value_type=value_type, device_name=device_name)` 