### PR TITLE
Fix the parsing of operation mode strings to HVACOperationMode

### DIFF
--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -980,7 +980,7 @@ class TestClimate(unittest.TestCase):
 
     def test_custom_supported_operation_modes_as_str(self):
         """Test get_supported_operation_modes with custom mode as str list."""
-        str_modes = ['STANDBY', 'FROST_PROTECTION']
+        str_modes = ['Standby', 'Frost Protection']
         modes = [HVACOperationMode.STANDBY, HVACOperationMode.FROST_PROTECTION]
         xknx = XKNX(loop=self.loop)
         climate_mode = ClimateMode(

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -71,7 +71,7 @@ class ClimateMode(Device):
         else:
             for mode in operation_modes:
                 if isinstance(mode, str):
-                    self.operation_modes_.append(HVACOperationMode[mode])
+                    self.operation_modes_.append(HVACOperationMode(mode))
                 elif isinstance(mode, HVACOperationMode):
                     self.operation_modes_.append(mode)
 


### PR DESCRIPTION
I tried to use the operation_modes option in HomeAssistant and it appears that there is a bug in XKNX when it tries to parse the provided operation_modes to HVACOperationMode.
This PR fixes that.
The problem was that it tried to match the provided string with the keys of the HVACOpertaionMode enum instead of using it as the value to get the key.