### PR TITLE
[WIP] Add support for other APCI services

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 - renamed "PhysicalAddress" to "IndividualAddress"
 - Telegram: `group_address` renamed to `destination_address`, to prepare support for other APCI services and add `source_address`
+- Telegram: remove `Telegram.telegramtype` and replace with payload object derived from `xknx.telegram.apci.APCI`.
+- CEMIFrame: remove `CEMIFrame.cmd`, which can be derived from `CEMIFrame.payload`.
 - Farewell Travis CI; Welcome Github Actions!
 
 ## 0.15.6 Bugfix for StateUpater 2020-11-26

--- a/examples/example_tunnel.py
+++ b/examples/example_tunnel.py
@@ -4,7 +4,7 @@ import asyncio
 from xknx import XKNX
 from xknx.dpt import DPTBinary
 from xknx.io import GatewayScanner, Tunnel
-from xknx.telegram import GroupAddress, IndividualAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, IndividualAddress, Telegram
 
 
 async def main():
@@ -38,11 +38,17 @@ async def main():
     await tunnel.connect()
 
     await tunnel.send_telegram(
-        Telegram(destination_address=GroupAddress("1/0/15"), payload=DPTBinary(1))
+        Telegram(
+            destination_address=GroupAddress("1/0/15"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
     )
     await asyncio.sleep(2)
     await tunnel.send_telegram(
-        Telegram(destination_address=GroupAddress("1/0/15"), payload=DPTBinary(0))
+        Telegram(
+            destination_address=GroupAddress("1/0/15"),
+            payload=GroupValueWrite(DPTBinary(0)),
+        )
     )
     await asyncio.sleep(2)
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -325,11 +325,11 @@ class KNXModule:
         self.hass.bus.async_fire(
             "knx_event",
             {
-                "data": telegram.payload.value,
+                "data": telegram.payload,
                 "destination": str(telegram.destination_address),
                 "direction": telegram.direction.value,
                 "source": str(telegram.source_address),
-                "telegramtype": telegram.telegramtype.value,
+                "telegramtype": telegram.payload.__class__.__name__,
             },
         )
 

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, Mock, patch
 from xknx import XKNX
 from xknx.dpt import DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import AddressFilter, GroupAddress, Telegram, TelegramDirection
+from xknx.telegram import (
+    AddressFilter,
+    GroupAddress,
+    GroupValueWrite,
+    Telegram,
+    TelegramDirection,
+)
 
 
 class AsyncMock(MagicMock):
@@ -40,7 +46,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -75,14 +81,12 @@ class TestTelegramQueue(unittest.TestCase):
 
         telegram_in = Telegram(
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
-            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         telegram_out = Telegram(
             direction=TelegramDirection.OUTGOING,
-            payload=DPTBinary(1),
-            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -120,7 +124,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -144,7 +148,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -170,7 +174,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -193,7 +197,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -215,7 +219,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.OUTGOING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         # log a warning if there is no KNXIP interface instanciated
@@ -249,7 +253,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         xknx.telegrams.put_nowait(telegram)
@@ -279,12 +283,12 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         telegram_out = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.OUTGOING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         xknx.telegrams.put_nowait(telegram_in)
@@ -314,7 +318,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -343,7 +347,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -372,7 +376,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())

--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -6,7 +6,14 @@ from unittest.mock import patch
 from xknx import XKNX
 from xknx.core import ValueReader
 from xknx.dpt import DPTBinary
-from xknx.telegram import GroupAddress, Telegram, TelegramDirection, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+    TelegramDirection,
+)
 
 
 class TestValueReader(unittest.TestCase):
@@ -28,9 +35,8 @@ class TestValueReader(unittest.TestCase):
         test_group_address = GroupAddress("0/0/0")
         response_telegram = Telegram(
             destination_address=test_group_address,
-            telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueResponse(DPTBinary(1)),
         )
 
         value_reader = ValueReader(xknx, test_group_address)
@@ -94,8 +100,7 @@ class TestValueReader(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("0/0/0"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("0/0/0"), payload=GroupValueRead()
             ),
         )
 
@@ -105,27 +110,23 @@ class TestValueReader(unittest.TestCase):
         test_group_address = GroupAddress("0/0/0")
         expected_telegram_1 = Telegram(
             destination_address=test_group_address,
-            telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueResponse(DPTBinary(1)),
         )
         expected_telegram_2 = Telegram(
             destination_address=test_group_address,
-            telegramtype=TelegramType.GROUP_WRITE,
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         telegram_wrong_address = Telegram(
             destination_address=GroupAddress("0/0/1"),
-            telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueResponse(DPTBinary(1)),
         )
         telegram_wrong_type = Telegram(
             destination_address=test_group_address,
-            telegramtype=TelegramType.GROUP_READ,
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueRead(),
         )
 
         value_reader = ValueReader(xknx, test_group_address)

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Action, BinarySensor, Switch
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueResponse, GroupValueWrite, Telegram
 
 
 class AsyncMock(MagicMock):
@@ -38,14 +38,16 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput.state, None)
 
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(binaryinput.process(telegram_on))
 
         self.assertEqual(binaryinput.state, True)
 
         telegram_off = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.loop.run_until_complete(binaryinput.process(telegram_off))
         self.assertEqual(binaryinput.state, False)
@@ -54,7 +56,8 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput2.state, None)
 
         telegram_off2 = Telegram(
-            destination_address=GroupAddress("1/2/4"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/4"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.loop.run_until_complete(binaryinput2.process(telegram_off2))
         self.assertEqual(binaryinput2.state, False)
@@ -67,14 +70,16 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(bs_invert.state, None)
 
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.loop.run_until_complete(bs_invert.process(telegram_on))
 
         self.assertEqual(bs_invert.state, True)
 
         telegram_off = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(bs_invert.process(telegram_off))
         self.assertEqual(bs_invert.state, False)
@@ -92,7 +97,8 @@ class TestBinarySensor(unittest.TestCase):
             device_updated_cb=async_after_update_callback,
         )
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(binaryinput.process(telegram_on))
@@ -131,7 +137,8 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_on))
         # process outgoing telegram from queue
@@ -141,7 +148,8 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, True)
 
         telegram_off = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_off))
         self.loop.run_until_complete(switch.process(xknx.telegrams.get_nowait()))
@@ -164,7 +172,8 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         with patch("time.time") as mock_time, patch(
@@ -197,7 +206,8 @@ class TestBinarySensor(unittest.TestCase):
         xknx = XKNX()
         binary_sensor = BinarySensor(xknx, "Warning", group_address_state="1/2/3")
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x1, 0x2, 0x3))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(binary_sensor.process(telegram))
@@ -245,7 +255,8 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because ignore_internal_state is False
@@ -273,7 +284,8 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.assertEqual(switch.counter, 0)
 
@@ -315,7 +327,8 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because context_timeout is False
@@ -342,12 +355,14 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         write_telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         response_telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1),
-            telegramtype=TelegramType.GROUP_RESPONSE,
+            payload=GroupValueResponse(
+                DPTBinary(1),
+            ),
         )
         self.assertIsNone(switch.state)
         # initial GroupValueResponse changes state and runs callback

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -19,7 +19,7 @@ from xknx.dpt import (
 )
 from xknx.dpt.dpt_hvac_mode import HVACControllerMode
 from xknx.exceptions import CouldNotParseTelegram, DeviceIllegalValue
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueRead, GroupValueWrite, Telegram
 
 DPT_20102_MODES = [
     HVACOperationMode.AUTO,
@@ -233,7 +233,7 @@ class TestClimate(unittest.TestCase):
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/1"),
-            payload=DPTArray(DPTTemperature.to_knx(23)),
+            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(23))),
         )
         self.loop.run_until_complete(climate.process(telegram))
         after_update_callback.assert_called_with(climate)
@@ -241,7 +241,7 @@ class TestClimate(unittest.TestCase):
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=DPTArray(DPTTemperature.to_knx(23)),
+            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(23))),
         )
         self.loop.run_until_complete(climate.process(telegram))
         after_update_callback.assert_called_with(climate)
@@ -249,7 +249,7 @@ class TestClimate(unittest.TestCase):
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray(DPTValue1Count.to_knx(-4)),
+            payload=GroupValueWrite(DPTArray(DPTValue1Count.to_knx(-4))),
         )
         self.loop.run_until_complete(climate.process(telegram))
         after_update_callback.assert_called_with(climate)
@@ -276,7 +276,8 @@ class TestClimate(unittest.TestCase):
         # Note: the climate object processes the telegram, but the cb
         # is called with the climate_mode object.
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/4"), payload=DPTArray(1)
+            destination_address=GroupAddress("1/2/4"),
+            payload=GroupValueWrite(DPTArray(1)),
         )
         self.loop.run_until_complete(climate.process(telegram))
         after_update_callback.assert_called_with(climate_mode)
@@ -303,7 +304,9 @@ class TestClimate(unittest.TestCase):
                 telegram,
                 Telegram(
                     destination_address=GroupAddress("1/2/4"),
-                    payload=DPTArray(DPTHVACMode.to_knx(operation_mode)),
+                    payload=GroupValueWrite(
+                        DPTArray(DPTHVACMode.to_knx(operation_mode))
+                    ),
                 ),
             )
 
@@ -325,7 +328,9 @@ class TestClimate(unittest.TestCase):
                 telegram,
                 Telegram(
                     destination_address=GroupAddress("1/2/4"),
-                    payload=DPTArray(DPTHVACContrMode.to_knx(controller_mode)),
+                    payload=GroupValueWrite(
+                        DPTArray(DPTHVACContrMode.to_knx(controller_mode))
+                    ),
                 ),
             )
 
@@ -367,7 +372,9 @@ class TestClimate(unittest.TestCase):
                 telegram,
                 Telegram(
                     destination_address=GroupAddress("1/2/4"),
-                    payload=DPTArray(DPTControllerStatus.to_knx(operation_mode)),
+                    payload=GroupValueWrite(
+                        DPTArray(DPTControllerStatus.to_knx(operation_mode))
+                    ),
                 ),
             )
 
@@ -393,15 +400,21 @@ class TestClimate(unittest.TestCase):
             telegrams.append(xknx.telegrams.get_nowait())
 
         test_telegrams = [
-            Telegram(destination_address=GroupAddress("1/2/4"), payload=DPTArray(1)),
             Telegram(
-                destination_address=GroupAddress("1/2/5"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/4"),
+                payload=GroupValueWrite(DPTArray(1)),
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/6"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/5"),
+                payload=GroupValueWrite(DPTBinary(False)),
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/7"), payload=DPTBinary(True)
+                destination_address=GroupAddress("1/2/6"),
+                payload=GroupValueWrite(DPTBinary(False)),
+            ),
+            Telegram(
+                destination_address=GroupAddress("1/2/7"),
+                payload=GroupValueWrite(DPTBinary(True)),
             ),
         ]
 
@@ -425,7 +438,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/14"), payload=DPTBinary(True)
+                destination_address=GroupAddress("1/2/14"),
+                payload=GroupValueWrite(DPTBinary(True)),
             ),
         )
         self.loop.run_until_complete(
@@ -436,7 +450,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/14"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/14"),
+                payload=GroupValueWrite(DPTBinary(False)),
             ),
         )
 
