### PR TITLE
Added config option force_hook to binary sensors

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -13,7 +13,7 @@ CONF_STATE_ADDRESS = "state_address"
 CONF_SIGNIFICANT_BIT = "significant_bit"
 CONF_DEFAULT_SIGNIFICANT_BIT = 1
 CONF_SYNC_STATE = "sync_state"
-CONF_FORCE_HOOK = "force_hook"
+CONF_IGNORE_INTERNAL_STATE = "ignore_internal_state"
 CONF_AUTOMATION = "automation"
 CONF_HOOK = "hook"
 CONF_DEFAULT_HOOK = "on"
@@ -42,7 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
         ): cv.positive_int,
         vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-        vol.Optional(CONF_FORCE_HOOK, default=False): cv.boolean,
+        vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=False): cv.boolean,
         vol.Required(CONF_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): cv.string,
         vol.Optional(CONF_RESET_AFTER): cv.positive_int,
@@ -79,7 +79,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         name=name,
         group_address_state=config[CONF_STATE_ADDRESS],
         sync_state=config[CONF_SYNC_STATE],
-        force_hook=config[CONF_FORCE_HOOK],
+        ignore_internal_state=config[CONF_IGNORE_INTERNAL_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER),

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -13,6 +13,7 @@ CONF_STATE_ADDRESS = "state_address"
 CONF_SIGNIFICANT_BIT = "significant_bit"
 CONF_DEFAULT_SIGNIFICANT_BIT = 1
 CONF_SYNC_STATE = "sync_state"
+CONF_FORCE_HOOK = "force_hook"
 CONF_AUTOMATION = "automation"
 CONF_HOOK = "hook"
 CONF_DEFAULT_HOOK = "on"
@@ -41,6 +42,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
         ): cv.positive_int,
         vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
+        vol.Optional(CONF_FORCE_HOOK, default=False): cv.boolean,
         vol.Required(CONF_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): cv.string,
         vol.Optional(CONF_RESET_AFTER): cv.positive_int,
@@ -77,6 +79,7 @@ def async_add_entities_config(hass, config, async_add_entities):
         name=name,
         group_address_state=config[CONF_STATE_ADDRESS],
         sync_state=config[CONF_SYNC_STATE],
+        force_hook=config[CONF_FORCE_HOOK],
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER),

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -133,6 +133,58 @@ class TestBinarySensor(unittest.TestCase):
             xknx.devices['TestOutlet'].state,
             False)
 
+    def test_process_action_ignore_internal_state(self):
+        """Test process / reading telegrams from telegram queue. Test if action is executed."""
+        xknx = XKNX(loop=self.loop)
+        switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
+        xknx.devices.add(switch)
+
+        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/5', ignore_internal_state=True)
+        action_on = Action(
+            xknx,
+            hook='on',
+            target='TestOutlet',
+            method='on')
+        binary_sensor.actions.append(action_on)
+        xknx.devices.add(binary_sensor)
+
+        self.assertEqual(
+            xknx.devices['TestInput'].state,
+            BinarySensorState.OFF)
+        self.assertEqual(
+            xknx.devices['TestOutlet'].state,
+            False)
+
+        telegram_on = Telegram()
+        telegram_on.payload = DPTBinary(1)
+        self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_on)))
+
+        self.assertEqual(
+            xknx.devices['TestInput'].state,
+            BinarySensorState.ON)
+        self.assertEqual(
+            xknx.devices['TestOutlet'].state,
+            True)
+
+        self.loop.run_until_complete(asyncio.Task(switch.set_off()))
+        self.assertEqual(
+            xknx.devices['TestOutlet'].state,
+            False)
+        self.assertEqual(
+            xknx.devices['TestInput'].state,
+            BinarySensorState.ON)
+
+        self.loop.run_until_complete(asyncio.sleep(1))
+        self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_on)))
+
+        self.assertEqual(
+            xknx.devices['TestInput'].state,
+            BinarySensorState.ON)
+        self.assertEqual(
+            xknx.devices['TestOutlet'].state,
+            True)
+
+
     def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
         xknx = XKNX(loop=self.loop)

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -184,7 +184,6 @@ class TestBinarySensor(unittest.TestCase):
             xknx.devices['TestOutlet'].state,
             True)
 
