### PR TITLE
Optionally disable reading (GroupValueRead) for sensor and binary_sensor

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -20,6 +20,9 @@ binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', devi
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
 * `group_address_state` is the KNX group address of the sensor device.
+* `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
+* `significant_bit` Defining which bit should be relevant for the binary state. Defaults to `1`
+* `reset_after` may be used to reset the internal state to `OFF` again after given time in ms. Defaults to `None`
 * `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
 ## [](#header-2)Example

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -13,6 +13,7 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
         xknx=xknx,
         name='DiningRoom.Temperatur.Sensor',
         group_address_state='6/2/1',
+        sync_state=True,
         value_type='float',
         device_class='temperature')
     await sensor2.sync()
@@ -22,6 +23,7 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
 * `group_address_state` is the KNX group address of the sensor device.
+* `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 * `value_type` controls how the value should be rendered in a human readable representation. The attribut may have may have the values `percent`, `temperature`, `illuminance`, `speed_ms` or `current`.
 * `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
@@ -33,7 +35,7 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
 ```yaml
     sensor:
         Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
+        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent', sync_state: False}
         Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
         Some.Other.Value: {group_address_state: '2/0/3'}
 ```

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -11,6 +11,7 @@ from . import ATTR_DISCOVER_DEVICES, DATA_XKNX, KNXAutomation
 
 CONF_SIGNIFICANT_BIT = 'significant_bit'
 CONF_DEFAULT_SIGNIFICANT_BIT = 1
+CONF_SYNC_STATE = 'sync_state'
 CONF_AUTOMATION = 'automation'
 CONF_HOOK = 'hook'
 CONF_DEFAULT_HOOK = 'on'
@@ -31,11 +32,12 @@ AUTOMATION_SCHEMA = vol.Schema({
 AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Optional(CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT):
         cv.positive_int,
+    vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
+    vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_RESET_AFTER): cv.positive_int,
     vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
 })
@@ -69,6 +71,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         hass.data[DATA_XKNX].xknx,
         name=name,
         group_address_state=config[CONF_ADDRESS],
+        sync_state=config[CONF_SYNC_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER))

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -34,11 +34,11 @@ AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Optional(CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT):
         cv.positive_int,
     vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
     vol.Required(CONF_STATE_ADDRESS): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS): cv.string,
     vol.Optional(CONF_RESET_AFTER): cv.positive_int,
     vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
 })

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -3,12 +3,13 @@ import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA, BinarySensorDevice)
-from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_CLASS, CONF_NAME
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_DISCOVER_DEVICES, DATA_XKNX, KNXAutomation
 
+CONF_STATE_ADDRESS = 'state_address'
 CONF_SIGNIFICANT_BIT = 'significant_bit'
 CONF_DEFAULT_SIGNIFICANT_BIT = 1
 CONF_SYNC_STATE = 'sync_state'
@@ -37,7 +38,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT):
         cv.positive_int,
     vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-    vol.Required(CONF_ADDRESS): cv.string,
+    vol.Required(CONF_STATE_ADDRESS): cv.string,
     vol.Optional(CONF_RESET_AFTER): cv.positive_int,
     vol.Optional(CONF_AUTOMATION): AUTOMATIONS_SCHEMA,
 })
@@ -70,7 +71,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     binary_sensor = xknx.devices.BinarySensor(
         hass.data[DATA_XKNX].xknx,
         name=name,
-        group_address_state=config[CONF_ADDRESS],
+        group_address_state=config[CONF_STATE_ADDRESS],
         sync_state=config[CONF_SYNC_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config[CONF_SIGNIFICANT_BIT],

--- a/home-assistant-plugin/custom_components/xknx/manifest.json
+++ b/home-assistant-plugin/custom_components/xknx/manifest.json
@@ -3,7 +3,7 @@
   "name": "Knx",
   "documentation": "https://www.home-assistant.io/components/knx",
   "requirements": [
-    "xknx==0.10.0"
+    "xknx==0.11.0"
   ],
   "dependencies": [],
   "codeowners": [

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -2,20 +2,21 @@
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_ADDRESS, CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_NAME, CONF_TYPE
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 
 from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 
+CONF_STATE_ADDRESS = 'state_address'
 CONF_SYNC_STATE = 'sync_state'
 DEFAULT_NAME = 'XKNX Sensor'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-    vol.Required(CONF_ADDRESS): cv.string,
+    vol.Required(CONF_STATE_ADDRESS): cv.string,
     vol.Required(CONF_TYPE): cv.string,
 })
 
@@ -46,7 +47,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     sensor = xknx.devices.Sensor(
         hass.data[DATA_XKNX].xknx,
         name=config[CONF_NAME],
-        group_address_state=config[CONF_ADDRESS],
+        group_address_state=config[CONF_STATE_ADDRESS],
         sync_state=config[CONF_SYNC_STATE],
         value_type=config[CONF_TYPE])
     hass.data[DATA_XKNX].xknx.devices.add(sensor)

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -9,10 +9,13 @@ from homeassistant.helpers.entity import Entity
 
 from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 
+CONF_SYNC_STATE = 'sync_state'
 DEFAULT_NAME = 'XKNX Sensor'
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_ADDRESS): cv.string,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
+    vol.Required(CONF_ADDRESS): cv.string,
     vol.Required(CONF_TYPE): cv.string,
 })
 