@@ -533,7 +548,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(30)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(30)),
+            ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
 
@@ -544,7 +562,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(23.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -556,7 +574,10 @@ class TestClimate(unittest.TestCase):
         _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             _telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(40)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(40)),
+            ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
         _telegram = xknx.telegrams.get_nowait()
@@ -564,7 +585,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(24.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(24.00))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -576,7 +597,10 @@ class TestClimate(unittest.TestCase):
         _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             _telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(35)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(35)),
+            ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
         _telegram = xknx.telegrams.get_nowait()
@@ -584,7 +608,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(23.50)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.50))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -619,7 +643,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(10)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(10)),
+            ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
 
@@ -630,7 +657,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(23.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -642,7 +669,10 @@ class TestClimate(unittest.TestCase):
         _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             _telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(0xF1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0xF1)),
+            ),
         )  # -15
         self.loop.run_until_complete(xknx.devices.process(_telegram))
         _telegram = xknx.telegrams.get_nowait()
@@ -650,7 +680,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(20.50)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(20.50))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -662,7 +692,10 @@ class TestClimate(unittest.TestCase):
         _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             _telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(0xE2)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0xE2)),
+            ),
         )  # -30
         self.loop.run_until_complete(xknx.devices.process(_telegram))
         _telegram = xknx.telegrams.get_nowait()
@@ -670,7 +703,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(19.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(19.00))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -709,7 +742,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             # temperature_step is 0.5 -> payload = setpoint_shift * 2
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(6)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(6)),
+            ),
         )
 
         self.loop.run_until_complete(climate.target_temperature.set(23.00))
@@ -720,7 +756,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(23.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
             ),
         )
         self.assertEqual(climate.base_temperature, 20.00)
@@ -730,7 +766,10 @@ class TestClimate(unittest.TestCase):
         self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
             _telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(8)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(8)),
+            ),
         )
         _telegram = xknx.telegrams.get_nowait()
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -738,7 +777,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(24.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(24.00))),
             ),
         )
         self.assertEqual(climate.target_temperature.value, 24.00)
@@ -771,7 +810,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=DPTArray(DPT2ByteFloat().to_knx(21.00)),
+                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(21.00))),
             ),
         )
         self.assertFalse(climate.initialized_for_setpoint_shift_calculations)
@@ -785,7 +824,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(10)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(10)),
+            ),
         )
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.base_temperature, 20.00)
@@ -799,7 +841,10 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(20)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(20)),
+            ),
         )
         _telegram = xknx.telegrams.get_nowait()
         self.loop.run_until_complete(xknx.devices.process(_telegram))
@@ -826,7 +871,7 @@ class TestClimate(unittest.TestCase):
             climate.target_temperature.process(
                 Telegram(
                     destination_address=GroupAddress("1/2/2"),
-                    payload=DPTArray(DPT2ByteFloat().to_knx(20.00)),
+                    payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(20.00))),
                 )
             )
         )
@@ -841,7 +886,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x00, 0x00)),
+                payload=GroupValueWrite(DPTArray((0x00, 0x00))),
             ),
         )  # 0
         # - 0.6 °C = 19.4
@@ -853,7 +898,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x87, 0xC4)),
+                payload=GroupValueWrite(DPTArray((0x87, 0xC4))),
             ),
         )  # -0.6
         # simulate incoming new target temperature for next calculation
@@ -861,7 +906,7 @@ class TestClimate(unittest.TestCase):
             climate.target_temperature.process(
                 Telegram(
                     destination_address=GroupAddress("1/2/2"),
-                    payload=DPTArray(DPT2ByteFloat().to_knx(19.40)),
+                    payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(19.40))),
                 )
             )
         )
@@ -874,7 +919,7 @@ class TestClimate(unittest.TestCase):
             _telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x01, 0x5E)),
+                payload=GroupValueWrite(DPTArray((0x01, 0x5E))),
             ),
         )  # +3.5
 
@@ -927,11 +972,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
-            telegram1,
-            Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
-            ),
+            telegram1, Telegram(GroupAddress("1/2/3"), payload=GroupValueRead())
         )
 
     def test_sync_operation_mode(self):
@@ -947,11 +988,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
-            telegram1,
-            Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
-            ),
+            telegram1, Telegram(GroupAddress("1/2/4"), payload=GroupValueRead())
         )
 
     def test_sync_controller_status(self):
@@ -967,11 +1004,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
-            telegram1,
-            Telegram(
-                destination_address=GroupAddress("1/2/24"),
-                telegramtype=TelegramType.GROUP_READ,
-            ),
+            telegram1, Telegram(GroupAddress("1/2/24"), payload=GroupValueRead())
         )
 
     def test_sync_controller_mode(self):
@@ -987,11 +1020,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
-            telegram1,
-            Telegram(
-                destination_address=GroupAddress("1/2/14"),
-                telegramtype=TelegramType.GROUP_READ,
-            ),
+            telegram1, Telegram(GroupAddress("1/2/14"), payload=GroupValueRead())
         )
 
     def test_sync_operation_mode_state(self):
@@ -1013,22 +1042,13 @@ class TestClimate(unittest.TestCase):
         telegrams = []
         for _ in range(3):
             telegrams.append(xknx.telegrams.get_nowait())
-        self.assertSetEqual(
-            set(telegrams),
-            {
-                Telegram(
-                    destination_address=GroupAddress("1/2/5"),
-                    telegramtype=TelegramType.GROUP_READ,
-                ),
-                Telegram(
-                    destination_address=GroupAddress("1/2/6"),
-                    telegramtype=TelegramType.GROUP_READ,
-                ),
-                Telegram(
-                    destination_address=GroupAddress("1/2/14"),
-                    telegramtype=TelegramType.GROUP_READ,
-                ),
-            },
+        self.assertListEqual(
+            telegrams,
+            [
+                Telegram(GroupAddress("1/2/5"), payload=GroupValueRead()),
+                Telegram(GroupAddress("1/2/6"), payload=GroupValueRead()),
+                Telegram(GroupAddress("1/2/14"), payload=GroupValueRead()),
+            ],
         )
 
     def test_sync_heat_cool(self):
@@ -1044,11 +1064,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
-            telegram1,
-            Telegram(
-                destination_address=GroupAddress("1/2/15"),
-                telegramtype=TelegramType.GROUP_READ,
-            ),
+            telegram1, Telegram(GroupAddress("1/2/15"), payload=GroupValueRead())
         )
 
     #
@@ -1059,8 +1075,10 @@ class TestClimate(unittest.TestCase):
         xknx = XKNX()
         climate = Climate(xknx, "TestClimate", group_address_temperature="1/2/3")
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.payload = DPTArray(DPTTemperature().to_knx(21.34))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(DPTTemperature().to_knx(21.34))),
+        )
         self.loop.run_until_complete(climate.process(telegram))
         self.assertEqual(climate.temperature.value, 21.34)
 
@@ -1074,15 +1092,21 @@ class TestClimate(unittest.TestCase):
             group_address_controller_status="1/2/3",
         )
         for operation_mode in DPT_20102_MODES:
-            telegram = Telegram(destination_address=GroupAddress("1/2/5"))
-            telegram.payload = DPTArray(DPTHVACMode.to_knx(operation_mode))
+            telegram = Telegram(
+                destination_address=GroupAddress("1/2/5"),
+                payload=GroupValueWrite(DPTArray(DPTHVACMode.to_knx(operation_mode))),
+            )
             self.loop.run_until_complete(climate_mode.process(telegram))
             self.assertEqual(climate_mode.operation_mode, operation_mode)
         for operation_mode in DPT_20102_MODES:
             if operation_mode == HVACOperationMode.AUTO:
                 continue
-            telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-            telegram.payload = DPTArray(DPTControllerStatus.to_knx(operation_mode))
+            telegram = Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(
+                    DPTArray(DPTControllerStatus.to_knx(operation_mode))
+                ),
+            )
             self.loop.run_until_complete(climate_mode.process(telegram))
             self.assertEqual(climate_mode.operation_mode, operation_mode)
 
@@ -1093,8 +1117,12 @@ class TestClimate(unittest.TestCase):
             xknx, "TestClimate", group_address_controller_mode="1/2/5"
         )
         for _, controller_mode in DPTHVACContrMode.SUPPORTED_MODES.items():
-            telegram = Telegram(destination_address=GroupAddress("1/2/5"))
-            telegram.payload = DPTArray(DPTHVACContrMode.to_knx(controller_mode))
+            telegram = Telegram(
+                destination_address=GroupAddress("1/2/5"),
+                payload=GroupValueWrite(
+                    DPTArray(DPTHVACContrMode.to_knx(controller_mode))
+                ),
+            )
             self.loop.run_until_complete(climate_mode.process(telegram))
             self.assertEqual(climate_mode.controller_mode, controller_mode)
 
@@ -1108,7 +1136,8 @@ class TestClimate(unittest.TestCase):
             group_address_controller_status="1/2/3",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(climate_mode.process(telegram))
@@ -1123,7 +1152,8 @@ class TestClimate(unittest.TestCase):
             group_address_controller_status="1/2/3",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(climate_mode.process(telegram))
@@ -1138,7 +1168,8 @@ class TestClimate(unittest.TestCase):
             group_address_controller_status="1/2/3",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(climate_mode.process(telegram))
@@ -1153,7 +1184,8 @@ class TestClimate(unittest.TestCase):
             group_address_controller_status="1/2/3",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(climate_mode.process(telegram))
@@ -1172,8 +1204,10 @@ class TestClimate(unittest.TestCase):
 
         climate.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.payload = DPTArray(DPTTemperature().to_knx(21.34))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(DPTTemperature().to_knx(21.34))),
+        )
         self.loop.run_until_complete(climate.process(telegram))
         after_update_callback.assert_called_with(climate)
 
@@ -1187,13 +1221,17 @@ class TestClimate(unittest.TestCase):
             group_address_heat_cool_state="1/2/15",
         )
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/14"))
-        telegram.payload = DPTBinary(False)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/14"),
+            payload=GroupValueWrite(DPTBinary(False)),
+        )
         self.loop.run_until_complete(climate_mode.process(telegram))
         self.assertEqual(climate_mode.controller_mode, HVACControllerMode.COOL)
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/14"))
-        telegram.payload = DPTBinary(True)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/14"),
+            payload=GroupValueWrite(DPTBinary(True)),
+        )
         self.loop.run_until_complete(climate_mode.process(telegram))
         self.assertEqual(climate_mode.controller_mode, HVACControllerMode.HEAT)
 
@@ -1349,16 +1387,20 @@ class TestClimate(unittest.TestCase):
         """Test process / reading telegrams from telegram queue. Test if DPT20.105 controller mode is set correctly."""
         xknx = XKNX()
         climate = Climate(xknx, "TestClimate", group_address_on_off="1/2/2")
-        telegram = Telegram(destination_address=GroupAddress("1/2/2"))
-        telegram.payload = DPTBinary(1)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/2"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
         self.loop.run_until_complete(climate.process(telegram))
         self.assertEqual(climate.is_on, True)
 
         climate_inv = Climate(
             xknx, "TestClimate", group_address_on_off="1/2/2", on_off_invert=True
         )
