### PR TITLE
Corrected binding to multicast address in Windows

### DIFF
--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -6,6 +6,7 @@ Due to lame support of UDP multicast within asyncio some special treatment for m
 """
 import asyncio
 import socket
+from sys import platform
 
 from xknx.exceptions import CouldNotParseKNXIP, XKNXException
 from xknx.knxip import KNXIPFrame
@@ -144,7 +145,10 @@ class UDPClient:
         # - bind() with own_ip does not work with ROUTING_INDICATIONS on Gira
         #   knx router - for an unknown reason.
         if bind_to_multicast_addr:
-            sock.bind((remote_addr[0], remote_addr[1]))
+            if platform == "win32":
+                sock.bind(('', remote_addr[1]))
+            else:
+                sock.bind((remote_addr[0], remote_addr[1]))
         else:
             sock.bind((own_ip, 0))
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 0)


### PR DESCRIPTION
I got the following error in Home Assistant while using the KNX component on Windows.
```
2020-01-21 09:08:42 ERROR (MainThread) [homeassistant.setup] Error during setup of component knx
Traceback (most recent call last):
  File "d:\homeassistant\lib\site-packages\homeassistant\setup.py", line 169, in _async_setup_component
    result = await component.async_setup(  # type: ignore
  File "d:\homeassistant\lib\site-packages\homeassistant\components\knx\__init__.py", line 101, in async_setup
    await hass.data[DATA_KNX].start()
  File "d:\homeassistant\lib\site-packages\homeassistant\components\knx\__init__.py", line 171, in start
    await self.xknx.start(
  File "d:\homeassistant\lib\site-packages\xknx\xknx.py", line 76, in start
    await self.knxip_interface.start()
  File "d:\homeassistant\lib\site-packages\xknx\io\knxip_interface.py", line 93, in start
    await self.start_routing(
  File "d:\homeassistant\lib\site-packages\xknx\io\knxip_interface.py", line 155, in start_routing
    await self.interface.start()
  File "d:\homeassistant\lib\site-packages\xknx\io\routing.py", line 66, in start
    await self.udpclient.connect()
  File "d:\homeassistant\lib\site-packages\xknx\io\udp_client.py", line 164, in connect
    sock = UDPClient.create_multicast_sock(self.local_addr[0], self.remote_addr, self.bind_to_multicast_addr)
  File "d:\homeassistant\lib\site-packages\xknx\io\udp_client.py", line 151, in create_multicast_sock
    sock.bind((remote_addr[0], remote_addr[1]))
OSError: [WinError 10049] The requested address is not valid in its context
```
The way of binding to the multicast address in Windows is different to the way of binding in Linux / Mac OS.

I fixed this with the this patch.

Note: this is my first pull request ever on Github so forgive me if there is something wrong with this PR :grinning: