### PR TITLE
Bugfix: finish the last task from the telegram queue

### DIFF
--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -62,6 +62,7 @@ class TelegramQueue():
 
             # Breaking up queue if None is pushed to the queue
             if telegram is None:
+                self.xknx.telegrams.task_done()
                 break
 
             await self.process_telegram(telegram)


### PR DESCRIPTION
When xknx is started and stopped multiple times sequentially
```python
await xknx.start()
await xknx.stop()
await asyncio.sleep(1)
await xknx.start()
await xknx.stop()
```
the second stop() call blocked infinitely https://github.com/XKNX/xknx/blob/ef18a0fa4795655e275721a08ffc5605d4095b02/xknx/xknx.py#L91
because of the `None` had no task_done() .