-        telegram = Telegram(destination_address=GroupAddress("1/2/2"))
-        telegram.payload = DPTBinary(1)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/2"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
         self.loop.run_until_complete(climate_inv.process(telegram))
         self.assertEqual(climate_inv.is_on, False)
 
@@ -1373,7 +1415,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/2"), payload=DPTBinary(True)
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(True)),
             ),
         )
         self.loop.run_until_complete(climate.turn_off())
@@ -1383,7 +1426,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/2"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(False)),
             ),
         )
 
@@ -1397,7 +1441,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/2"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(False)),
             ),
         )
         self.loop.run_until_complete(climate_inv.turn_off())
@@ -1407,6 +1452,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(
             _telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/2"), payload=DPTBinary(True)
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(True)),
             ),
         )

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from xknx import XKNX
 from xknx.devices import Cover
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueRead, GroupValueWrite, Telegram
 
 
 class TestCover(unittest.TestCase):
@@ -129,8 +129,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
         )
 
@@ -151,8 +150,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -173,16 +171,14 @@ class TestCover(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
         )
         telegram2 = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram2,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -203,8 +199,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -228,7 +223,10 @@ class TestCover(unittest.TestCase):
         # DPT 1.008 - 0:up 1:down
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     #
@@ -250,7 +248,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -273,7 +274,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     #
@@ -296,7 +300,10 @@ class TestCover(unittest.TestCase):
         # DPT 1.008 - 0:up 1:down
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/2"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     #
@@ -320,7 +327,10 @@ class TestCover(unittest.TestCase):
         # DPT 1.008 - 0:up 1:down
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/2"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -343,7 +353,10 @@ class TestCover(unittest.TestCase):
         # DPT 1.008 - 0:up 1:down
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/2"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -365,7 +378,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/2"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/2"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
         cover_manual_stop = Cover(
@@ -382,7 +398,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/0"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/0"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -404,7 +423,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x80)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0x80)),
+            ),
         )
 
     def test_position_without_position_address_up(self):
@@ -424,7 +446,10 @@ class TestCover(unittest.TestCase):
         # DPT 1.008 - 0:up 1:down
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
         self.assertEqual(cover.travelcalculator.travel_to_position, 50)
         self.assertTrue(cover.is_opening())
@@ -449,7 +474,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
         self.assertEqual(cover.travelcalculator.travel_to_position, 80)
         self.assertTrue(cover.is_closing())
@@ -480,7 +508,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     def test_position_without_position_address_uninitialized_down(self):
@@ -506,7 +537,10 @@ class TestCover(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     def test_angle(self):
@@ -528,7 +562,8 @@ class TestCover(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/4/18"), payload=DPTArray(0x80)
+                destination_address=GroupAddress("1/4/18"),
+                payload=GroupValueWrite(DPTArray(0x80)),
             ),
         )
 
@@ -564,14 +599,14 @@ class TestCover(unittest.TestCase):
         )
         # initial position process - position is unknown so this is the new state - not moving
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray(213)
+            GroupAddress("1/2/3"), payload=GroupValueWrite(DPTArray(213))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertEqual(cover.current_position(), 84)
         self.assertFalse(cover.is_traveling())
         # state telegram updates current position - we are not moving so this is new state - not moving
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/4"), payload=DPTArray(42)
+            GroupAddress("1/2/4"), payload=GroupValueWrite(DPTArray(42))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertEqual(cover.current_position(), 16)
@@ -579,7 +614,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(cover.travelcalculator.travel_to_position, 16)
         # new position - movement starts
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray(255)
+            GroupAddress("1/2/3"), payload=GroupValueWrite(DPTArray(255))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertEqual(cover.current_position(), 16)
@@ -587,7 +622,7 @@ class TestCover(unittest.TestCase):
         self.assertEqual(cover.travelcalculator.travel_to_position, 100)
         # new state while moving - movement goes on; travelcalculator updated
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/4"), payload=DPTArray(213)
+            GroupAddress("1/2/4"), payload=GroupValueWrite(DPTArray(213))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertEqual(cover.current_position(), 84)
@@ -606,7 +641,7 @@ class TestCover(unittest.TestCase):
             group_address_angle_state="1/2/4",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/4"), payload=DPTArray(42)
+            GroupAddress("1/2/4"), payload=GroupValueWrite(DPTArray(42))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertEqual(cover.current_angle(), 16)
@@ -620,7 +655,7 @@ class TestCover(unittest.TestCase):
         cover.travelcalculator.set_position(50)
         self.assertFalse(cover.is_traveling())
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/1"), payload=DPTBinary(0)
+            GroupAddress("1/2/1"), payload=GroupValueWrite(DPTBinary(0))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertTrue(cover.is_opening())
@@ -634,7 +669,7 @@ class TestCover(unittest.TestCase):
         cover.travelcalculator.set_position(50)
         self.assertFalse(cover.is_traveling())
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/1"), payload=DPTBinary(1)
+            GroupAddress("1/2/1"), payload=GroupValueWrite(DPTBinary(1))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertTrue(cover.is_closing())
@@ -652,7 +687,7 @@ class TestCover(unittest.TestCase):
         self.loop.run_until_complete(cover.set_down())
         self.assertTrue(cover.is_traveling())
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/2"), payload=DPTBinary(1)
+            GroupAddress("1/2/2"), payload=GroupValueWrite(DPTBinary(1))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertFalse(cover.is_traveling())
@@ -670,7 +705,7 @@ class TestCover(unittest.TestCase):
         self.loop.run_until_complete(cover.set_down())
         self.assertTrue(cover.is_traveling())
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/2"), payload=DPTBinary(1)
+            GroupAddress("1/2/2"), payload=GroupValueWrite(DPTBinary(1))
         )
         self.loop.run_until_complete(cover.process(telegram))
         self.assertFalse(cover.is_traveling())
@@ -708,14 +743,15 @@ class TestCover(unittest.TestCase):
         ]:
             with self.subTest(address=address, feature=feature):
                 telegram = Telegram(
-                    destination_address=GroupAddress(address), payload=payload
+                    destination_address=GroupAddress(address),
+                    payload=GroupValueWrite(payload),
                 )
                 self.loop.run_until_complete(cover.process(telegram))
                 after_update_callback.assert_called_with(cover)
                 after_update_callback.reset_mock()
         # Stop only when cover is travelling
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            GroupAddress("1/2/3"), payload=GroupValueWrite(DPTBinary(1))
         )
         self.loop.run_until_complete(cover.process(telegram))
         after_update_callback.assert_not_called()

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -7,7 +7,13 @@ from unittest.mock import patch
 from xknx import XKNX
 from xknx.devices import DateTime
 from xknx.dpt import DPTArray
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+)
 
 
 class TestDateTime(unittest.TestCase):
@@ -43,10 +49,9 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
-        self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
-        self.assertEqual(len(telegram.payload.value), 8)
+        self.assertEqual(len(telegram.payload.dpt.value), 8)
         self.assertEqual(
-            telegram.payload.value, (0x75, 0x01, 0x07, 0xE9, 0x0D, 0x0E, 0x20, 0x80)
+            telegram.payload.dpt.value, (0x75, 0x01, 0x07, 0xE9, 0x0D, 0x0E, 0x20, 0x80)
         )
 
     #
@@ -69,9 +74,8 @@ class TestDateTime(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
-        self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
-        self.assertEqual(len(telegram.payload.value), 3)
-        self.assertEqual(telegram.payload.value, (0x07, 0x01, 0x11))
+        self.assertEqual(len(telegram.payload.dpt.value), 3)
+        self.assertEqual(telegram.payload.dpt.value, (0x07, 0x01, 0x11))
 
     #
     # SYNC Time
@@ -93,9 +97,8 @@ class TestDateTime(unittest.TestCase):
 
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
-        self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
-        self.assertEqual(len(telegram.payload.value), 3)
-        self.assertEqual(telegram.payload.value, (0xE9, 0x0D, 0x0E))
+        self.assertEqual(len(telegram.payload.dpt.value), 3)
+        self.assertEqual(telegram.payload.dpt.value, (0xE9, 0x0D, 0x0E))
 
     #
     # PROCESS
@@ -111,8 +114,7 @@ class TestDateTime(unittest.TestCase):
         )
 
         telegram_read = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            telegramtype=TelegramType.GROUP_READ,
+            destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
         )
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
@@ -127,8 +129,7 @@ class TestDateTime(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_RESPONSE,
-                payload=DPTArray((0xE9, 0xD, 0xE)),
+                payload=GroupValueResponse(DPTArray((0xE9, 0xD, 0xE))),
             ),
         )
 

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, Mock, patch
 from xknx import XKNX
 from xknx.devices import Device, Sensor
 from xknx.dpt import DPTArray
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+)
 
 
 class TestDevice(unittest.TestCase):
@@ -102,9 +108,7 @@ class TestDevice(unittest.TestCase):
             fut.set_result(None)
             mock_group_read.return_value = fut
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/1"),
-                payload=DPTArray((0x01, 0x02)),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/1"), payload=GroupValueRead()
             )
             self.loop.run_until_complete(device.process(telegram))
             mock_group_read.assert_called_with(telegram)
@@ -115,8 +119,7 @@ class TestDevice(unittest.TestCase):
             mock_group_write.return_value = fut
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/1"),
-                payload=DPTArray((0x01, 0x02)),
-                telegramtype=TelegramType.GROUP_WRITE,
+                payload=GroupValueWrite(DPTArray((0x01, 0x02))),
             )
             self.loop.run_until_complete(device.process(telegram))
             mock_group_write.assert_called_with(telegram)
@@ -127,8 +130,7 @@ class TestDevice(unittest.TestCase):
             mock_group_response.return_value = fut
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/1"),
-                payload=DPTArray((0x01, 0x02)),
-                telegramtype=TelegramType.GROUP_RESPONSE,
+                payload=GroupValueResponse(DPTArray((0x01, 0x02))),
             )
             self.loop.run_until_complete(device.process(telegram))
             mock_group_response.assert_called_with(telegram)

--- a/test/devices_tests/expose_sensor_test.py
+++ b/test/devices_tests/expose_sensor_test.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 from xknx import XKNX
 from xknx.devices import ExposeSensor
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+)
 
 
 class TestExposeSensor(unittest.TestCase):
@@ -73,8 +79,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_WRITE,
-                payload=DPTBinary(0),
+                payload=GroupValueWrite(DPTBinary(0)),
             ),
         )
 
@@ -92,8 +97,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_WRITE,
-                payload=DPTArray((0xBF,)),
+                payload=GroupValueWrite(DPTArray((0xBF,))),
             ),
         )
 
@@ -110,8 +114,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_WRITE,
-                payload=DPTArray((0x0C, 0x1A)),
+                payload=GroupValueWrite(DPTArray((0x0C, 0x1A))),
             ),
         )
 
