### PR TITLE
added DPT 9.006 as pressure_2Byte sensor.

### DIFF
--- a/examples/example_sensor.py
+++ b/examples/example_sensor.py
@@ -19,7 +19,7 @@ async def main():
     await sensor1.sync()
     print(sensor1)
 
-    sensor2 = Sensor( 
+    sensor2 = Sensor(
         xknx,
         'DiningRoom.Temperature.Sensor',
         group_address_state='6/2/1',

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -52,6 +52,7 @@ class SensorExposeLoopTest(unittest.TestCase):
             ('powerfactor', DPTArray((0x42, 0xA9, 0x6B, 0x85)), 84.71),
             ('ppm', DPTArray((0x00, 0x03)), 0.03),
             ('pressure', DPTArray((0x42, 0xA9, 0x6B, 0x85)), 84.71),
+            ('pressure_2Byte', DPTArray((0x2E, 0xA9)), 545.6),
             ('pulse', DPTArray((0x11)), 17),
             ('rotation_angle', DPTArray((0xAE, 0xC0)), -20800),
             ('scene_number', DPTArray((0x00)), 1),

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -52,7 +52,7 @@ class SensorExposeLoopTest(unittest.TestCase):
             ('powerfactor', DPTArray((0x42, 0xA9, 0x6B, 0x85)), 84.71),
             ('ppm', DPTArray((0x00, 0x03)), 0.03),
             ('pressure', DPTArray((0x42, 0xA9, 0x6B, 0x85)), 84.71),
-            ('pressure_2Byte', DPTArray((0x2E, 0xA9)), 545.6),
+            ('pressure_2byte', DPTArray((0x2E, 0xA9)), 545.6),
             ('pulse', DPTArray((0x11)), 17),
             ('rotation_angle', DPTArray((0xAE, 0xC0)), -20800),
             ('scene_number', DPTArray((0x00)), 1),

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -52,7 +52,7 @@ class RemoteValueSensor(RemoteValue):
         'powerfactor': DPTPowerFactor,
         'ppm': DPTPartsPerMillion,
         'pressure': DPTPressure,
-        'pressure_2Byte': DPTPressure2Byte,
+        'pressure_2byte': DPTPressure2Byte,
         'pulse': DPTValue1Ucount,
         'rotation_angle': DPTRotationAngle,
         'scene_number': DPTSceneNumber,

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -13,9 +13,9 @@ from xknx.knx import (
     DPTEnthalpy, DPTFrequency, DPTHeatFlowRate, DPTHumidity, DPTLuminousFlux,
     DPTLux, DPTPartsPerMillion, DPTPercentU8, DPTPercentV8, DPTPercentV16,
     DPTPhaseAngleDeg, DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTPressure,
-    DPTRotationAngle, DPTScaling, DPTSceneNumber, DPTSpeed, DPTString,
-    DPTTemperature, DPTUElCurrentmA, DPTValue1Count, DPTValue1Ucount,
-    DPTValue2Count, DPTVoltage, DPTWsp, DPTPressure2Byte)
+    DPTPressure2Byte, DPTRotationAngle, DPTScaling, DPTSceneNumber, DPTSpeed,
+    DPTString, DPTTemperature, DPTUElCurrentmA, DPTValue1Count,
+    DPTValue1Ucount, DPTValue2Count, DPTVoltage, DPTWsp)
 
 from .remote_value import RemoteValue
 

--- a/xknx/devices/remote_value_sensor.py
+++ b/xknx/devices/remote_value_sensor.py
@@ -15,7 +15,7 @@ from xknx.knx import (
     DPTPhaseAngleDeg, DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTPressure,
     DPTRotationAngle, DPTScaling, DPTSceneNumber, DPTSpeed, DPTString,
     DPTTemperature, DPTUElCurrentmA, DPTValue1Count, DPTValue1Ucount,
-    DPTValue2Count, DPTVoltage, DPTWsp)
+    DPTValue2Count, DPTVoltage, DPTWsp, DPTPressure2Byte)
 
 from .remote_value import RemoteValue
 
@@ -52,6 +52,7 @@ class RemoteValueSensor(RemoteValue):
         'powerfactor': DPTPowerFactor,
         'ppm': DPTPartsPerMillion,
         'pressure': DPTPressure,
+        'pressure_2Byte': DPTPressure2Byte,
         'pulse': DPTValue1Ucount,
         'rotation_angle': DPTRotationAngle,
         'scene_number': DPTSceneNumber,

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -16,7 +16,7 @@ from .dpt_1byte_uint import (
     DPTPercentU8, DPTSceneNumber, DPTTariff, DPTValue1Ucount)
 from .dpt_2byte_float import (
     DPT2ByteFloat, DPTEnthalpy, DPTHumidity, DPTLux, DPTPartsPerMillion,
-    DPTTemperature, DPTVoltage, DPTWsp)
+    DPTTemperature, DPTVoltage, DPTWsp, DPTPressure2Byte)
 from .dpt_2byte_signed import (
     DPT2ByteSigned, DPTDeltaTimeHrs, DPTDeltaTimeMin, DPTDeltaTimeMsec,
     DPTDeltaTimeSec, DPTPercentV16, DPTRotationAngle, DPTValue2Count)

--- a/xknx/knx/__init__.py
+++ b/xknx/knx/__init__.py
@@ -16,7 +16,7 @@ from .dpt_1byte_uint import (
     DPTPercentU8, DPTSceneNumber, DPTTariff, DPTValue1Ucount)
 from .dpt_2byte_float import (
     DPT2ByteFloat, DPTEnthalpy, DPTHumidity, DPTLux, DPTPartsPerMillion,
-    DPTTemperature, DPTVoltage, DPTWsp, DPTPressure2Byte)
+    DPTPressure2Byte, DPTTemperature, DPTVoltage, DPTWsp)
 from .dpt_2byte_signed import (
     DPT2ByteSigned, DPTDeltaTimeHrs, DPTDeltaTimeMin, DPTDeltaTimeMsec,
     DPTDeltaTimeSec, DPTPercentV16, DPTRotationAngle, DPTValue2Count)

--- a/xknx/knx/dpt_2byte_float.py
+++ b/xknx/knx/dpt_2byte_float.py
@@ -133,3 +133,9 @@ class DPTEnthalpy(DPT2ByteFloat):
     """DPT 9.* 2-byte float value (with unit)."""
 
     unit = "H"
+
+class DPTPressure2Byte(DPT2ByteFloat):
+    """DPT 9.006 DPT_Value_Pressure."""
+
+    unit = 'Pa'
+    ha_device_class = "pressure"

--- a/xknx/knx/dpt_2byte_float.py
+++ b/xknx/knx/dpt_2byte_float.py
@@ -134,6 +134,7 @@ class DPTEnthalpy(DPT2ByteFloat):
 
     unit = "H"
 
+
 class DPTPressure2Byte(DPT2ByteFloat):
     """DPT 9.006 DPT_Value_Pressure."""
 


### PR DESCRIPTION
with release 0.11.0 a new type 'pressure' was introduced for 4byte pressure values. But in KNX there are also 2Byte pressure values possible (DPT 9.006). 
Therefore I adjusted the coding and added the type `pressure_2Byte`. Not sure about the naming, maybe also `pressure_short` and `pressure_long` would work.

