### PR TITLE
Small adjustments to the sensor documentation and example

### DIFF
--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -10,12 +10,12 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 
 ```python
     sensor = Sensor(
-        xknx=xknx,
-        name='DiningRoom.Temperatur.Sensor',
-        group_address_state='6/2/1',
-        sync_state=True,
-        value_type='float',
-        device_class='temperature')
+        xknx = xknx,
+        name = 'DiningRoom.Temperature.Sensor',
+        group_address_state = '6/2/1',
+        sync_state = True,
+        value_type = 'temperature'
+    )
     await sensor2.sync()
     print(sensor2)
 ```
@@ -25,7 +25,6 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 * `group_address_state` is the KNX group address of the sensor device.
 * `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 * `value_type` controls how the value should be rendered in a human readable representation. The attribut may have may have the values `percent`, `temperature`, `illuminance`, `speed_ms` or `current`.
-* `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
 
 ## [](#header-2)Configuration via **xknx.yaml**
@@ -45,7 +44,7 @@ Sensor objects are usually configured via [`xknx.yaml`](/configuration):
 ```python
 sensor = Sensor(
         xknx=xknx,
-        name='DiningRoom.Temperatur.Sensor',
+        name='DiningRoom.Temperature.Sensor',
         group_address_state='6/2/1')
 
 await sensor.sync() # Syncs the state. Tries to read the corresponding value from the bus.

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -10,14 +10,14 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 
 ```python
     sensor = Sensor(
-        xknx = xknx,
-        name = 'DiningRoom.Temperature.Sensor',
-        group_address_state = '6/2/1',
-        sync_state = True,
-        value_type = 'temperature'
+        xknx=xknx,
+        name='DiningRoom.Temperature.Sensor',
+        group_address_state='6/2/1',
+        sync_state=True,
+        value_type='temperature'
     )
-    await sensor2.sync()
-    print(sensor2)
+    await sensor.sync()
+    print(sensor)
 ```
 
 * `xknx` is the XKNX object.

--- a/examples/example_sensor.py
+++ b/examples/example_sensor.py
@@ -1,4 +1,4 @@
-"""Example for Sensor device."""
+"""Example for Sensor device. See docs/sensor.md and docs/binary_sensor.md for a detailed explanation."""
 import asyncio
 
 from xknx import XKNX
@@ -14,15 +14,18 @@ async def main():
         xknx,
         'DiningRoom.Motion.Sensor',
         group_address_state='6/0/2',
-        device_class='motion')
+        device_class='motion'
+    )
     await sensor1.sync()
     print(sensor1)
 
-    sensor2 = Sensor(
+    sensor2 = Sensor( 
         xknx,
-        'DiningRoom.Temperatur.Sensor',
+        'DiningRoom.Temperature.Sensor',
         group_address_state='6/2/1',
-        value_type='float')
+        value_type='temperature'
+    )
+
     await sensor2.sync()
     print(sensor2)
 


### PR DESCRIPTION
Removed unusable type and set value_type to an proper type for temperature. Fixed a 'spelling error' (I'm guessing the creator is German, so changed temperatur to temperature) and spaced out the formatting.