### PR TITLE
Avoid leaking ValueError exception on unknown APCI command

### DIFF
--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -1,0 +1,69 @@
+"""Tests for the CEMIFrame object"""
+
+from unittest.mock import MagicMock
+from pytest import raises, fixture
+from xknx.knx import DPTBinary, PhysicalAddress
+from xknx.knxip.cemi_frame import CEMIFrame
+from xknx.knxip.knxip_enum import CEMIMessageCode, APCICommand
+from xknx.exceptions import CouldNotParseKNXIP
+
+
+def get_data(code, adil, flags, src, dst, mpdu_len, tpci_apci, payload):
+    return [
+        code,
+        adil,  # adil
+        (flags >> 8) & 255,  # flags
+        flags & 255,  # flags
+        (src >> 8) & 255,  # src
+        src & 255,  # src
+        (dst >> 8) & 255,  # dst
+        dst & 255,  # dst
+        mpdu_len,  # mpdu_len
+        (tpci_apci >> 8) & 255,  # tpci_apci
+        tpci_apci & 255,  # tpci_apci
+        *payload,  # payload
+    ]
+
+
+@fixture(name="frame")
+def fixture_frame():
+    """Fixture to get a simple mocked frame"""
+    xknx = MagicMock()
+    return CEMIFrame(xknx)
+
+
+def test_valid_command(frame):
+    """Test for valid frame parsing"""
+    packet_len = frame.from_knx(get_data(0x29, 0, 0, 0, 0, 1, 0, []))
+    assert frame.code == CEMIMessageCode.L_DATA_IND
+    assert frame.cmd == APCICommand.GROUP_READ
+    assert frame.flags == 0
+    assert frame.mpdu_len == 1
+    assert frame.payload == DPTBinary(0)
+    assert frame.src_addr == PhysicalAddress(0)
+    assert frame.dst_addr == PhysicalAddress(0)
+    assert packet_len == 11
+
+
+def test_invalid_tpci_apci(frame):
+    """Test for invalid APCICommand"""
+    with raises(CouldNotParseKNXIP, match=r".*APCI not supported: .*"):
+        frame.from_knx(get_data(0x29, 0, 0, 0, 0, 1, 0xFFC0, []))
+
+
+def test_invalid_apdu_len(frame):
+    """Test for invalid apdu len"""
+    with raises(CouldNotParseKNXIP, match=r".*APDU LEN should be .*"):
+        frame.from_knx(get_data(0x29, 0, 0, 0, 0, 2, 0, []))
+
+
+def test_invalid_invalid_len(frame):
+    """Test for invalid cemi len"""
+    with raises(CouldNotParseKNXIP, match=r".*CEMI too small"):
+        frame.from_knx(get_data(0x29, 0, 0, 0, 0, 2, 0, [])[:5])
+
+
+def test_invalid_invalid_code(frame):
+    """Test for invalid cemi code"""
+    with raises(CouldNotParseKNXIP, match=r".*Could not understand CEMIMessageCode"):
+        frame.from_knx(get_data(0x0, 0, 0, 0, 0, 2, 0, []))

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -1,11 +1,13 @@
 """Tests for the CEMIFrame object"""
 
 from unittest.mock import MagicMock
-from pytest import raises, fixture
+
+from pytest import fixture, raises
+
+from xknx.exceptions import CouldNotParseKNXIP
 from xknx.knx import DPTBinary, PhysicalAddress
 from xknx.knxip.cemi_frame import CEMIFrame
-from xknx.knxip.knxip_enum import CEMIMessageCode, APCICommand
-from xknx.exceptions import CouldNotParseKNXIP
+from xknx.knxip.knxip_enum import APCICommand, CEMIMessageCode
 
 
 def get_data(code, adil, flags, src, dst, mpdu_len, tpci_apci, payload):

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -140,7 +140,11 @@ class CEMIFrame(KNXIPBody):
 
         tpci_apci = cemi[9 + addil] * 256 + cemi[10 + addil]
 
-        self.cmd = APCICommand(tpci_apci & 0xFFC0)
+        try:
+            self.cmd = APCICommand(tpci_apci & 0xFFC0)
+        except ValueError:
+            raise CouldNotParseKNXIP(
+                "APCI not supported: {0:#b}".format(tpci_apci & 0xFFC0))
 
         apdu = cemi[10 + addil:]
         if len(apdu) != self.mpdu_len:

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -144,7 +144,7 @@ class CEMIFrame(KNXIPBody):
             self.cmd = APCICommand(tpci_apci & 0xFFC0)
         except ValueError:
             raise CouldNotParseKNXIP(
-                "APCI not supported: {0:#b}".format(tpci_apci & 0xFFC0))
+                "APCI not supported: {0:#012b}".format(tpci_apci & 0xFFC0))
 
         apdu = cemi[10 + addil:]
         if len(apdu) != self.mpdu_len:

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -105,7 +105,10 @@ class CEMIFrame(KNXIPBody):
 
     def from_knx(self, raw):
         """Parse/deserialize from KNX/IP raw data."""
-        self.code = CEMIMessageCode(raw[0])
+        try:
+            self.code = CEMIMessageCode(raw[0])
+        except ValueError:
+            raise CouldNotParseKNXIP("Could not understand CEMIMessageCode: {0} ".format(raw[0]))
 
         if self.code == CEMIMessageCode.L_DATA_IND or \
                 self.code == CEMIMessageCode.L_Data_REQ or \


### PR DESCRIPTION
This avoid crashing homeassistant on these types of messages.

Fixes #226