@@ -126,8 +129,7 @@ class TestExposeSensor(unittest.TestCase):
         )
         expose_sensor.sensor_value.payload = DPTBinary(1)
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.telegramtype = TelegramType.GROUP_READ
+        telegram = Telegram(GroupAddress("1/2/3"), payload=GroupValueRead())
         self.loop.run_until_complete(expose_sensor.process(telegram))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
@@ -135,8 +137,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_RESPONSE,
-                payload=DPTBinary(True),
+                payload=GroupValueResponse(DPTBinary(True)),
             ),
         )
 
@@ -148,8 +149,7 @@ class TestExposeSensor(unittest.TestCase):
         )
         expose_sensor.sensor_value.payload = DPTArray((0x40,))
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.telegramtype = TelegramType.GROUP_READ
+        telegram = Telegram(GroupAddress("1/2/3"), payload=GroupValueRead())
         self.loop.run_until_complete(expose_sensor.process(telegram))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
@@ -157,8 +157,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_RESPONSE,
-                payload=DPTArray((0x40,)),
+                payload=GroupValueResponse(DPTArray((0x40,))),
             ),
         )
 
@@ -170,8 +169,7 @@ class TestExposeSensor(unittest.TestCase):
         )
         expose_sensor.sensor_value.payload = DPTArray((0x0C, 0x1A))
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.telegramtype = TelegramType.GROUP_READ
+        telegram = Telegram(GroupAddress("1/2/3"), payload=GroupValueRead())
         self.loop.run_until_complete(expose_sensor.process(telegram))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
@@ -179,8 +177,7 @@ class TestExposeSensor(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_RESPONSE,
-                payload=DPTArray((0x0C, 0x1A)),
+                payload=GroupValueResponse(DPTArray((0x0C, 0x1A))),
             ),
         )
 

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Fan
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueRead, GroupValueWrite, Telegram
 
 
 class TestFan(unittest.TestCase):
@@ -39,8 +39,7 @@ class TestFan(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
         )
 
@@ -64,8 +63,7 @@ class TestFan(unittest.TestCase):
         self.assertEqual(
             telegram1,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -83,7 +81,10 @@ class TestFan(unittest.TestCase):
         # 140 is 55% as byte (0...255)
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTArray(140)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(140)),
+            ),
         )
 
     #
@@ -97,7 +98,8 @@ class TestFan(unittest.TestCase):
 
         # 140 is 55% as byte (0...255)
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray(140)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(140)),
         )
         self.loop.run_until_complete(fan.process(telegram))
         self.assertEqual(fan.current_speed, 55)
@@ -107,7 +109,8 @@ class TestFan(unittest.TestCase):
         xknx = XKNX()
         fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3")
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(fan.process(telegram))
@@ -118,7 +121,8 @@ class TestFan(unittest.TestCase):
         xknx = XKNX()
         fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3")
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(fan.process(telegram))

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Light
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueRead, GroupValueWrite, Telegram
 
 
 class TestLight(unittest.TestCase):
@@ -156,33 +156,27 @@ class TestLight(unittest.TestCase):
 
         test_telegrams = [
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/5"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/5"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/6"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/6"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/7"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/9"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/8"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/7"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/9"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/8"), payload=GroupValueRead()
             ),
         ]
 
-        self.assertEqual(len(set(telegrams)), 6)
-        self.assertEqual(set(telegrams), set(test_telegrams))
+        self.assertEqual(len(telegrams), 6)
+        self.assertListEqual(telegrams, test_telegrams)
 
     #
     # SYNC WITH STATE ADDRESS
@@ -216,33 +210,27 @@ class TestLight(unittest.TestCase):
 
         test_telegrams = [
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/6"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/6"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/8"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/8"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/10"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/14"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/12"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/10"), payload=GroupValueRead()
             ),
             Telegram(
-                destination_address=GroupAddress("1/2/14"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/12"), payload=GroupValueRead()
             ),
         ]
 
-        self.assertEqual(len(set(telegrams)), 6)
-        self.assertEqual(set(telegrams), set(test_telegrams))
+        self.assertEqual(len(telegrams), 6)
+        self.assertListEqual(telegrams, test_telegrams)
 
     #
     # TEST SET ON
@@ -261,7 +249,10 @@ class TestLight(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -281,7 +272,10 @@ class TestLight(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     #
@@ -301,7 +295,10 @@ class TestLight(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/5"), payload=DPTArray(23)),
+            Telegram(
+                destination_address=GroupAddress("1/2/5"),
+                payload=GroupValueWrite(DPTArray(23)),
+            ),
         )
 
     def test_set_brightness_not_dimmable(self):
@@ -335,7 +332,7 @@ class TestLight(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/5"),
-                payload=DPTArray((23, 24, 25)),
+                payload=GroupValueWrite(DPTArray((23, 24, 25))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(telegram))
@@ -373,7 +370,7 @@ class TestLight(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/5"),
-                payload=DPTArray((23, 24, 25, 26, 0, 15)),
+                payload=GroupValueWrite(DPTArray((23, 24, 25, 26, 0, 15))),
             ),
         )
         self.loop.run_until_complete(xknx.devices.process(telegram))
@@ -414,7 +411,10 @@ class TestLight(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/5"), payload=DPTArray(23)),
+            Telegram(
+                destination_address=GroupAddress("1/2/5"),
+                payload=GroupValueWrite(DPTArray(23)),
+            ),
         )
 
     def test_set_tw_unsupported(self):
@@ -448,10 +448,12 @@ class TestLight(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/5"),
-                payload=DPTArray(
-                    (
-                        0x0F,
-                        0xA0,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x0F,
+                            0xA0,
+                        )
                     )
                 ),
             ),
@@ -484,13 +486,15 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.state, None)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.state, True)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.state, False)
@@ -515,7 +519,8 @@ class TestLight(unittest.TestCase):
         light.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(light.process(telegram))
 
@@ -533,7 +538,8 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.current_brightness, None)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray(23)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray(23)),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.current_brightness, 23)
@@ -548,7 +554,8 @@ class TestLight(unittest.TestCase):
             group_address_brightness="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))
@@ -564,7 +571,8 @@ class TestLight(unittest.TestCase):
             group_address_brightness="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))
@@ -580,7 +588,8 @@ class TestLight(unittest.TestCase):
         )
         self.assertEqual(light.current_color, (None, None))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray((23, 24, 25))
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray((23, 24, 25))),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.current_color, ((23, 24, 25), None))
@@ -598,7 +607,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.current_color, (None, None))
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
-            payload=DPTArray((23, 24, 25, 26, 0, 15)),
+            payload=GroupValueWrite(DPTArray((23, 24, 25, 26, 0, 15))),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.current_color, ([23, 24, 25], 26))
@@ -615,7 +624,8 @@ class TestLight(unittest.TestCase):
         self.assertEqual(light.current_tunable_white, None)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray(23)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray(23)),
         )
         self.loop.run_until_complete(light.process(telegram))
         self.assertEqual(light.current_tunable_white, 23)
@@ -630,7 +640,8 @@ class TestLight(unittest.TestCase):
             group_address_tunable_white="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))
@@ -646,7 +657,8 @@ class TestLight(unittest.TestCase):
             group_address_tunable_white="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))
@@ -664,10 +676,12 @@ class TestLight(unittest.TestCase):
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
-            payload=DPTArray(
-                (
-                    0x0F,
-                    0xA0,
+            payload=GroupValueWrite(
+                DPTArray(
+                    (
+                        0x0F,
+                        0xA0,
+                    )
                 )
             ),
         )
@@ -684,7 +698,8 @@ class TestLight(unittest.TestCase):
             group_address_color_temperature="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))
@@ -700,7 +715,8 @@ class TestLight(unittest.TestCase):
             group_address_color_temperature="1/2/5",
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTArray(23)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTArray(23)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(light.process(telegram))

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.devices import Notification
 from xknx.dpt import DPTArray, DPTBinary, DPTString
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import GroupAddress, GroupValueRead, GroupValueWrite, Telegram
 
 
 class TestNotification(unittest.TestCase):
@@ -37,8 +37,7 @@ class TestNotification(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -51,14 +50,14 @@ class TestNotification(unittest.TestCase):
         notification = Notification(xknx, "Warning", group_address="1/2/3")
         telegram_set = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray(DPTString().to_knx("Ein Prosit!")),
+            payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
         )
         self.loop.run_until_complete(notification.process(telegram_set))
         self.assertEqual(notification.message, "Ein Prosit!")
 
         telegram_unset = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray(DPTString().to_knx("")),
+            payload=GroupValueWrite(DPTArray(DPTString().to_knx(""))),
         )
         self.loop.run_until_complete(notification.process(telegram_unset))
         self.assertEqual(notification.message, "")
@@ -77,7 +76,7 @@ class TestNotification(unittest.TestCase):
         notification.register_device_updated_cb(async_after_update_callback)
         telegram_set = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray(DPTString().to_knx("Ein Prosit!")),
+            payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
         )
         self.loop.run_until_complete(notification.process(telegram_set))
         after_update_callback.assert_called_with(notification)
@@ -88,7 +87,8 @@ class TestNotification(unittest.TestCase):
         xknx = XKNX()
         notification = Notification(xknx, "Warning", group_address="1/2/3")
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((23, 24))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((23, 24))),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(notification.process(telegram))
@@ -98,7 +98,8 @@ class TestNotification(unittest.TestCase):
         xknx = XKNX()
         notification = Notification(xknx, "Warning", group_address="1/2/3")
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(notification.process(telegram))
@@ -117,7 +118,7 @@ class TestNotification(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(DPTString().to_knx("Ein Prosit!")),
+                payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
             ),
         )
         # test if message longer than 14 chars gets cropped
@@ -129,7 +130,7 @@ class TestNotification(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(DPTString().to_knx("This is too lo")),
+                payload=GroupValueWrite(DPTArray(DPTString().to_knx("This is too lo"))),
             ),
         )
 

--- a/test/devices_tests/scene_test.py
+++ b/test/devices_tests/scene_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 from xknx import XKNX
 from xknx.devices import Scene
 from xknx.dpt import DPTArray
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestScene(unittest.TestCase):
@@ -46,7 +46,10 @@ class TestScene(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTArray(0x16)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTArray(0x16)),
+            ),
         )
 
     def test_do(self):
@@ -58,7 +61,10 @@ class TestScene(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/1"), payload=DPTArray(0x16)),
+            Telegram(
+                destination_address=GroupAddress("1/2/1"),
+                payload=GroupValueWrite(DPTArray(0x16)),
+            ),
         )
 
     def test_wrong_do(self):

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -5,7 +5,7 @@ import unittest
 from xknx import XKNX
 from xknx.devices import BinarySensor, ExposeSensor, Sensor
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.telegram import GroupAddress, Telegram, TelegramDirection, TelegramType
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram, TelegramDirection
 
 
 class SensorExposeLoopTest(unittest.TestCase):
@@ -1460,9 +1460,8 @@ class SensorExposeLoopTest(unittest.TestCase):
 
                 incoming_telegram = Telegram(
                     destination_address=GroupAddress("1/1/1"),
-                    telegramtype=TelegramType.GROUP_WRITE,
                     direction=TelegramDirection.INCOMING,
-                    payload=test_payload,
+                    payload=GroupValueWrite(test_payload),
                 )
                 self.loop.run_until_complete(sensor.process(incoming_telegram))
 
