### PR TITLE
Ignore unknown CEMI Messages

### DIFF
--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 from pytest import fixture, raises
 
 from xknx.dpt import DPTBinary
-from xknx.exceptions import CouldNotParseKNXIP
+from xknx.exceptions import CouldNotParseKNXIP, UnsupportedCEMIMessage
 from xknx.knxip.cemi_frame import CEMIFrame
 from xknx.knxip.knxip_enum import APCICommand, CEMIMessageCode
 from xknx.telegram import PhysicalAddress
@@ -50,8 +50,8 @@ def test_valid_command(frame):
 
 def test_invalid_tpci_apci(frame):
     """Test for invalid APCICommand"""
-    with raises(CouldNotParseKNXIP, match=r".*APCI not supported: .*"):
-        frame.from_knx(get_data(0x29, 0, 0, 0, 0, 1, 0xFFC0, []))
+    with raises(UnsupportedCEMIMessage, match=r".*APCI not supported: .*"):
+        frame.from_knx_data_link_layer(get_data(0x29, 0, 0, 0, 0, 1, 0xFFC0, []))
 
 
 def test_invalid_apdu_len(frame):
@@ -62,11 +62,5 @@ def test_invalid_apdu_len(frame):
 
 def test_invalid_invalid_len(frame):
     """Test for invalid cemi len"""
-    with raises(CouldNotParseKNXIP, match=r".*CEMI too small"):
-        frame.from_knx(get_data(0x29, 0, 0, 0, 0, 2, 0, [])[:5])
-
-
-def test_invalid_invalid_code(frame):
-    """Test for invalid cemi code"""
-    with raises(CouldNotParseKNXIP, match=r".*Could not understand CEMIMessageCode"):
-        frame.from_knx(get_data(0x0, 0, 0, 0, 0, 2, 0, []))
+    with raises(UnsupportedCEMIMessage, match=r".*CEMI too small.*"):
+        frame.from_knx_data_link_layer(get_data(0x29, 0, 0, 0, 0, 2, 0, [])[:5])

--- a/xknx/exceptions/__init__.py
+++ b/xknx/exceptions/__init__.py
@@ -2,4 +2,5 @@
 # flake8: noqa
 from .exception import (
     ConversionError, CouldNotParseAddress, CouldNotParseKNXIP,
-    CouldNotParseTelegram, DeviceIllegalValue, XKNXException)
+    CouldNotParseTelegram, DeviceIllegalValue, UnsupportedCEMIMessage,
+    XKNXException)

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -39,13 +39,27 @@ class CouldNotParseKNXIP(XKNXException):
     """Exception class for wrong KNXIP data."""
 
     def __init__(self, description=""):
-        """Initialize CouldNotParseTelegram class."""
+        """Initialize CouldNotParseKNXIP class."""
         super().__init__()
         self.description = description
 
     def __str__(self):
         """Return object as readable string."""
         return '<CouldNotParseKNXIP description="{0}" />' \
+            .format(self.description)
+
+
+class UnsupportedCEMIMessage(XKNXException):
+    """Exception class for unsupported CEMI Messages."""
+
+    def __init__(self, description=""):
+        """Initialize UnsupportedCEMIMessage class."""
+        super().__init__()
+        self.description = description
+
+    def __str__(self):
+        """Return object as readable string."""
+        return '<UnsupportedCEMIMessage description="{0}" />' \
             .format(self.description)
 
 


### PR DESCRIPTION
If we don't understand the CEMI Message ignore it and move on (eg. send TunnellingAck).
Previously we would raise CuldNotParseKNXIP and loose the connection because no Ack was sent.

> From 03_06_03 EMI_IMI v01.03.03 AS:
> 4.1.3.3 Exception handling: unknown messages
> General behaviour after reception of an unknown or unsupported message (this is, the cEMI Server does not know the received cEMI message code): the received message shall be ignored, this is, the cEMI Server shall generate no confirmation message.

closes #147 
fixes home-assistant/core#32394
fixes #226 (again)