### PR TITLE
Fix some documentation issues

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -7,7 +7,7 @@ Binary Sensor
 
 Binary sensors which have either the state "on" or "off". Binary sensors could be e.g. a switch in the wall (the thing you press on when switching on the light) or a motion detector. 
 
-Switches are mainly intended to act on input, which means to execute so called `Actions`. An action can be the switching of an outlet or light or the moving of a cover.
+Switches are mainly intended to act on input, which means to execute so called `Actions`. An action can be toggling a switch or a light or the moving of a cover.
 
 The logic within switches can further handle if a button is pressed once or twice - and trigger different actions. Use the attribute `counter` for this purpose.
 
@@ -25,10 +25,10 @@ binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', devi
 ## [](#header-2)Example
 
 ```python
-outlet = Outlet(xknx, 'TestOutlet', group_address='1/2/3')
+outlet = Switch(xknx, 'TestOutlet', group_address='1/2/3')
 xknx.devices.devices.append(outlet)
 
-binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
+binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='2/3/4')
 action_on = Action(
     xknx,
     hook='on',

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -27,7 +27,7 @@ print("Current temperature: ", climate.temperature)
 
 ## [](#header-2)Configuration via **xknx.yaml**
 
-Switches are usually configured via [`xknx.yaml`](/configuration):
+Climate devices are usually configured via [`xknx.yaml`](/configuration):
 
 ```yaml
 groups:

--- a/docs/light.md
+++ b/docs/light.md
@@ -32,7 +32,7 @@ await xknx.devices['TestLight'].set_brightness(23)
 
 ## [](#header-2)Configuration via **xknx.yaml**
 
-Outlets are usually configured via [`xknx.yaml`](/configuration):
+Lights are usually configured via [`xknx.yaml`](/configuration):
 
 ```yaml
 groups:

--- a/docs/time.md
+++ b/docs/time.md
@@ -6,12 +6,12 @@ layout: default
 
 ## [](#header-2)Overview
 
-XKNX provides the possibility to send the local time to the KNX bus in regular intervals. This can be used to display the time within [KNX touch sensors](https://katalog.gira.de/en/datenblatt.html?id=638294) or for KNX automation schemes programmed with the ETS.
+XKNX provides the possibility to send the local time, date or both combined to the KNX bus in regular intervals. This can be used to display the time within [KNX touch sensors](https://katalog.gira.de/en/datenblatt.html?id=638294) or for KNX automation schemes programmed with the ETS.
 
 ## [](#header-2)Example
 
 ```python
-time = Time(xknx, 'TimeTest', group_address='1/2/3')
+time = DateTime(xknx, 'TimeTest', group_address='1/2/3')
 xknx.devices.add(time)
 
 # Sending time to knx bus
@@ -34,11 +34,12 @@ When XKNX is started in [daemon mode](/xknx), with START_STATE_UPDATER enabled, 
 
 ```python
 import asyncio
-from xknx import XKNX, Time
+from xknx import XKNX
+from xknx.devices import DateTime
 
 async def main():
     xknx = XKNX()
-    time = Time(xknx, 'TimeTest', group_address='1/2/3')
+    time = DateTime(xknx, 'TimeTest', group_address='1/2/3')
     xknx.devices.add(time)
     print("Sending time to KNX bus every hour")
     await xknx.start(daemon_mode=True, state_updater=True)
@@ -54,10 +55,11 @@ loop.close()
 
 
 ```python
-from xknx import XKNX,Time
+from xknx import XKNX
+from xknx.devices import DateTime, DateTimeBroadcastType
 
 xknx = XKNX()
-time = Time(xknx, 'TimeTest', group_address='1/2/3')
+time = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type=DateTimeBroadcastType.TIME)
 
 # Sending Time to KNX bus 
 await time.sync()

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -68,13 +68,13 @@ The XKNX may keep all devices in a local storage named `devices`. All devices ma
 Example:
 
 ```python
-outlet = Outlet(xknx,
-                name='TestOutlet',
+switch = Switch(xknx,
+                name='TestSwitch',
                 group_address='1/1/11')
-xknx.devices.add(outlet)
+xknx.devices.add(switch)
 
-await xknx.devices['TestOutlet'].set_on()
-await xknx.devices['TestOutlet'].set_off()
+await xknx.devices['TestSwitch'].set_on()
+await xknx.devices['TestSwitch'].set_off()
 ```
 
 
@@ -104,7 +104,7 @@ For all devices stored in the `devices` storage (see [above](#devices)) a callba
 
 ```python
 import asyncio
-from xknx import XKNX, Outlet
+from xknx import XKNX, Switch
 
 
 async def device_updated_cb(device):
@@ -113,10 +113,10 @@ async def device_updated_cb(device):
 
 async def main():
     xknx = XKNX(device_updated_cb=device_updated_cb)
-    outlet = Outlet(xknx,
-                    name='TestOutlet',
+    switch = Switch(xknx,
+                    name='TestSwitch',
                     group_address='1/1/11')
-    xknx.devices.add(outlet)
+    xknx.devices.add(switch)
 
     await xknx.start(daemon_mode=True)
 

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -104,7 +104,8 @@ For all devices stored in the `devices` storage (see [above](#devices)) a callba
 
 ```python
 import asyncio
-from xknx import XKNX, Switch
+from xknx import XKNX
+from xknx.devices import Switch
 
 
 async def device_updated_cb(device):


### PR DESCRIPTION
- deprecated Outlet() device was still in documentation
- wrong imports in examples

related issue: #150 