@@ -1482,9 +1481,8 @@ class SensorExposeLoopTest(unittest.TestCase):
                     outgoing_telegram,
                     Telegram(
                         destination_address=GroupAddress("2/2/2"),
-                        telegramtype=TelegramType.GROUP_WRITE,
                         direction=TelegramDirection.OUTGOING,
-                        payload=test_payload,
+                        payload=GroupValueWrite(test_payload),
                     ),
                 )
 
@@ -1510,9 +1508,8 @@ class SensorExposeLoopTest(unittest.TestCase):
 
                 incoming_telegram = Telegram(
                     destination_address=GroupAddress("1/1/1"),
-                    telegramtype=TelegramType.GROUP_WRITE,
                     direction=TelegramDirection.INCOMING,
-                    payload=test_payload,
+                    payload=GroupValueWrite(test_payload),
                 )
                 self.loop.run_until_complete(sensor.process(incoming_telegram))
 
@@ -1526,8 +1523,7 @@ class SensorExposeLoopTest(unittest.TestCase):
                     outgoing_telegram,
                     Telegram(
                         destination_address=GroupAddress("2/2/2"),
-                        telegramtype=TelegramType.GROUP_WRITE,
                         direction=TelegramDirection.OUTGOING,
-                        payload=test_payload,
+                        payload=GroupValueWrite(test_payload),
                     ),
                 )

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -6,7 +6,13 @@ from unittest.mock import Mock
 from xknx import XKNX
 from xknx.devices import Sensor
 from xknx.dpt import DPTArray
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+)
 
 
 class TestSensor(unittest.TestCase):
@@ -78,11 +84,12 @@ class TestSensor(unittest.TestCase):
         #  set initial payload of sensor
         sensor.sensor_value.payload = payload
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"), payload=payload)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"), payload=GroupValueWrite(payload)
+        )
         response_telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=payload,
-            telegramtype=TelegramType.GROUP_RESPONSE,
+            payload=GroupValueResponse(payload),
         )
 
         # verify not called when always_callback is False
@@ -2642,8 +2649,7 @@ class TestSensor(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
         )
 
@@ -2669,8 +2675,10 @@ class TestSensor(unittest.TestCase):
             xknx, "TestSensor", value_type="temperature", group_address_state="1/2/3"
         )
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.payload = DPTArray((0x06, 0xA0))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x06, 0xA0))),
+        )
         self.loop.run_until_complete(sensor.process(telegram))
         self.assertEqual(sensor.sensor_value.payload, DPTArray((0x06, 0xA0)))
         self.assertEqual(sensor.resolve_state(), 16.96)
@@ -2691,7 +2699,9 @@ class TestSensor(unittest.TestCase):
 
         sensor.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(destination_address=GroupAddress("1/2/3"))
-        telegram.payload = DPTArray((0x01, 0x02))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x01, 0x02))),
+        )
         self.loop.run_until_complete(sensor.process(telegram))
         after_update_callback.assert_called_with(sensor)

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -6,7 +6,13 @@ from unittest.mock import MagicMock, Mock, patch
 from xknx import XKNX
 from xknx.devices import Switch
 from xknx.dpt import DPTBinary
-from xknx.telegram import GroupAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    Telegram,
+)
 
 
 class AsyncMock(MagicMock):
@@ -44,8 +50,7 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
             ),
         )
 
@@ -63,8 +68,7 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/4"),
-                telegramtype=TelegramType.GROUP_READ,
+                destination_address=GroupAddress("1/2/4"), payload=GroupValueRead()
             ),
         )
 
@@ -87,10 +91,12 @@ class TestSwitch(unittest.TestCase):
         callback_mock.assert_not_called()
 
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         telegram_off = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
 
         self.loop.run_until_complete(switch1.process(telegram_on))
@@ -136,13 +142,11 @@ class TestSwitch(unittest.TestCase):
 
         telegram_on = Telegram(
             destination_address=GroupAddress("1/2/4"),
-            payload=DPTBinary(1),
-            telegramtype=TelegramType.GROUP_RESPONSE,
+            payload=GroupValueResponse(DPTBinary(1)),
         )
         telegram_off = Telegram(
             destination_address=GroupAddress("1/2/4"),
-            payload=DPTBinary(0),
-            telegramtype=TelegramType.GROUP_RESPONSE,
+            payload=GroupValueResponse(DPTBinary(0)),
         )
 
         self.loop.run_until_complete(switch1.process(telegram_on))
@@ -170,10 +174,12 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_inv_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         telegram_inv_off = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(switch.process(telegram_inv_on))
@@ -189,7 +195,8 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -208,7 +215,8 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueResponse(DPTBinary(1)),
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -238,7 +246,8 @@ class TestSwitch(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(switch.process(telegram))
 
@@ -256,7 +265,10 @@ class TestSwitch(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #
@@ -271,7 +283,10 @@ class TestSwitch(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     #
@@ -287,7 +302,10 @@ class TestSwitch(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
         self.loop.run_until_complete(switch.set_off())
@@ -295,7 +313,10 @@ class TestSwitch(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     #

--- a/test/io_tests/tunnelling_test.py
+++ b/test/io_tests/tunnelling_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray
 from xknx.io import Tunnelling, UDPClient
 from xknx.knxip import ErrorCode, KNXIPFrame, KNXIPServiceType, TunnellingAck
-from xknx.telegram import GroupAddress, IndividualAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, IndividualAddress, Telegram
 
 
 class TestTunnelling(unittest.TestCase):
@@ -29,7 +29,8 @@ class TestTunnelling(unittest.TestCase):
         communication_channel_id = 23
         udp_client = UDPClient(xknx, ("192.168.1.1", 0), ("192.168.1.2", 1234))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x1, 0x2, 0x3))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
         )
         sequence_counter = 42
         src_address = IndividualAddress("2.2.2")

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -6,7 +6,7 @@ from pytest import fixture, raises
 from xknx.dpt import DPTBinary, DPTComparator
 from xknx.exceptions import ConversionError, CouldNotParseKNXIP, UnsupportedCEMIMessage
 from xknx.knxip.cemi_frame import CEMIFrame
-from xknx.knxip.knxip_enum import APCICommand, CEMIFlags, CEMIMessageCode
+from xknx.knxip.knxip_enum import CEMIFlags, CEMIMessageCode
 from xknx.telegram import GroupAddress, GroupValueRead, IndividualAddress, Telegram
 
 
@@ -50,7 +50,7 @@ def test_valid_command(frame):
 
 def test_invalid_tpci_apci(frame):
     """Test for invalid APCICommand"""
-    with raises(UnsupportedCEMIMessage, match=r".*APCI not supported: .*"):
+    with raises(CouldNotParseKNXIP, match=r".*APCI not supported: .*"):
         frame.from_knx_data_link_layer(get_data(0x29, 0, 0, 0, 0, 1, 0xFFC0, []))
 
 
@@ -63,7 +63,6 @@ def test_invalid_apdu_len(frame):
 def test_invalid_src_addr(frame):
     """Test for invalid src addr"""
     frame.code = CEMIMessageCode.L_DATA_IND
-    frame.cmd = APCICommand.GROUP_READ
     frame.flags = 0
     frame.mpdu_len = 1
     frame.payload = GroupValueRead()
@@ -77,7 +76,6 @@ def test_invalid_src_addr(frame):
 def test_invalid_dst_addr(frame):
     """Test for invalid dst addr"""
     frame.code = CEMIMessageCode.L_DATA_IND
-    frame.cmd = APCICommand.GROUP_READ
     frame.flags = 0
     frame.mpdu_len = 1
     frame.payload = GroupValueRead()
@@ -91,7 +89,6 @@ def test_invalid_dst_addr(frame):
 def test_invalid_payload(frame):
     """Test for having wrong payload set"""
     frame.code = CEMIMessageCode.L_DATA_IND
-    frame.cmd = APCICommand.GROUP_READ
     frame.flags = 0
     frame.mpdu_len = 1
     frame.payload = DPTComparator()
@@ -117,14 +114,6 @@ def test_from_knx_with_not_implemented_cemi(frame):
         frame.from_knx(
             get_data(CEMIMessageCode.L_BUSMON_IND.value, 0, 0, 0, 0, 2, 0, [])
         )
-
-
-def test_invalid_telegram(frame):
-    """Test for invalid telegram type"""
-    packet_len = frame.from_knx(get_data(0x29, 0, 0, 0, 0, 1, 0, []))
-    frame.cmd = None
-    with raises(ConversionError, match=r".*Telegram not implemented for.*"):
-        tg = frame.telegram
 
 
 def test_invalid_invalid_len(frame):

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -6,7 +6,14 @@ import unittest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTTime
 from xknx.knxip import CEMIFrame, KNXIPFrame, KNXIPServiceType, RoutingIndication
-from xknx.telegram import GroupAddress, IndividualAddress, Telegram, TelegramType
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueResponse,
+    GroupValueWrite,
+    IndividualAddress,
+    Telegram,
+)
 
 
 class Test_KNXIP(unittest.TestCase):
@@ -36,8 +43,8 @@ class Test_KNXIP(unittest.TestCase):
         self.assertEqual(knxipframe.body.cemi.src_addr, IndividualAddress("1.2.2"))
         self.assertEqual(knxipframe.body.cemi.dst_addr, GroupAddress(337))
 
-        self.assertEqual(len(knxipframe.body.cemi.payload.value), 1)
-        self.assertEqual(knxipframe.body.cemi.payload.value[0], 0xF0)
+        self.assertEqual(len(knxipframe.body.cemi.payload.dpt.value), 1)
+        self.assertEqual(knxipframe.body.cemi.payload.dpt.value[0], 0xF0)
 
     def test_from_knx_to_knx(self):
         """Test parsing and streaming CEMIFrame KNX/IP."""
@@ -61,7 +68,9 @@ class Test_KNXIP(unittest.TestCase):
 
         telegram = Telegram(
             destination_address=GroupAddress(337),
-            payload=DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S"))),
+            payload=GroupValueWrite(
+                DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S")))
+            ),
         )
 
         knxipframe.body.cemi.telegram = telegram
@@ -86,8 +95,8 @@ class Test_KNXIP(unittest.TestCase):
 
         self.assertEqual(telegram.destination_address, GroupAddress(337))
 
-        self.assertEqual(len(telegram.payload.value), 1)
-        self.assertEqual(telegram.payload.value[0], 0xF0)
+        self.assertEqual(len(telegram.payload.dpt.value), 1)
+        self.assertEqual(telegram.payload.dpt.value[0], 0xF0)
 
     #
     # End-tox-End tests:
@@ -109,7 +118,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("329"),
-                payload=DPTBinary(1),
+                payload=GroupValueWrite(DPTBinary(1)),
                 source_address=IndividualAddress("15.15.249"),
             ),
         )
@@ -137,7 +146,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("329"),
-                payload=DPTBinary(0),
+                payload=GroupValueWrite(DPTBinary(0)),
                 source_address=IndividualAddress("15.15.249"),
             ),
         )