@@ -44,6 +47,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         hass.data[DATA_XKNX].xknx,
         name=config[CONF_NAME],
         group_address_state=config[CONF_ADDRESS],
+        sync_state=config[CONF_SYNC_STATE],
         value_type=config[CONF_TYPE])
     hass.data[DATA_XKNX].xknx.devices.add(sensor)
     async_add_entities([KNXSensor(sensor)])

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -376,6 +376,18 @@ class TestConfig(unittest.TestCase):
                    'Heating.Valve1',
                    group_address_state='2/0/0',
                    value_type='percent',
+                   sync_state=True,
+                   device_updated_cb=TestConfig.xknx.devices.device_updated))
+
+    def test_config_sensor_percent_passive(self):
+        """Test passive percent Sensor from config file."""
+        self.assertEqual(
+            TestConfig.xknx.devices['Heating.Valve2'],
+            Sensor(TestConfig.xknx,
+                   'Heating.Valve2',
+                   group_address_state='2/0/1',
+                   value_type='percent',
+                   sync_state=False,
                    device_updated_cb=TestConfig.xknx.devices.device_updated))
 
     def test_config_sensor_temperature_type(self):

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -414,10 +414,21 @@ class TestConfig(unittest.TestCase):
     def test_config_sensor_binary_device_class(self):
         """Test reading Sensor with device_class from config file."""
         self.assertEqual(
+            TestConfig.xknx.devices['Kitchen.Motion.Sensor'],
+            BinarySensor(TestConfig.xknx,
+                         'Kitchen.Motion.Sensor',
+                         group_address_state='3/0/0',
+                         device_class='motion',
+                         device_updated_cb=TestConfig.xknx.devices.device_updated))
+
+    def test_config_sensor_binary_passive(self):
+        """Test reading Sensor with sync_state False from config file."""
+        self.assertEqual(
             TestConfig.xknx.devices['DiningRoom.Motion.Sensor'],
             BinarySensor(TestConfig.xknx,
                          'DiningRoom.Motion.Sensor',
                          group_address_state='3/0/1',
+                         sync_state=False,
                          device_class='motion',
                          device_updated_cb=TestConfig.xknx.devices.device_updated))
 

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -220,8 +220,20 @@ class TestBinarySensor(unittest.TestCase):
     def test_state_addresses(self):
         """Test binary sensor returns state address as list."""
         xknx = XKNX(loop=self.loop)
-        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/4')
+        binary_sensor = BinarySensor(
+            xknx,
+            'TestInput',
+            group_address_state='1/2/4')
         self.assertEqual(binary_sensor.state_addresses(), [GroupAddress('1/2/4')])
 
-        binary_sensor2 = BinarySensor(xknx, 'TestInput')
+        binary_sensor2 = BinarySensor(
+            xknx,
+            'TestInput')
         self.assertEqual(binary_sensor2.state_addresses(), [])
+
+        binary_sensor_passive = BinarySensor(
+            xknx,
+            'TestInput',
+            group_address_state='1/2/5',
+            sync_state=False)
+        self.assertEqual(binary_sensor_passive.state_addresses(), [])

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -126,6 +126,23 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(telegram,
                          Telegram(GroupAddress('1/2/3'), TelegramType.GROUP_READ))
 
+    def test_sync_passive(self):
+        """Test sync function / not sending group reads to KNX bus."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            value_type="temperature",
+            group_address_state='1/2/3',
+            sync_state=False)
+
+        self.loop.run_until_complete(asyncio.Task(sensor.sync(False)))
+
+        self.assertEqual(xknx.telegrams.qsize(), 0)
+
+        with self.assertRaises(asyncio.queues.QueueEmpty):
+            xknx.telegrams.get_nowait()
+
     #
     # HAS GROUP ADDRESS
     #
@@ -152,6 +169,17 @@ class TestSensor(unittest.TestCase):
             value_type='temperature',
             group_address_state='1/2/3')
         self.assertEqual(sensor.state_addresses(), [GroupAddress('1/2/3')])
+
+    def test_state_addresses_passive(self):
+        """Test state addresses of passive sensor object."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(
+            xknx,
+            'TestSensor',
+            value_type='temperature',
+            group_address_state='1/2/3',
+            sync_state=False)
+        self.assertEqual(sensor.state_addresses(), [])
 
     #
     # TEST PROCESS

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -38,7 +38,7 @@ groups:
 
     binary_sensor_motion_dection:
         Kitchen.Motion.Sensor: {group_address_state: '3/0/0', device_class: 'motion'}
-        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', device_class: 'motion'}
+        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', sync_state: False, device_class: 'motion'}
 
         # Some states are encoded into different bits of the same group_address
         # Defining which bit should be relevant for the binary state via the "significant_bit" option

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -122,8 +122,8 @@ groups:
 
     sensor:
         Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
