### PR TITLE
Fix exceptions

### DIFF
--- a/test/core_tests/exceptions_test.py
+++ b/test/core_tests/exceptions_test.py
@@ -1,0 +1,51 @@
+"""Unit tests for exceptions"""
+import pytest
+
+from xknx.exceptions import (
+    ConversionError, CouldNotParseAddress, CouldNotParseKNXIP,
+    CouldNotParseTelegram, DeviceIllegalValue, XKNXException)
+
+
+@pytest.mark.parametrize(
+    "base,equal,diff",
+    [
+        (
+            ConversionError("desc1"),
+            ConversionError("desc1"),
+            ConversionError("desc2"),
+        ),
+        (
+            CouldNotParseAddress(123),
+            CouldNotParseAddress(123),
+            CouldNotParseAddress(321),
+        ),
+        (
+            CouldNotParseKNXIP("desc1"),
+            CouldNotParseKNXIP("desc1"),
+            CouldNotParseKNXIP("desc2"),
+        ),
+        (
+            CouldNotParseTelegram("desc", arg1=1, arg2=2),
+            CouldNotParseTelegram("desc", arg1=1, arg2=2),
+            CouldNotParseTelegram("desc", arg1=2, arg2=1),
+        ),
+        (
+            DeviceIllegalValue("value1", "desc"),
+            DeviceIllegalValue("value1", "desc"),
+            DeviceIllegalValue("value1", "desc2"),
+        ),
+        (
+            XKNXException("desc1"),
+            XKNXException("desc1"),
+            XKNXException("desc2"),
+        ),
+    ],
+)
+def test_exceptions(base, equal, diff):
+    """Test hashability and repr of exceptions."""
+    assert hash(base) == hash(equal)
+    assert hash(base) != hash(diff)
+    assert base == equal
+    assert base != diff
+    assert repr(base) == repr(equal)
+    assert repr(base) != repr(diff)

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -21,7 +21,7 @@ class CouldNotParseTelegram(XKNXException):
 
     def __init__(self, description, **kwargs):
         """Initialize CouldNotParseTelegram class."""
-        super().__init__("Could not parse Telegram")
+        super().__init__()
         self.description = description
         self.parameter = kwargs
 
@@ -39,7 +39,7 @@ class CouldNotParseKNXIP(XKNXException):
 
     def __init__(self, description=""):
         """Initialize CouldNotParseTelegram class."""
-        super().__init__("Could not parse KNXIP")
+        super().__init__()
         self.description = description
 
     def __str__(self):
@@ -53,7 +53,7 @@ class ConversionError(XKNXException):
 
     def __init__(self, description, **kwargs):
         """Initialize ConversionError class."""
-        super().__init__("Conversion Error")
+        super().__init__()
         self.description = description
         self.parameter = kwargs
 
@@ -70,7 +70,7 @@ class CouldNotParseAddress(XKNXException):
 
     def __init__(self, address=None):
         """Initialize CouldNotParseAddress class."""
-        super().__init__("Could not parse address")
+        super().__init__()
         self.address = address
 
     def __str__(self):
@@ -83,7 +83,7 @@ class DeviceIllegalValue(XKNXException):
 
     def __init__(self, value, description):
         """Initialize DeviceIllegalValue class."""
-        super().__init__("Illegal value for device")
+        super().__init__()
         self.value = value
         self.description = description
 

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -9,10 +9,11 @@ class XKNXException(Exception):
         return repr(self) == repr(other)
 
     def __hash__(self):
-        """Hash function"""
+        """Hash function."""
         return hash(str(self))
 
     def __repr__(self):
+        """Representation of object."""
         return str(self)
 
 

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -6,7 +6,14 @@ class XKNXException(Exception):
 
     def __eq__(self, other):
         """Equal operator."""
-        return self.__dict__ == other.__dict__
+        return repr(self) == repr(other)
+
+    def __hash__(self):
+        """Hash function"""
+        return hash(str(self))
+
+    def __repr__(self):
+        return str(self)
 
 
 class CouldNotParseTelegram(XKNXException):


### PR DESCRIPTION
Restore hash ability of exceptions

Also make sure we override base repr function since base repr will
just use the init value of base class

Fixes #228