@@ -165,7 +174,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("331"),
-                payload=DPTArray(0x65),
+                payload=GroupValueWrite(DPTArray(0x65)),
                 source_address=IndividualAddress("15.15.249"),
             ),
         )
@@ -193,7 +202,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("2049"),
-                payload=DPTArray(DPTTemperature().to_knx(19.85)),
+                payload=GroupValueWrite(DPTArray(DPTTemperature().to_knx(19.85))),
                 source_address=IndividualAddress("1.4.2"),
             ),
         )
@@ -221,7 +230,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("440"),
-                telegramtype=TelegramType.GROUP_READ,
+                payload=GroupValueRead(),
                 source_address=IndividualAddress("15.15.249"),
             ),
         )
@@ -249,8 +258,7 @@ class Test_KNXIP(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("392"),
-                telegramtype=TelegramType.GROUP_RESPONSE,
-                payload=DPTBinary(1),
+                payload=GroupValueResponse(DPTBinary(1)),
                 source_address=IndividualAddress("1.3.1"),
             ),
         )
@@ -270,7 +278,7 @@ class Test_KNXIP(unittest.TestCase):
         """Test parsing and streaming CEMIFrame KNX/IP packet, testing maximum APCI."""
         telegram = Telegram(
             destination_address=GroupAddress(337),
-            payload=DPTBinary(DPTBinary.APCI_MAX_VALUE),
+            payload=GroupValueWrite(DPTBinary(DPTBinary.APCI_MAX_VALUE)),
             source_address=IndividualAddress("1.3.1"),
         )
         xknx = XKNX()

--- a/test/knxip_tests/tunnelling_request_test.py
+++ b/test/knxip_tests/tunnelling_request_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTBinary
 from xknx.exceptions import CouldNotParseKNXIP
 from xknx.knxip import CEMIFrame, KNXIPFrame, KNXIPServiceType, TunnellingRequest
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class Test_KNXIP_TunnelingReq(unittest.TestCase):
@@ -59,13 +59,17 @@ class Test_KNXIP_TunnelingReq(unittest.TestCase):
 
         self.assertEqual(
             knxipframe.body.cemi.telegram,
-            Telegram(destination_address=GroupAddress("9/0/8"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("9/0/8"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.TUNNELLING_REQUEST)
         knxipframe2.body.cemi.telegram = Telegram(
-            destination_address=GroupAddress("9/0/8"), payload=DPTBinary(1)
+            destination_address=GroupAddress("9/0/8"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         knxipframe2.body.sequence_counter = 23
         knxipframe2.normalize()

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.remote_value import RemoteValue1Count
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValue1Count(unittest.TestCase):
@@ -43,7 +43,8 @@ class TestRemoteValue1Count(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x64,))),
             ),
         )
         self.loop.run_until_complete(
@@ -56,7 +57,8 @@ class TestRemoteValue1Count(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x65,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x65,))),
             ),
         )
 
@@ -65,7 +67,8 @@ class TestRemoteValue1Count(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64,))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 100)
@@ -76,16 +79,19 @@ class TestRemoteValue1Count(unittest.TestCase):
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -12,7 +12,7 @@ from xknx.remote_value import (
     RemoteValueClimateMode,
 )
 from xknx.remote_value.remote_value_climate_mode import _RemoteValueBinaryClimateMode
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueDptValue1Ucount(unittest.TestCase):
@@ -178,7 +178,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x03,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x03,))),
             ),
         )
         self.loop.run_until_complete(
@@ -189,7 +190,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x04,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x04,))),
             ),
         )
 
@@ -207,7 +209,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(True)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(True)),
             ),
         )
         self.loop.run_until_complete(
@@ -218,7 +221,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(False)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(False)),
             ),
         )
 
@@ -231,7 +235,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE,
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x00,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x00,))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.AUTO)
@@ -245,7 +250,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             operation_mode=HVACOperationMode.FROST_PROTECTION,
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(True)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(True)),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.FROST_PROTECTION)
@@ -260,16 +266,19 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )
@@ -285,16 +294,19 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x01,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x01,))),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueColorRGB
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueColorRGB(unittest.TestCase):
@@ -66,7 +66,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x66)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
             ),
         )
         self.loop.run_until_complete(remote_value.set((100, 101, 104)))
@@ -76,7 +76,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x68)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x68))),
             ),
         )
 
@@ -86,7 +86,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x64, 0x65, 0x66)),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, (100, 101, 102))
@@ -97,12 +97,13 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x66, 0x67)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueColorRGBW
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueColorRGBW(unittest.TestCase):
@@ -94,7 +94,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F))),
             ),
         )
         self.loop.run_until_complete(remote_value.set((100, 101, 104, 105)))
@@ -104,7 +104,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x68, 0x69, 0x00, 0x0F)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x68, 0x69, 0x00, 0x0F))),
             ),
         )
 
@@ -114,7 +114,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F)),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, [100, 101, 102, 103])
@@ -125,18 +125,21 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64, 0x65, 0x66)),
+                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67)),
+                payload=GroupValueWrite(
+                    DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67))
+                ),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueDpt2ByteUnsigned
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueDptValue2Ucount(unittest.TestCase):
@@ -55,7 +55,7 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x0A, 0x0B)),
+                payload=GroupValueWrite(DPTArray((0x0A, 0x0B))),
             ),
         )
         self.loop.run_until_complete(remote_value.set(5500))
@@ -65,10 +65,12 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x15,
-                        0x7C,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x15,
+                            0x7C,
+                        )
                     )
                 ),
             ),
@@ -81,7 +83,8 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A, 0x0B))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x0A, 0x0B))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 2571)
@@ -94,22 +97,26 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
-            )
-            self.loop.run_until_complete(remote_value.process(telegram))
-        with self.assertRaises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x53,
-                        0x42,
+                payload=GroupValueWrite(DPTArray((0x64,))),
+            )
+            self.loop.run_until_complete(remote_value.process(telegram))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x53,
+                            0x42,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueDptValue1Ucount
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueDptValue1Ucount(unittest.TestCase):
@@ -54,7 +54,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x0A,))),
             ),
         )
         self.loop.run_until_complete(remote_value.set(11))
@@ -63,7 +64,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0B,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x0B,))),
             ),
         )
 
@@ -74,7 +76,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x0A,))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 10)
@@ -87,16 +90,19 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueSceneNumber
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueSceneNumber(unittest.TestCase):
@@ -52,7 +52,8 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x0A,))),
             ),
         )
         self.loop.run_until_complete(remote_value.set(12))
@@ -61,7 +62,8 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0B,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x0B,))),
             ),
         )
 
@@ -70,7 +72,8 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x0A,))),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 11)
@@ -81,16 +84,19 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueStep
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueStep(unittest.TestCase):
@@ -81,14 +81,20 @@ class TestRemoteValueStep(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
         self.loop.run_until_complete(remote_value.increase())
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
 
     def test_process(self):
@@ -96,7 +102,8 @@ class TestRemoteValueStep(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -108,12 +115,14 @@ class TestRemoteValueStep(unittest.TestCase):
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0x01)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(3)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueString
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueString(unittest.TestCase):
@@ -93,7 +93,9 @@ class TestRemoteValueString(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((97, 115, 100, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
+                payload=GroupValueWrite(
+                    DPTArray((97, 115, 100, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+                ),
             ),
         )
         self.loop.run_until_complete(remote_value.set("ASDF"))
@@ -103,7 +105,9 @@ class TestRemoteValueString(unittest.TestCase):
             telegram,
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((65, 83, 68, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
+                payload=GroupValueWrite(
+                    DPTArray((65, 83, 68, 70, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+                ),
             ),
         )
 
@@ -113,22 +117,24 @@ class TestRemoteValueString(unittest.TestCase):
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray(
-                (
-                    0x41,
-                    0x41,
-                    0x41,
-                    0x41,
-                    0x41,
-                    0x42,
-                    0x42,
-                    0x42,
-                    0x42,
-                    0x42,
-                    0x43,
-                    0x43,
-                    0x43,
-                    0x43,
+            payload=GroupValueWrite(
+                DPTArray(
+                    (
+                        0x41,
+                        0x41,
+                        0x41,
+                        0x41,
+                        0x41,
+                        0x42,
+                        0x42,
+                        0x42,
+                        0x42,
+                        0x42,
+                        0x43,
+                        0x43,
+                        0x43,
+                        0x43,
+                    )
                 )
             ),
         )
@@ -141,16 +147,19 @@ class TestRemoteValueString(unittest.TestCase):
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(
-                    (
-                        0x64,
-                        0x65,
+                payload=GroupValueWrite(
+                    DPTArray(
+                        (
+                            0x64,
+                            0x65,
+                        )
                     )
                 ),
             )

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueSwitch
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueSwitch(unittest.TestCase):
@@ -65,14 +65,20 @@ class TestRemoteValueSwitch(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
         self.loop.run_until_complete(remote_value.off())
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     def test_process(self):
@@ -80,7 +86,8 @@ class TestRemoteValueSwitch(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -92,7 +99,8 @@ class TestRemoteValueSwitch(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -105,12 +113,14 @@ class TestRemoteValueSwitch(unittest.TestCase):
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0x01)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(3)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -7,7 +7,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.remote_value import RemoteValue, RemoteValueSwitch
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValue(unittest.TestCase):
@@ -96,7 +96,7 @@ class TestRemoteValue(unittest.TestCase):
 
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/1"),
-                payload=DPTArray((0x01, 0x02)),
+                payload=GroupValueWrite(DPTArray((0x01, 0x02))),
             )
             with self.assertRaises(CouldNotParseTelegram):
                 self.loop.run_until_complete(remote_value.process(telegram))
@@ -113,7 +113,8 @@ class TestRemoteValue(unittest.TestCase):
 
             fut = asyncio.Future()
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
             )
             fut.set_result(telegram)
             patch_read.return_value = fut
@@ -158,7 +159,8 @@ class TestRemoteValue(unittest.TestCase):
             patch_valid.return_value = True
             test_payload = DPTArray((0x01, 0x02))
             telegram = Telegram(
-                destination_address=GroupAddress("1/1/1"), payload=test_payload
+                destination_address=GroupAddress("1/1/1"),
+                payload=GroupValueWrite(test_payload),
             )
             self.assertTrue(
                 self.loop.run_until_complete(

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueUpDown
-from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram import GroupAddress, GroupValueWrite, Telegram
 
 
 class TestRemoteValueUpDown(unittest.TestCase):
@@ -81,14 +81,20 @@ class TestRemoteValueUpDown(unittest.TestCase):
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(1)),
+            ),
         )
         self.loop.run_until_complete(remote_value.up())
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,
-            Telegram(destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)),
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(0)),
+            ),
         )
 
     def test_process(self):
@@ -96,7 +102,8 @@ class TestRemoteValueUpDown(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -108,12 +115,14 @@ class TestRemoteValueUpDown(unittest.TestCase):
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(0x01)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(3)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -481,7 +481,7 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(telegram),
             '<Telegram direction="Outgoing" source_address="0.0.0" '
-            'destination_address="GroupAddress("1/2/3")" payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
+            'destination_address="1/2/3" payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
         )
 
     def test_dib_generic(self):
@@ -649,7 +649,7 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(tunnelling_request),
             '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="<CEMIFrame SourceAddress="IndividualAddress("0.0.0")"'
-            ' DestinationAddress="GroupAddress("0/0/0")" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />',
+            ' DestinationAddress="GroupAddress("0/0/0")" Flags="               0" payload="None" />" />',
         )
 
     def test_tunnelling_ack(self):
@@ -675,7 +675,7 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(cemi_frame),
             '<CEMIFrame SourceAddress="GroupAddress("1/2/3")" DestinationAddress="GroupAddress("1/2/5")" Flags="1011110011100000" '
-            'Command="APCICommand.GROUP_WRITE" payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
+            'payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
         )
 
     def test_knxip_frame(self):
@@ -718,5 +718,5 @@ class TestStringRepresentations(unittest.TestCase):
         ri = RoutingIndication(xknx)
         self.assertEqual(
             str(ri),
-            '<RoutingIndication cemi="<CEMIFrame SourceAddress="IndividualAddress("0.0.0")" DestinationAddress="GroupAddress("0/0/0")" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />',
+            '<RoutingIndication cemi="<CEMIFrame SourceAddress="IndividualAddress("0.0.0")" DestinationAddress="GroupAddress("0/0/0")" Flags="               0" payload="None" />" />',
         )

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -55,7 +55,13 @@ from xknx.knxip import (
     TunnellingRequest,
 )
 from xknx.remote_value import RemoteValue
-from xknx.telegram import GroupAddress, IndividualAddress, Telegram, TelegramDirection
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueWrite,
+    IndividualAddress,
+    Telegram,
+    TelegramDirection,
+)
 
 
 # pylint: disable=too-many-public-methods,invalid-name
