### PR TITLE
comments and documentation and unit fix

### DIFF
--- a/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
+++ b/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
@@ -53,12 +53,6 @@ class Row():
             content = getattr(self, index)
             return "| " + content.ljust(Row.column_width[index] + 1)
 
-        # return (_format_column_ljust("value_type") +
-        #         _format_column_ljust("unit") +
-        #         _format_column_ljust("dpt_number") +
-        #         _format_column_ljust("dpt_size") +
-        #         # _format_column_ljust("dpt_range") +
-        #         "|")
         _row = ""
         for column in COLUMN_ORDER:
             _row += _format_column_ljust(column)
@@ -127,13 +121,6 @@ def table_delimiter():
             _row += table_delimiter_center(_cell_width)
     _row += "|"
     return _row
-
-    # return (table_delimiter_ljust(Row.column_width["value_type"]) +
-    #         table_delimiter_ljust(Row.column_width["unit"]) +
-    #         table_delimiter_rjust(Row.column_width["dpt_number"]) +
-    #         table_delimiter_rjust(Row.column_width["dpt_size"]) +
-    #         # table_delimiter_center(Row.column_width["dpt_range"]) +
-    #         "|")
 
 
 def print_table():

--- a/test/knx_tests/dpt_1byte_signed_test.py
+++ b/test/knx_tests/dpt_1byte_signed_test.py
@@ -52,6 +52,6 @@ class TestDPTRelativeValue(unittest.TestCase):
 
     def test_unit(self):
         """Test unit of 1 byte relative value objects."""
-        self.assertEqual(DPTSignedRelativeValue.unit, 'counter pulses')
+        self.assertEqual(DPTSignedRelativeValue.unit, '')
         self.assertEqual(DPTPercentV8.unit, '%')
         self.assertEqual(DPTValue1Count.unit, 'counter pulses')

--- a/xknx/knx/dpt_1byte_signed.py
+++ b/xknx/knx/dpt_1byte_signed.py
@@ -9,12 +9,12 @@ class DPTSignedRelativeValue(DPTBase):
     """
     Abstraction for KNX 1 Byte "1-octet Signed Relative Value".
 
-    DPT 6.010 and 6.001
+    DPT 6.***
     """
 
     value_min = -128
     value_max = 127
-    unit = "counter pulses"
+    unit = ""
     payload_length = 1
 
     @classmethod

--- a/xknx/knx/dpt_2byte_float.py
+++ b/xknx/knx/dpt_2byte_float.py
@@ -13,7 +13,7 @@ class DPT2ByteFloat(DPTBase):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
-    DPT 9.xxx
+    DPT 9.***
     """
 
     value_min = -671088.64

--- a/xknx/knx/dpt_2byte_uint.py
+++ b/xknx/knx/dpt_2byte_uint.py
@@ -11,7 +11,7 @@ class DPT2ByteUnsigned(DPTBase):
 
     Contains smaller counters, timers  etc.
 
-    DPT 7.xxx
+    DPT 7.***
     """
 
     value_min = 0

--- a/xknx/knx/dpt_4byte_float.py
+++ b/xknx/knx/dpt_4byte_float.py
@@ -20,7 +20,7 @@ class DPT4ByteFloat(DPTBase):
     The negative minimum finite float literal is -3.40282347e+38f.
     No value range are defined for DPTs 14.000-079.
 
-    DPT 14.xxx
+    DPT 14.***
     """
 
     unit = ""

--- a/xknx/knx/dpt_4byte_int.py
+++ b/xknx/knx/dpt_4byte_int.py
@@ -17,7 +17,7 @@ class DPT4ByteUnsigned(DPTBase):
     """
     Abstraction for KNX 4 Byte "32-bit unsigned".
 
-    DPT 12.x
+    DPT 12.***
     """
 
     value_min = 0
@@ -59,7 +59,7 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     """
     Abstraction for KNX 4 Byte "32-bit signed".
 
-    DPT 13.x
+    DPT 13.***
     """
 
     value_min = -2147483648


### PR DESCRIPTION
- removed some comments 
- dpt docstrings have same scheme now (eg. DPT 6.***) to extract it with the sensor_table_generator
- DPT 6.*** should have no   unit - "counter pulses" is 6.010