-
     def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
         xknx = XKNX(loop=self.loop)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -40,6 +40,7 @@ class BinarySensor(Device):
                  name,
                  group_address_state=None,
                  sync_state=True,
+                 force_hook=False,
                  device_class=None,
                  significant_bit=1,
                  reset_after=None,
@@ -62,7 +63,7 @@ class BinarySensor(Device):
         self.reset_after = reset_after
         self.state = BinarySensorState.OFF
         self.actions = actions
-
+        self.force_hook = force_hook
         self.last_set = None
         self.count_set_on = 0
         self.count_set_off = 0
@@ -78,7 +79,8 @@ class BinarySensor(Device):
             config.get('device_class')
         significant_bit = \
             config.get('significant_bit', 1)
-
+        force_hook = \
+            config.get('force_hook', True)
         actions = []
         if "actions" in config:
             for action in config["actions"]:
@@ -89,6 +91,7 @@ class BinarySensor(Device):
                    name,
                    group_address_state=group_address_state,
                    sync_state=sync_state,
+                   force_hook=force_hook,
                    device_class=device_class,
                    significant_bit=significant_bit,
                    actions=actions)
@@ -106,7 +109,7 @@ class BinarySensor(Device):
 
     async def _set_internal_state(self, state):
         """Set the internal state of the device. If state was changed after update hooks and connected Actions are executed."""
-        if state != self.state:
+        if state != self.state or self.force_hook == True:
             self.state = state
             counter = self.bump_and_get_counter(state)
             await self.after_update()

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -40,7 +40,7 @@ class BinarySensor(Device):
                  name,
                  group_address_state=None,
                  sync_state=True,
-                 force_hook=False,
+                 ignore_internal_state=False,
                  device_class=None,
                  significant_bit=1,
                  reset_after=None,
@@ -63,7 +63,7 @@ class BinarySensor(Device):
         self.reset_after = reset_after
         self.state = BinarySensorState.OFF
         self.actions = actions
-        self.force_hook = force_hook
+        self.ignore_internal_state = ignore_internal_state
         self.last_set = None
         self.count_set_on = 0
         self.count_set_off = 0
@@ -79,8 +79,8 @@ class BinarySensor(Device):
             config.get('device_class')
         significant_bit = \
             config.get('significant_bit', 1)
-        force_hook = \
-            config.get('force_hook', False)
+        ignore_internal_state = \
+            config.get('ignore_internal_state', False)
         actions = []
         if "actions" in config:
             for action in config["actions"]:
@@ -91,7 +91,7 @@ class BinarySensor(Device):
                    name,
                    group_address_state=group_address_state,
                    sync_state=sync_state,
-                   force_hook=force_hook,
+                   ignore_internal_state=ignore_internal_state,
                    device_class=device_class,
                    significant_bit=significant_bit,
                    actions=actions)
@@ -109,7 +109,7 @@ class BinarySensor(Device):
 
     async def _set_internal_state(self, state):
         """Set the internal state of the device. If state was changed after update hooks and connected Actions are executed."""
-        if state != self.state or self.force_hook:
+        if state != self.state or self.ignore_internal_state:
             self.state = state
             counter = self.bump_and_get_counter(state)
             await self.after_update()

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -109,7 +109,7 @@ class BinarySensor(Device):
 
     async def _set_internal_state(self, state):
         """Set the internal state of the device. If state was changed after update hooks and connected Actions are executed."""
-        if state != self.state or self.force_hook == True:
+        if state != self.state or self.force_hook:
             self.state = state
             counter = self.bump_and_get_counter(state)
             await self.after_update()

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -80,7 +80,7 @@ class BinarySensor(Device):
         significant_bit = \
             config.get('significant_bit', 1)
         force_hook = \
-            config.get('force_hook', True)
+            config.get('force_hook', False)
         actions = []
         if "actions" in config:
             for action in config["actions"]:


### PR DESCRIPTION
 ...to allow enforcing hook call regardless of the current binary sensor state.
If you need an on/off switch on one button, e.g. for a group of lights and want to enforce the state in any case by pressing the button.