@@ -283,7 +289,7 @@ class TestStringRepresentations(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTArray(0x40),
+            payload=GroupValueWrite(DPTArray(0x40)),
         )
         self.loop.run_until_complete(sensor.process_group_write(telegram))
         self.assertEqual(
@@ -352,7 +358,7 @@ class TestStringRepresentations(unittest.TestCase):
         telegram = Telegram(
             destination_address=GroupAddress("7/0/10"),
             direction=TelegramDirection.INCOMING,
-            payload=DPTBinary(1),
+            payload=GroupValueWrite(DPTBinary(1)),
         )
         self.loop.run_until_complete(weather.process_group_write(telegram))
 
@@ -469,12 +475,13 @@ class TestStringRepresentations(unittest.TestCase):
     def test_telegram(self):
         """Test string representation of Telegram."""
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(7)
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(7)),
         )
         self.assertEqual(
             str(telegram),
             '<Telegram direction="Outgoing" source_address="0.0.0" '
-            'destination_address="GroupAddress("1/2/3")" payload="<DPTBinary value="7" />" />',
+            'destination_address="GroupAddress("1/2/3")" payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
         )
 
     def test_dib_generic(self):
@@ -662,12 +669,13 @@ class TestStringRepresentations(unittest.TestCase):
         cemi_frame = CEMIFrame(xknx)
         cemi_frame.src_addr = GroupAddress("1/2/3")
         cemi_frame.telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(7)
+            destination_address=GroupAddress("1/2/5"),
+            payload=GroupValueWrite(DPTBinary(7)),
         )
         self.assertEqual(
             str(cemi_frame),
-            '<CEMIFrame SourceAddress="GroupAddress("1/2/3")" DestinationAddress="GroupAddress("1/2/5")" Flags="1011110011100000" Command="APCIC'
-            'ommand.GROUP_WRITE" payload="<DPTBinary value="7" />" />',
+            '<CEMIFrame SourceAddress="GroupAddress("1/2/3")" DestinationAddress="GroupAddress("1/2/5")" Flags="1011110011100000" '
+            'Command="APCICommand.GROUP_WRITE" payload="<GroupValueWrite dpt="<DPTBinary value="7" />" />" />',
         )
 
     def test_knxip_frame(self):

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -473,8 +473,8 @@ class TestStringRepresentations(unittest.TestCase):
         )
         self.assertEqual(
             str(telegram),
-            '<Telegram direction="Outgoing" telegramtype="GroupValueWrite" source_address="0.0.0" '
-            'destination_address="1/2/3" payload="<DPTBinary value="7" />" />',
+            '<Telegram direction="Outgoing" source_address="0.0.0" '
+            'destination_address="GroupAddress("1/2/3")" payload="<DPTBinary value="7" />" />',
         )
 
     def test_dib_generic(self):

--- a/test/telegram_tests/telegram_test.py
+++ b/test/telegram_tests/telegram_test.py
@@ -1,7 +1,14 @@
 """Unit test for Telegram objects."""
 import unittest
 
-from xknx.telegram import GroupAddress, Telegram, TelegramDirection, TelegramType
+from xknx.dpt import DPTBinary
+from xknx.telegram import (
+    GroupAddress,
+    GroupValueRead,
+    GroupValueWrite,
+    Telegram,
+    TelegramDirection,
+)
 
 
 class TestTelegram(unittest.TestCase):
@@ -13,25 +20,25 @@ class TestTelegram(unittest.TestCase):
     def test_telegram_equal(self):
         """Test equals operator."""
         self.assertEqual(
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_READ),
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_READ),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueRead()),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueRead()),
         )
 
     def test_telegram_not_equal(self):
         """Test not equals operator."""
         self.assertNotEqual(
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_READ),
-            Telegram(GroupAddress("1/2/4"), TelegramType.GROUP_READ),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueRead()),
+            Telegram(GroupAddress("1/2/4"), payload=GroupValueRead()),
         )
         self.assertNotEqual(
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_READ),
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_WRITE),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueRead()),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueWrite(DPTBinary(1))),
         )
         self.assertNotEqual(
-            Telegram(GroupAddress("1/2/3"), TelegramType.GROUP_READ),
+            Telegram(GroupAddress("1/2/3"), payload=GroupValueRead()),
             Telegram(
                 GroupAddress("1/2/3"),
-                TelegramType.GROUP_READ,
                 TelegramDirection.INCOMING,
+                payload=GroupValueRead(),
             ),
         )

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -11,7 +11,7 @@ import asyncio
 import logging
 
 from xknx.exceptions import CommunicationError, XKNXException
-from xknx.telegram import TelegramDirection, TelegramType
+from xknx.telegram import GroupValueWrite, TelegramDirection
 
 logger = logging.getLogger("xknx.log")
 telegram_logger = logging.getLogger("xknx.telegram")
@@ -133,7 +133,7 @@ class TelegramQueue:
         telegram_logger.debug(telegram)
         if self.xknx.knxip_interface is not None:
             await self.xknx.knxip_interface.send_telegram(telegram)
-            if telegram.telegramtype == TelegramType.GROUP_WRITE:
+            if isinstance(telegram.payload, GroupValueWrite):
                 await self.xknx.devices.process(telegram)
         else:
             logger.warning("No KNXIP interface defined")

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -10,7 +10,7 @@ The module will
 import asyncio
 import logging
 
-from xknx.telegram import Telegram, TelegramType
+from xknx.telegram import GroupValueRead, GroupValueResponse, GroupValueWrite, Telegram
 
 logger = logging.getLogger("xknx.log")
 
@@ -49,19 +49,14 @@ class ValueReader:
     async def send_group_read(self):
         """Send group read."""
         telegram = Telegram(
-            destination_address=self.group_address, telegramtype=TelegramType.GROUP_READ
+            destination_address=self.group_address, payload=GroupValueRead()
         )
         await self.xknx.telegrams.put(telegram)
 
     async def telegram_received(self, telegram):
         """Test if telegram has correct group address and trigger event."""