-        Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature'}
+        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent', sync_state: False}
+        Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature', sync_state: True}
 
     expose_sensor:
         Outside.Temperature: {group_address: '2/0/3', value_type: 'temperature'}

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -38,6 +38,7 @@ class BinarySensor(Device):
                  xknx,
                  name,
                  group_address_state=None,
+                 sync_state=True,
                  device_class=None,
                  significant_bit=1,
                  reset_after=None,
@@ -54,6 +55,7 @@ class BinarySensor(Device):
             actions = []
 
         self.group_address_state = group_address_state
+        self.sync_state = sync_state
         self.device_class = device_class
         self.significant_bit = significant_bit
         self.reset_after = reset_after
@@ -69,6 +71,8 @@ class BinarySensor(Device):
         """Initialize object from configuration structure."""
         group_address_state = \
             config.get('group_address_state')
+        sync_state = \
+            config.get('sync_state', True)
         device_class = \
             config.get('device_class')
         significant_bit = \
@@ -83,6 +87,7 @@ class BinarySensor(Device):
         return cls(xknx,
                    name,
                    group_address_state=group_address_state,
+                   sync_state=sync_state,
                    device_class=device_class,
                    significant_bit=significant_bit,
                    actions=actions)
@@ -93,7 +98,8 @@ class BinarySensor(Device):
 
     def state_addresses(self):
         """Return group addresses which should be requested to sync state."""
-        if self.group_address_state is not None:
+        if self.sync_state and \
+                self.group_address_state is not None:
             return [self.group_address_state, ]
         return []
 

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -35,8 +35,8 @@ class SetpointShiftValue(RemoteValue1Count):
         super().__init__(xknx,
                          group_address,
                          group_address_state,
-                         device_name,
-                         after_update_cb)
+                         device_name=device_name,
+                         after_update_cb=after_update_cb)
 
         self.setpoint_shift_step = setpoint_shift_step
         self.min_temp_delta = min_temp_delta
@@ -129,8 +129,8 @@ class Climate(Device):
             xknx,
             group_address_on_off,
             group_address_on_off_state,
-            self.name,
-            self.after_update)
+            device_name=self.name,
+            after_update_cb=self.after_update)
 
         self.mode = mode
 

--- a/xknx/devices/remote_value.py
+++ b/xknx/devices/remote_value.py
@@ -16,6 +16,7 @@ class RemoteValue():
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 sync_state=True,
                  device_name=None,
                  after_update_cb=None):
         """Initialize RemoteValue class."""
@@ -28,15 +29,21 @@ class RemoteValue():
 
         self.group_address = group_address
         self.group_address_state = group_address_state
-        self.after_update_cb = after_update_cb
+        self.sync_state = sync_state
         self.device_name = "Unknown" \
             if device_name is None else device_name
+        self.after_update_cb = after_update_cb
         self.payload = None
 
     @property
     def initialized(self):
         """Evaluate if remote value is initialized with group address."""
         return bool(self.group_address_state or self.group_address)
+
+    @property
+    def readable(self):
+        """Evaluate if remote value should be read from bus."""
+        return self.sync_state and isinstance(self.group_address_state, GroupAddress)
 
     @property
     def writable(self):
@@ -49,7 +56,7 @@ class RemoteValue():
 
     def state_addresses(self):
         """Return group addresses which should be requested to sync state."""
-        if self.group_address_state:
+        if self.readable:
             return [self.group_address_state, ]
         return []
 

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -82,6 +82,7 @@ class RemoteValueSensor(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 sync_state=True,
                  value_type=None,
                  device_name=None,
                  after_update_cb=None):
@@ -90,6 +91,7 @@ class RemoteValueSensor(RemoteValue):
         super().__init__(xknx,
                          group_address,
                          group_address_state,
+                         sync_state=sync_state,
                          device_name=device_name,
                          after_update_cb=after_update_cb)
         if value_type not in self.DPTMAP:

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -17,31 +17,32 @@ class Sensor(Device):
                  xknx,
                  name,
                  group_address_state=None,
+                 sync_state=True,
                  value_type=None,
                  device_updated_cb=None):
         """Initialize Sensor class."""
         # pylint: disable=too-many-arguments
         super().__init__(xknx, name, device_updated_cb)
 
-        self.sensor_value = None
         self.sensor_value = RemoteValueSensor(
             xknx,
             group_address_state=group_address_state,
+            sync_state=sync_state,
+            value_type=value_type,
             device_name=self.name,
-            after_update_cb=self.after_update,
-            value_type=value_type)
+            after_update_cb=self.after_update)
 
     @classmethod
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
-        group_address_state = \
-            config.get('group_address_state')
-        value_type = \
-            config.get('value_type')
+        group_address_state = config.get('group_address_state')
+        sync_state = config.get('sync_state', True)
+        value_type = config.get('value_type')
 
         return cls(xknx,
                    name,
                    group_address_state=group_address_state,
+                   sync_state=sync_state,
                    value_type=value_type)
 
     def has_group_address(self, group_address):


### PR DESCRIPTION
- possiblity to disable reading (GroupValueRead) for sensor and binary_sensor
- move from `address` to `state_address` in HA components sensor and binary_sensor