### PR TITLE
make HA entities updateable from `homeassistant.update_entity` service

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -124,6 +124,10 @@ class KNXBinarySensor(BinarySensorDevice):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -215,6 +215,11 @@ class KNXClimate(ClimateDevice):
         self.device.register_device_updated_cb(after_update_callback)
         self.device.mode.register_device_updated_cb(after_update_callback)
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+        await self.device.mode.sync()
+
     @property
     def name(self) -> str:
         """Return the name of the KNX device."""

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -116,6 +116,10 @@ class KNXCover(CoverDevice):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/home-assistant-plugin/custom_components/xknx/light.py
+++ b/home-assistant-plugin/custom_components/xknx/light.py
@@ -162,6 +162,10 @@ class KNXLight(Light):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -77,6 +77,10 @@ class KNXSensor(Entity):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Update the state from KNX."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""

--- a/home-assistant-plugin/custom_components/xknx/switch.py
+++ b/home-assistant-plugin/custom_components/xknx/switch.py
@@ -73,6 +73,10 @@ class KNXSwitch(SwitchDevice):
         """Store register state change callback."""
         self.async_register_callbacks()
 
+    async def async_update(self):
+        """Request a state update from KNX bus."""
+        await self.device.sync()
+
     @property
     def name(self):
         """Return the name of the KNX device."""


### PR DESCRIPTION
a service call to `homeassistant.update_entity` with the entity_id as payload issues GroupValueRead requests for all readable device GAs. 
This can be handy especially for sensors and binary_sensors.
If `sync_state` is false for the entity_id no telegrams will be sent.