-        if (
-            telegram.destination_address == self.group_address
-            and telegram.telegramtype
-            in (
-                TelegramType.GROUP_RESPONSE,
-                TelegramType.GROUP_WRITE,
-            )
+        if telegram.destination_address == self.group_address and isinstance(
+            telegram.payload, (GroupValueResponse, GroupValueWrite)
         ):
             self.success = True
             self.received_telegram = telegram

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -5,7 +5,7 @@ It provides basis functionality for reading the state from the KNX bus.
 """
 import logging
 
-from xknx.telegram import TelegramType
+from xknx.telegram import GroupValueRead, GroupValueResponse, GroupValueWrite
 
 logger = logging.getLogger("xknx.log")
 
@@ -51,12 +51,14 @@ class Device:
 
     async def process(self, telegram):
         """Process incoming telegram."""
-        if telegram.telegramtype == TelegramType.GROUP_WRITE:
+        if isinstance(telegram.payload, GroupValueWrite):
             await self.process_group_write(telegram)
-        elif telegram.telegramtype == TelegramType.GROUP_RESPONSE:
+        elif isinstance(telegram.payload, GroupValueResponse):
             await self.process_group_response(telegram)
-        elif telegram.telegramtype == TelegramType.GROUP_READ:
+        elif isinstance(telegram.payload, GroupValueRead):
             await self.process_group_read(telegram)
+        else:
+            raise ValueError("Unsupported payload.")
 
     async def process_group_read(self, telegram):
         """Process incoming GroupValueRead telegrams."""
@@ -69,7 +71,7 @@ class Device:
 
     async def process_group_write(self, telegram):
         """Process incoming GroupValueWrite telegrams."""
-        # The dafault is, that devices dont process group writes
+        # The default is, that devices dont process group writes
 
     def get_name(self):
         """Return name of device."""

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -6,7 +6,6 @@ Routing uses UDP Multicast to broadcast and receive KNX/IP messages.
 import logging
 
 from xknx.knxip import (
-    APCICommand,
     CEMIFrame,
     CEMIMessageCode,
     KNXIPFrame,
@@ -49,12 +48,6 @@ class Routing:
             return
         elif knxipframe.body.cemi.src_addr == self.xknx.own_address:
             logger.debug("Ignoring own packet")
-        elif knxipframe.body.cemi.cmd not in (
-            APCICommand.GROUP_READ,
-            APCICommand.GROUP_WRITE,
-            APCICommand.GROUP_RESPONSE,
-        ):
-            logger.warning("APCI not implemented: %s", knxipframe)
         else:
             telegram = knxipframe.body.cemi.telegram
             telegram.direction = TelegramDirection.INCOMING

--- a/xknx/knxip/__init__.py
+++ b/xknx/knxip/__init__.py
@@ -14,7 +14,6 @@ from .header import KNXIPHeader
 from .hpai import HPAI
 from .knxip import KNXIPFrame
 from .knxip_enum import (
-    APCICommand,
     CEMIFlags,
     CEMIMessageCode,
     ConnectRequestType,

--- a/xknx/knxip/knxip_enum.py
+++ b/xknx/knxip/knxip_enum.py
@@ -52,9 +52,9 @@ class CEMIMessageCode(Enum):
 class APCICommand(Enum):
     """Enum class for KNX/IP APCI Commands."""
 
-    GROUP_READ = 0x00
-    GROUP_WRITE = 0x80
-    GROUP_RESPONSE = 0x40
+    GROUP_READ = 0x0000
+    GROUP_RESPONSE = 0x0040
+    GROUP_WRITE = 0x0080
 
 
 class CEMIFlags:

--- a/xknx/knxip/knxip_enum.py
+++ b/xknx/knxip/knxip_enum.py
@@ -49,14 +49,6 @@ class CEMIMessageCode(Enum):
     L_RAW_CON = 0x2F
 
 
-class APCICommand(Enum):
-    """Enum class for KNX/IP APCI Commands."""
-
-    GROUP_READ = 0x0000
-    GROUP_RESPONSE = 0x0040
-    GROUP_WRITE = 0x0080
-
-
 class CEMIFlags:
     """Enum class for KNX/IP CEMI Flags."""
 

--- a/xknx/telegram/__init__.py
+++ b/xknx/telegram/__init__.py
@@ -8,4 +8,5 @@ Module for handling KNX primitves.
 # flake8: noqa
 from .address import GroupAddress, GroupAddressType, IndividualAddress
 from .address_filter import AddressFilter
+from .apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 from .telegram import Telegram, TelegramDirection

--- a/xknx/telegram/__init__.py
+++ b/xknx/telegram/__init__.py
@@ -8,4 +8,4 @@ Module for handling KNX primitves.
 # flake8: noqa
 from .address import GroupAddress, GroupAddressType, IndividualAddress
 from .address_filter import AddressFilter
-from .telegram import Telegram, TelegramDirection, TelegramType
+from .telegram import Telegram, TelegramDirection

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -1,0 +1,213 @@
+"""
+Module for serialization and deserialization of APCI payloads.
+
+APCI stands for Application Layer Protocol Control Information.
+
+An APCI payload contains a service and payload. For example, a GroupValueWrite
+is a service that takes a DPT as a value.
+"""
+from enum import Enum
+import logging
+from typing import Optional, Type, Union
+
+from xknx.dpt import DPTArray, DPTBinary
+from xknx.exceptions import ConversionError
+
+logger = logging.getLogger("xknx.log")
+
+
+def encode_cmd_and_payload(
+    cmd: "APCICommand",
+    encoded_payload: int = 0,
+    appended_payload: Optional[bytes] = None,
+) -> bytes:
+    """Encode cmd and payload."""
+    if appended_payload is None:
+        appended_payload = bytes()
+
+    data = bytearray(
+        [
+            1 + len(appended_payload),
+            (cmd.value >> 8) & 0xFF,
+            (cmd.value & 0xFF) | (encoded_payload & DPTBinary.APCI_BITMASK),
+        ]
+    )
+    data.extend(appended_payload)
+    return data
+
+
+class APCICommand(Enum):
+    """Enum class for APCI services."""
+
+    GROUP_READ = 0x0000
+    GROUP_RESPONSE = 0x0040
+    GROUP_WRITE = 0x0080
+
+    ESCAPE = 0x03C0
+
+
+class APCIExtendedCommand(Enum):
+    """Enum class for extended APCI services."""
+
+
+class APCI:
+    """
+    Base class for ACPI services.
+
+    This base class is only the interface for the derived classes.
+    """
+
+    code: APCICommand = APCICommand.ESCAPE
+
+    def __init__(self) -> None:
+        """Initialize APCI class."""
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload - to be implemented in derived class."""
+        logger.warning(
+            "'calculated_length()' not implemented for %s", self.__class__.__name__
+        )
+
+        return 0
+
+    def from_knx(self, raw: bytes) -> None:
+        """Parse/deserialize from KNX/IP raw data - to be implemented in derived class."""
+        # pylint: disable=unused-argument
+        logger.warning("'from_knx()' not implemented for %s", self.__class__.__name__)
+
+    def to_knx(self) -> bytes:
+        """Serialize to KNX/IP raw data - to be implemented in derived class."""
+        # pylint: disable=unused-argument
+        logger.warning("'to_knx()' not implemented for %s", self.__class__.__name__)
+
+        return bytes()
+
+    def __eq__(self, other: object) -> bool:
+        """Equal operator."""
+        return self.__dict__ == other.__dict__
+
+    @staticmethod
+    def resolve_class(apci: int) -> Type["APCI"]:
+        """Return telegram type from APCI Command."""
+        extended = (apci & APCICommand.ESCAPE.value) == APCICommand.ESCAPE.value
+
+        if extended:
+            raise ConversionError(
+                f"Telegram not implemented for extended APCI {apci:#012b}."
+            )
+
+        apci = apci & 0x03C0
+
+        if apci == APCICommand.GROUP_READ.value:
+            return GroupValueRead
+        if apci == APCICommand.GROUP_WRITE.value:
+            return GroupValueWrite
+        if apci == APCICommand.GROUP_RESPONSE.value:
+            return GroupValueResponse
+        raise ConversionError(f"Telegram not implemented for APCI {apci:#012b}.")
+
+
+class GroupValueRead(APCI):
+    """
+    GroupValueRead service.
+
+    Does not have any payload.
+    """
+
+    code = APCICommand.GROUP_READ
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 1
+
+    def to_knx(self) -> bytes:
+        """Serialize to KNX/IP raw data."""
+        return encode_cmd_and_payload(self.code)
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return "<GroupValueRead />"
+
+
+class GroupValueWrite(APCI):
+    """
+    GroupValueRead service.
+
+    Takes a DPT as payload.
+    """
+
+    code = APCICommand.GROUP_WRITE
+
+    def __init__(self, dpt: Optional[Union[DPTBinary, DPTArray]] = None) -> None:
+        """Initialize a new instance of GroupValueWrite."""
+        super().__init__()
+        self.dpt = dpt
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        if isinstance(self.dpt, DPTBinary):
+            return 1
+        if isinstance(self.dpt, DPTArray):
+            return 1 + len(self.dpt.value)
+        raise TypeError()
+
+    def from_knx(self, raw: bytes) -> None:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) == 1:
+            self.dpt = DPTBinary(raw[0] & DPTBinary.APCI_BITMASK)
+        else:
+            self.dpt = DPTArray(raw[1:])
+
+    def to_knx(self) -> bytes:
+        """Serialize to KNX/IP raw data."""
+        if isinstance(self.dpt, DPTBinary):
+            return encode_cmd_and_payload(self.code, encoded_payload=self.dpt.value)
+        if isinstance(self.dpt, DPTArray):
+            return encode_cmd_and_payload(self.code, appended_payload=self.dpt.value)
+        raise TypeError()
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return f'<GroupValueWrite dpt="{self.dpt}" />'
+
+
+class GroupValueResponse(APCI):
+    """
+    GroupValueResponse service.
+
+    Takes a DPT as payload.
+    """
+
+    code = APCICommand.GROUP_RESPONSE
+
+    def __init__(self, dpt: Optional[Union[DPTBinary, DPTArray]] = None) -> None:
+        """Initialize a new instance of GroupValueResponse."""
+        super().__init__()
+        self.dpt = dpt
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        if isinstance(self.dpt, DPTBinary):
+            return 1
+        if isinstance(self.dpt, DPTArray):
+            return 1 + len(self.dpt.value)
+        raise TypeError()
+
+    def from_knx(self, raw: bytes) -> None:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) == 1:
+            self.dpt = DPTBinary(raw[0] & DPTBinary.APCI_BITMASK)
+        else:
+            self.dpt = DPTArray(raw[1:])
+
+    def to_knx(self) -> bytes:
+        """Serialize to KNX/IP raw data."""
+        if isinstance(self.dpt, DPTBinary):
+            return encode_cmd_and_payload(self.code, encoded_payload=self.dpt.value)
+        if isinstance(self.dpt, DPTArray):
+            return encode_cmd_and_payload(self.code, appended_payload=self.dpt.value)
+        raise TypeError()
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return f'<GroupValueResponse dpt="{self.dpt}" />'

--- a/xknx/telegram/telegram.py
+++ b/xknx/telegram/telegram.py
@@ -8,10 +8,9 @@ The telegram class is the leightweight interaction object between
 
 It contains
 
-* the telegram type (e.g. GROUP_WRITE)
 * the direction (incoming or outgoing)
 * the group address (e.g. 1/2/3)
-* and the payload (e.g. "12%" or "23.23 C".
+* and the payload (e.g. GroupValueWrite("12%")).
 
 """
 from enum import Enum
@@ -27,14 +26,6 @@ class TelegramDirection(Enum):
     OUTGOING = "Outgoing"
 
 
-class TelegramType(Enum):
-    """Enum class for type of telegram."""
-
-    GROUP_READ = "GroupValueRead"
-    GROUP_WRITE = "GroupValueWrite"
-    GROUP_RESPONSE = "GroupValueResponse"
-
-
 class Telegram:
     """Class for KNX telegrams."""
 
@@ -45,14 +36,12 @@ class Telegram:
         destination_address: Union[GroupAddress, IndividualAddress] = GroupAddress(
             None
         ),
-        telegramtype: TelegramType = TelegramType.GROUP_WRITE,
         direction: TelegramDirection = TelegramDirection.OUTGOING,
         payload: Any = None,
         source_address: IndividualAddress = IndividualAddress(None),
     ) -> None:
         """Initialize Telegram class."""
         self.destination_address = destination_address
-        self.telegramtype = telegramtype
         self.direction = direction
         self.payload = payload
         self.source_address = source_address
@@ -60,10 +49,9 @@ class Telegram:
     def __str__(self) -> str:
         """Return object as readable string."""
         return (
-            '<Telegram direction="{}" telegramtype="{}" source_address="{}" '
+            '<Telegram direction="{}" source_address="{}" '
             'destination_address="{}" payload="{}" />'.format(
                 self.direction.value,
-                self.telegramtype.value,
                 self.source_address,
                 self.destination_address,
                 self.payload,


### PR DESCRIPTION
This PR adds support for additional APCI services. APCI services are the actual payloads to communicate with actors. These payloads can be used for broadcast messages such as GroupValueWrite, but also for unicast messages such as MemoryRead. I need this to perform low(er)-level operations on my custom actors.

The main focus of this library was GroupValue payloads, so I had to refactor several parts of this library to make it more extensible. Fortunately, most of the higher-level API is still the same. In short:

- `Telegram.group_address` got replaced by `Telegram.address` (APCI supports both types)
- `Telegram.payload` should be a class that extends `knx.telegram.apci.APCI`. For instance, to write a DPT to a group address, you now use `Telegram(.., payload=GroupValueWrite(DPTArray(..)))`.
- `Telegram.telegramtype` is now encoded in `knx.telegram.apci.APCI.code`.

I've added two examples ([example_info.py](https://github.com/basilfx/xknx/blob/feature/apci_payload/examples/example_info.py) and [example_restart.py](https://github.com/basilfx/xknx/blob/feature/apci_payload/examples/example_restart.py)) to demonstate the new features.

Current limitation is that payloads can only be used in connectionless mode. This is not different from before, but several unicast messages are typically used with an active connection (that also supports sequencing and ACK/NACK on transport level). This would require more changes.

Current state is WIP and should not yet be merged. It's here to show and share my interest in this feature, and collect preliminary feedback. I'll continue on this one, but it needs a bit more time to fix the last part.