### PR TITLE
introduce RemoteValueDateTime

### DIFF
--- a/docs/time.md
+++ b/docs/time.md
@@ -11,12 +11,24 @@ XKNX provides the possibility to send the local time, date or both combined to t
 ## [](#header-2)Example
 
 ```python
-time = DateTime(xknx, 'TimeTest', group_address='1/2/3')
-xknx.devices.add(time)
+time_device = DateTime(
+    xknx, 'TimeTest',
+    group_address='1/2/3',
+    broadcast_type='TIME',
+    localtime=True
+)
+xknx.devices.add(time_device)
 
 # Sending time to knx bus
 await xknx.devices['TimeTest'].sync()
 ``` 
+
+* `xknx` is the XKNX object.
+* `name` is the name of the object.
+* `group_address` is the KNX group address of the sensor device.
+* `broadcast_type` defines the value type that will be sent to the KNX bus. Valid attributes are: 'time', 'date' and 'datetime'. Default: `time`
+* `localtime` If set `True` sync() and GroupValueRead requests always return the current local time. On `False` the set value will be sent. Default: `True`
+
 
 ## [](#header-2)Configuration via **xknx.yaml**
 
@@ -56,13 +68,12 @@ loop.close()
 
 ```python
 from xknx import XKNX
-from xknx.devices import DateTime, DateTimeBroadcastType
+from xknx.devices import DateTime
 
 xknx = XKNX()
-time = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type=DateTimeBroadcastType.TIME)
+time_device = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type='time')
 
 # Sending Time to KNX bus 
-await time.sync()
+await time_device.broadcast_localtime()
 ```
-
 

--- a/examples/example_datetime.py
+++ b/examples/example_datetime.py
@@ -2,13 +2,13 @@
 import asyncio
 
 from xknx import XKNX
-from xknx.devices import DateTime, DateTimeBroadcastType
+from xknx.devices import DateTime
 
 
 async def main():
     """Connect to KNX/IP device and broadcast time."""
     xknx = XKNX()
-    datetime = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type=DateTimeBroadcastType.TIME)
+    datetime = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type="time")
     xknx.devices.add(datetime)
     print("Sending time to KNX bus every hour")
     await xknx.start(daemon_mode=True, state_updater=True)

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -3,7 +3,7 @@ import logging
 
 import voluptuous as vol
 from xknx import XKNX
-from xknx.devices import ActionCallback, DateTime, DateTimeBroadcastType, ExposeSensor
+from xknx.devices import ActionCallback, DateTime, ExposeSensor
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import XKNXException
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
@@ -315,7 +315,7 @@ class KNXExposeTime:
     def async_register(self):
         """Register listener."""
         broadcast_type_string = self.type.upper()
-        broadcast_type = DateTimeBroadcastType[broadcast_type_string]
+        broadcast_type = broadcast_type_string
         self.device = DateTime(
             self.xknx, "Time", broadcast_type=broadcast_type, group_address=self.address
         )

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 from xknx import XKNX
 from xknx.core import Config
 from xknx.devices import (
-    Action, BinarySensor, Climate, ClimateMode, Cover, DateTime,
-    DateTimeBroadcastType, ExposeSensor, Fan, Light, Notification, Scene,
-    Sensor, Switch)
+    Action, BinarySensor, Climate, ClimateMode, Cover, DateTime, ExposeSensor,
+    Fan, Light, Notification, Scene, Sensor, Switch)
 from xknx.exceptions import XKNXException
 from xknx.io import ConnectionConfig, ConnectionType
 from xknx.telegram import PhysicalAddress
@@ -321,7 +320,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'General.Time',
                 group_address='2/1/1',
-                broadcast_type=DateTimeBroadcastType.TIME,
+                broadcast_type="TIME",
                 device_updated_cb=TestConfig.xknx.devices.device_updated))
         self.assertEqual(
             TestConfig.xknx.devices['General.DateTime'],
@@ -329,7 +328,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'General.DateTime',
                 group_address='2/1/2',
-                broadcast_type=DateTimeBroadcastType.DATETIME,
+                broadcast_type="DATETIME",
                 device_updated_cb=TestConfig.xknx.devices.device_updated))
         self.assertEqual(
             TestConfig.xknx.devices['General.Date'],
@@ -337,7 +336,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'General.Date',
                 group_address='2/1/3',
-                broadcast_type=DateTimeBroadcastType.DATE,
+                broadcast_type="DATE",
                 device_updated_cb=TestConfig.xknx.devices.device_updated))
 
     def test_config_notification(self):

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -5,7 +5,7 @@ import unittest
 from unittest.mock import patch
 
 from xknx import XKNX
-from xknx.devices import DateTime, DateTimeBroadcastType
+from xknx.devices import DateTime
 from xknx.dpt import DPTArray
 from xknx.telegram import GroupAddress, Telegram, TelegramType
 
@@ -28,7 +28,7 @@ class TestDateTime(unittest.TestCase):
     def test_sync_datetime(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX(loop=self.loop)
-        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type=DateTimeBroadcastType.DATETIME)
+        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type="DATETIME")
 
         with patch('time.localtime') as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
@@ -39,7 +39,7 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(telegram.group_address, GroupAddress('1/2/3'))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 8)
-        self.assertEqual(telegram.payload.value, (0x75, 0x01, 0x07, 0xE9, 0x0D, 0x0E, 0x0, 0x0))
+        self.assertEqual(telegram.payload.value, (0x75, 0x01, 0x07, 0xE9, 0x0D, 0x0E, 0x20, 0x80))
 
     #
     # SYNC Date
@@ -47,7 +47,7 @@ class TestDateTime(unittest.TestCase):
     def test_sync_date(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX(loop=self.loop)
-        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type=DateTimeBroadcastType.DATE)
+        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type="DATE")
         with patch('time.localtime') as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.sync(False)))
@@ -65,7 +65,7 @@ class TestDateTime(unittest.TestCase):
     def test_sync_time(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX(loop=self.loop)
-        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type=DateTimeBroadcastType.TIME)
+        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type="TIME")
         with patch('time.localtime') as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.sync(False)))
@@ -86,7 +86,7 @@ class TestDateTime(unittest.TestCase):
     def test_process_read(self):
         """Test test process a read telegram from KNX bus."""
         xknx = XKNX(loop=self.loop)
-        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type=DateTimeBroadcastType.TIME)
+        datetime = DateTime(xknx, "TestDateTime", group_address='1/2/3', broadcast_type="TIME")
 
         telegram_read = Telegram(
             group_address=GroupAddress('1/2/3'),

--- a/test/dpt_tests/dpt_date_test.py
+++ b/test/dpt_tests/dpt_date_test.py
@@ -1,4 +1,5 @@
 """Unit test for KNX date objects."""
+import time
 import unittest
 
 from xknx.dpt import DPTDate
@@ -11,55 +12,40 @@ class TestDPTDate(unittest.TestCase):
     def test_from_knx(self):
         """Test parsing of DPTDate object from binary values. Example 1."""
         self.assertEqual(
-            DPTDate().from_knx((0x04, 0x01, 0x02)), {
-                'year': 2002,
-                'month': 1,
-                'day': 4
-            })
+            DPTDate().from_knx((0x04, 0x01, 0x02)),
+            time.strptime("2002-01-04", "%Y-%m-%d")
+        )
 
     def test_from_knx_old_date(self):
         """Test parsing of DPTDate object from binary values. Example 2."""
         self.assertEqual(
-            DPTDate().from_knx((0x1F, 0x01, 0x5A)), {
-                'year': 1990,
-                'month': 1,
-                'day': 31
-            })
+            DPTDate().from_knx((0x1F, 0x01, 0x5A)),
+            time.strptime("1990-01-31", "%Y-%m-%d")
+        )
 
     def test_from_knx_future_date(self):
         """Test parsing of DPTDate object from binary values. Example 3."""
         self.assertEqual(
-            DPTDate().from_knx((0x04, 0x0C, 0x59)), {
-                'year': 2089,
-                'month': 12,
-                'day': 4
-            })
+            DPTDate().from_knx((0x04, 0x0C, 0x59)),
+            time.strptime("2089-12-4", "%Y-%m-%d")
+        )
 
     def test_to_knx(self):
         """Testing KNX/Byte representation of DPTDate object. Example 1."""
-        raw = DPTDate().to_knx({
-            'year': 2002,
-            'month': 1,
-            'day': 4
-        })
+        raw = DPTDate().to_knx(
+            time.strptime("2002-1-04", "%Y-%m-%d"))
         self.assertEqual(raw, (0x04, 0x01, 0x02))
 
     def test_to_knx_old_date(self):
         """Testing KNX/Byte representation of DPTDate object. Example 2."""
-        raw = DPTDate().to_knx({
-            'year': 1990,
-            'month': 1,
-            'day': 31
-        })
+        raw = DPTDate().to_knx(
+            time.strptime("1990-01-31", "%Y-%m-%d"))
         self.assertEqual(raw, (0x1F, 0x01, 0x5A))
 
     def test_to_knx_future_date(self):
         """Testing KNX/Byte representation of DPTDate object. Example 3."""
-        raw = DPTDate().to_knx({
-            'year': 2089,
-            'month': 12,
-            'day': 4
-        })
+        raw = DPTDate().to_knx(
+            time.strptime("2089-12-04", "%Y-%m-%d"))
         self.assertEqual(raw, (0x04, 0x0C, 0x59))
 
     def test_from_knx_wrong_parameter(self):
@@ -71,33 +57,6 @@ class TestDPTDate(unittest.TestCase):
         """Test parsing from DPTDate object from wrong string value."""
         with self.assertRaises(ConversionError):
             DPTDate().to_knx("hello")
-
-    def test_to_knx_wrong_day(self):
-        """Test parsing from DPTDate object from wrong day value."""
-        with self.assertRaises(ConversionError):
-            DPTDate().to_knx({
-                'year': 2002,
-                'month': 1,
-                'day': 32
-            })
-
-    def test_to_knx_wrong_year(self):
-        """Test parsing from DPTDate object from wrong year value."""
-        with self.assertRaises(ConversionError):
-            DPTDate().to_knx({
-                'year': 2091,
-                'month': 1,
-                'day': 20
-            })
-
-    def test_to_knx_wrong_month(self):
-        """Test parsing from DPTDate object from wrong month value."""
-        with self.assertRaises(ConversionError):
-            DPTDate().to_knx({
-                'year': 2002,
-                'month': 0,
-                'day': 20
-            })
 
     def test_from_knx_wrong_range_month(self):
         """Test Exception when parsing DPTDAte from KNX with wrong month."""

--- a/test/dpt_tests/dpt_datetime_test.py
+++ b/test/dpt_tests/dpt_datetime_test.py
@@ -1,7 +1,8 @@
 """Unit test for KNX datetime objects."""
+import time
 import unittest
 
-from xknx.dpt import DPTDateTime, DPTWeekday
+from xknx.dpt import DPTDateTime
 from xknx.exceptions import ConversionError
 
 
@@ -14,28 +15,15 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x00, 0x00)), {
-                'year': 2017,
-                'month': 11,
-                'day': 28,
-                'weekday': DPTWeekday.NONE,
-                'hours': 23,
-                'minutes': 7,
-                'seconds': 24
-            })
+            DPTDateTime().from_knx((0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x20, 0x80)),
+            time.strptime("2017-11-28 23:7:24", "%Y-%m-%d %H:%M:%S")
+        )
 
     def test_to_knx(self):
         """Testing KNX/Byte representation of DPTDateTime object."""
-        raw = DPTDateTime().to_knx({
-            'year': 2017,
-            'month': 11,
-            'day': 28,
-            'weekday': DPTWeekday.NONE,
-            'hours': 23,
-            'minutes': 7,
-            'seconds': 24
-        })
-        self.assertEqual(raw, (0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x00, 0x00))
+        raw = DPTDateTime().to_knx(
+            time.strptime("2017-11-28 23:7:24", "%Y-%m-%d %H:%M:%S"))
+        self.assertEqual(raw, (0x75, 0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
 
     #
     # TEST EARLIEST DATE POSSIBLE
@@ -43,28 +31,15 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx_date_in_past(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00)), {
-                'year': 1900,
-                'month': 1,
-                'day': 1,
-                'weekday': DPTWeekday.MONDAY,
-                'hours': 0,
-                'minutes': 0,
-                'seconds': 0
-            })
+            DPTDateTime().from_knx((0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00)),
+            time.strptime("1900 1 1 0 0 0", "%Y %m %d %H %M %S")
+        )
 
     def test_to_knx_date_in_past(self):
         """Testing KNX/Byte representation of DPTDateTime object."""
-        raw = DPTDateTime().to_knx({
-            'year': 1900,
-            'month': 1,
-            'day': 1,
-            'weekday': DPTWeekday.MONDAY,
-            'hours': 0,
-            'minutes': 0,
-            'seconds': 0
-        })
-        self.assertEqual(raw, (0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00))
+        raw = DPTDateTime().to_knx(
+            time.strptime("1900-1-1 1 0:0:0", "%Y-%m-%d %w %H:%M:%S"))
+        self.assertEqual(raw, (0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x20, 0x80))
 
     #
     # TEST LATEST DATE IN THE FUTURE
@@ -72,28 +47,15 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx_date_in_future(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00)), {
-                'year': 2155,
-                'month': 12,
-                'day': 31,
-                'weekday': DPTWeekday.SUNDAY,
-                'hours': 23,
-                'minutes': 59,
-                'seconds': 59
-            })
+            DPTDateTime().from_knx((0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80)),
+            time.strptime("2155-12-31 0 23:59:59", "%Y-%m-%d %w %H:%M:%S")
+        )
 
     def test_to_knx_date_in_future(self):
         """Testing KNX/Byte representation of DPTDateTime object."""
-        raw = DPTDateTime().to_knx({
-            'year': 2155,
-            'month': 12,
-            'day': 31,
-            'weekday': DPTWeekday.SUNDAY,
-            'hours': 23,
-            'minutes': 59,
-            'seconds': 59
-        })
-        self.assertEqual(raw, (0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00))
+        raw = DPTDateTime().to_knx(
+            time.strptime("2155-12-31 0 23:59:59", "%Y-%m-%d %w %H:%M:%S"))
+        self.assertEqual(raw, (0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80))
 
     #
     # TEST WRONG KNX
@@ -116,80 +78,3 @@ class TestDPTDateTime(unittest.TestCase):
         """Test parsing from DPTDateTime object from wrong string value."""
         with self.assertRaises(ConversionError):
             DPTDateTime().to_knx("hello")
-
-    def test_to_knx_wrong_seconds(self):
-        """Test parsing from DPTDateTime object from wrong seconds value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2002,
-                'month': 2,
-                'day': 20,
-                'hours': 12,
-                'minutes': 42,
-                'seconds': 61
-            })
-
-    def test_to_knx_wrong_minutes(self):
-        """Test parsing from DPTDateTime object from wrong minutes value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2002,
-                'month': 12,
-                'day': 20,
-                'hours': 12,
-                'minutes': 61,
-                'seconds': 53
-            })
-
-    def test_to_knx_wrong_hours(self):
-        """Test parsing from DPTDateTime object from wrong hours value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2002,
-                'month': 2,
-                'day': 20,
-                'hours': 24,
-                'minutes': 42,
-                'seconds': 53
-            })
-
-    def test_to_knx_wrong_day(self):
-        """Test parsing from DPTDateTime object from wrong day value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2002,
-                'month': 1,
-                'day': 32,
-                'hours': 12,
-                'minutes': 42,
-                'seconds': 53
-            })
-
-    def test_to_knx_wrong_year(self):
-        """Test parsing from DPTDateTime object from wrong year value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2156,
-                'month': 1,
-                'day': 20,
-                'hours': 12,
-                'minutes': 42,
-                'seconds': 53
-            })
-
-    def test_to_knx_wrong_month(self):
-        """Test parsing from DPTDateTime object from wrong month value."""
-        with self.assertRaises(ConversionError):
-            DPTDateTime().to_knx({
-                'year': 2002,
-                'month': 0,
-                'day': 20,
-                'hours': 12,
-                'minutes': 42,
-                'seconds': 53
-            })
-
-    def test_test_range_wrong_weekday(self):
-        """Test range testing with wrong weekday (Cant be tested with normal from_/to_knx)."""
-        # pylint: disable=protected-access
-        self.assertFalse(DPTDateTime._test_range(1900, 1, 1, 8, 0, 0, 0))

--- a/test/dpt_tests/dpt_time_test.py
+++ b/test/dpt_tests/dpt_time_test.py
@@ -1,7 +1,8 @@
 """Unit test for KNX time objects."""
+import time
 import unittest
 
-from xknx.dpt import DPTTime, DPTWeekday
+from xknx.dpt import DPTTime
 from xknx.exceptions import ConversionError
 
 
@@ -13,19 +14,15 @@ class TestDPTTime(unittest.TestCase):
     #
     def test_from_knx(self):
         """Test parsing of DPTTime object from binary values. Example 1."""
-        self.assertEqual(DPTTime().from_knx((0x4D, 0x17, 0x2A)),
-                         {'weekday': DPTWeekday.TUESDAY,
-                          'hours': 13,
-                          'minutes': 23,
-                          'seconds': 42})
+        self.assertEqual(
+            DPTTime().from_knx((0x4D, 0x17, 0x2A)),
+            time.strptime("13 23 42 2", "%H %M %S %w")
+        )
 
     def test_to_knx(self):
         """Testing KNX/Byte representation of DPTTime object."""
         raw = DPTTime().to_knx(
-            {'weekday': DPTWeekday.TUESDAY,
-             'hours': 13,
-             'minutes': 23,
-             'seconds': 42})
+            time.strptime("13 23 42 2", "%H %M %S %w"))
         self.assertEqual(raw, (0x4D, 0x17, 0x2A))
 
     #
@@ -34,19 +31,15 @@ class TestDPTTime(unittest.TestCase):
     def test_to_knx_max(self):
         """Testing KNX/Byte representation of DPTTime object. Maximum values."""
         raw = DPTTime().to_knx(
-            {'weekday': DPTWeekday.SUNDAY,
-             'hours': 23,
-             'minutes': 59,
-             'seconds': 59})
+            time.strptime("23 59 59 0", "%H %M %S %w"))
         self.assertEqual(raw, (0xF7, 0x3b, 0x3b))
 
     def test_from_knx_max(self):
         """Test parsing of DPTTime object from binary values. Example 2."""
-        self.assertEqual(DPTTime().from_knx((0xF7, 0x3b, 0x3b)),
-                         {'weekday': DPTWeekday.SUNDAY,
-                          'hours': 23,
-                          'minutes': 59,
-                          'seconds': 59})
+        self.assertEqual(
+            DPTTime().from_knx((0xF7, 0x3b, 0x3b)),
+            time.strptime("23 59 59 0", "%H %M %S %w")
+        )
 
     #
     # TEST MINIMUM TIME
@@ -54,26 +47,25 @@ class TestDPTTime(unittest.TestCase):
     def test_to_knx_min(self):
         """Testing KNX/Byte representation of DPTTime object. Minimum values."""
         raw = DPTTime().to_knx(
-            {'weekday': DPTWeekday.NONE,
-             'hours': 0,
-             'minutes': 0,
-             'seconds': 0})
+            time.strptime("0 0 0", "%H %M %S"))
         self.assertEqual(raw, (0x0, 0x0, 0x0))
 
     def test_from_knx_min(self):
         """Test parsing of DPTTime object from binary values. Example 3."""
-        self.assertEqual(DPTTime().from_knx((0x0, 0x0, 0x0)),
-                         {'weekday': DPTWeekday.NONE,
-                          'hours': 0,
-                          'minutes': 0,
-                          'seconds': 0})
+        self.assertEqual(
+            DPTTime().from_knx((0x0, 0x0, 0x0)),
+            time.strptime("0 0 0", "%H %M %S")
+        )
 
     #
     # TEST INITIALIZATION
     #
     def test_to_knx_default(self):
         """Testing default initialization of DPTTime object."""
-        self.assertEqual(DPTTime().to_knx({}), (0x0, 0x0, 0x0))
+        self.assertEqual(
+            DPTTime().to_knx(time.strptime("", "")),
+            (0x0, 0x0, 0x0)
+        )
 
     def test_from_knx_wrong_size(self):
         """Test parsing from DPTTime object from wrong binary values (wrong size)."""
@@ -83,7 +75,7 @@ class TestDPTTime(unittest.TestCase):
     def test_from_knx_wrong_bytes(self):
         """Test parsing from DPTTime object from wrong binary values (wrong bytes)."""
         with self.assertRaises(ConversionError):
-            # thirs parameter exceeds limit
+            # this parameter exceeds limit
             DPTTime().from_knx((0xF7, 0x3b, 0x3c))
 
     def test_from_knx_wrong_type(self):
@@ -95,35 +87,3 @@ class TestDPTTime(unittest.TestCase):
         """Test parsing from DPTTime object from wrong string value."""
         with self.assertRaises(ConversionError):
             DPTTime().to_knx("fnord")
-
-    def test_to_knx_wrong_seconds(self):
-        """Test parsing from DPTTime object from wrong seconds value."""
-        with self.assertRaises(ConversionError):
-            DPTTime().to_knx({
-                'hours': 12,
-                'minutes': 42,
-                'seconds': 61
-            })
-
-    def test_to_knx_wrong_minutes(self):
-        """Test parsing from DPTTime object from wrong minutes value."""
-        with self.assertRaises(ConversionError):
-            DPTTime().to_knx({
-                'hours': 12,
-                'minutes': 61,
-                'seconds': 53
-            })
-
-    def test_to_knx_wrong_hours(self):
-        """Test parsing from DPTTime object from wrong hours value."""
-        with self.assertRaises(ConversionError):
-            DPTTime().to_knx({
-                'hours': 24,
-                'minutes': 42,
-                'seconds': 53
-            })
-
-    def test_test_range_wrong_weekday(self):
-        """Test range testing with wrong weekday (Cant be tested with normal from_/to_knx)."""
-        # pylint: disable=protected-access
-        self.assertFalse(DPTTime._test_range(8, 0, 0, 0))

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -1,5 +1,6 @@
 """Unit test for KNX/IP RountingIndication objects."""
 import asyncio
+import time
 import unittest
 
 from xknx import XKNX
@@ -65,7 +66,7 @@ class Test_KNXIP(unittest.TestCase):
         telegram.group_address = GroupAddress(337)
 
         telegram.payload = DPTArray(DPTTime().to_knx(
-            {'hours': 13, 'minutes': 23, 'seconds': 42}))
+            time.strptime("13:23:42", "%H:%M:%S")))
 
         knxipframe.body.telegram = telegram
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -273,7 +273,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address="1/2/3")
         self.assertEqual(
             str(dateTime),
-            '<DateTime name="Zeit" group_address="GroupAddress("1/2/3")" broadcast_type="TIME" />')
+            '<DateTime name="Zeit" group_address="GroupAddress("1/2/3")/None/None/None" broadcast_type="TIME" />')
 
     def test_action_base(self):
         """Test string representation of action base."""

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -5,7 +5,7 @@ from .binary_sensor import BinarySensor, BinarySensorState
 from .climate import Climate
 from .climate_mode import ClimateMode
 from .cover import Cover
-from .datetime import DateTime, DateTimeBroadcastType
+from .datetime import DateTime
 from .device import Device
 from .devices import Devices
 from .expose_sensor import ExposeSensor

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -48,7 +48,7 @@ class SetpointShiftValue(RemoteValue1Count):
             return None
         return super().value * self.setpoint_shift_step
 
-    async def set(self, value):
+    async def set(self, value, response=False):
         """Set new value from Kelvin."""
         if value > self.max_temp_delta:
             self.xknx.logger.warning("setpoint_shift_max exceeded at %s: %s",

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -5,21 +5,11 @@ DateTime is a virtual/pseudo device, using the infrastructure for
 beeing configured via xknx.yaml and synchronized periodically
 by StateUpdate.
 """
+import time
 
-from enum import Enum
-
-from xknx.dpt import DPTArray, DPTDate, DPTDateTime, DPTTime
-from xknx.telegram import GroupAddress
+from xknx.remote_value import RemoteValueDateTime
 
 from .device import Device
-
-
-class DateTimeBroadcastType(Enum):
-    """Enum class for the broadcast type of the enum."""
-
-    DATETIME = 1
-    DATE = 2
-    TIME = 3
 
 
 class DateTime(Device):
@@ -29,24 +19,25 @@ class DateTime(Device):
     def __init__(self,
                  xknx,
                  name,
-                 broadcast_type=DateTimeBroadcastType.TIME,
+                 broadcast_type='TIME',
+                 localtime=True,
                  group_address=None,
                  device_updated_cb=None):
         """Initialize DateTime class."""
         super().__init__(xknx, name, device_updated_cb)
-
-        self.broadcast_type = broadcast_type
-
-        if isinstance(group_address, (str, int)):
-            group_address = GroupAddress(group_address)
-
-        self.group_address = group_address
+        self.localtime = localtime
+        self._broadcast_type = broadcast_type.upper()
+        self._remote_value = RemoteValueDateTime(xknx,
+                                                 group_address=group_address,
+                                                 sync_state=False,
+                                                 value_type=broadcast_type,
+                                                 device_name=name,
+                                                 after_update_cb=self.after_update)
 
     @classmethod
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
-        broadcast_type_string = config.get('broadcast_type', 'time').upper()
-        broadcast_type = DateTimeBroadcastType[broadcast_type_string]
+        broadcast_type = config.get('broadcast_type', 'time').upper()
         group_address = config.get('group_address')
         return cls(xknx,
                    name,
@@ -55,41 +46,38 @@ class DateTime(Device):
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""
-        return self.group_address == group_address
+        return self._remote_value.has_group_address(group_address)
 
-    async def broadcast_time(self, response):
-        """Broadcast time to KNX bus."""
-        if self.broadcast_type == DateTimeBroadcastType.DATETIME:
-            broadcast_data = DPTDateTime.current_datetime_as_knx()
-            await self.send(
-                self.group_address,
-                DPTArray(broadcast_data),
-                response=response)
-        elif self.broadcast_type == DateTimeBroadcastType.DATE:
-            broadcast_data = DPTDate.current_date_as_knx()
-            await self.send(
-                self.group_address,
-                DPTArray(broadcast_data),
-                response=response)
-        elif self.broadcast_type == DateTimeBroadcastType.TIME:
-            broadcast_data = DPTTime.current_time_as_knx()
-            await self.send(
-                self.group_address,
-                DPTArray(broadcast_data),
-                response=response)
+    def state_addresses(self):
+        """Return group addresses which should be requested to sync state."""
+        return self._remote_value.state_addresses()
+
+    async def broadcast_localtime(self, response=False):
+        """Broadcast the local time to KNX bus."""
+        await self._remote_value.set(time.localtime(), response=response)
+
+    async def set(self, struct_time: time.struct_time):
+        """Set time and send to KNX bus."""
+        await self._remote_value.set(struct_time)
 
     async def process_group_read(self, telegram):
-        """Process incoming GROUP RESPONSE telegram."""
-        await self.broadcast_time(True)
+        """Process incoming GROUP READ telegram."""
+        if self.localtime:
+            await self.broadcast_localtime(True)
+        else:
+            await self._remote_value.send(response=True)
 
     async def sync(self, wait_for_result=True):
         """Read state of device from KNX bus. Used here to broadcast time to KNX bus."""
-        await self.broadcast_time(False)
+        if self.localtime:
+            await self.broadcast_localtime(False)
 
     def __str__(self):
         """Return object as readable string."""
         return '<DateTime name="{0}" group_address="{1}" broadcast_type="{2}" />' \
-            .format(self.name, self.group_address.__repr__(), self.broadcast_type.name)
+            .format(self.name,
+                    self._remote_value.group_addr_str(),
+                    self._broadcast_type)
 
     def __eq__(self, other):
         """Equal operator."""

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -5,45 +5,52 @@ Module for encoding and decoding KNX datatypes.
 * Derived KNX Values like Scaling, Temperature
 """
 # flake8: noqa
-from .dpt import DPTArray, DPTBase, DPTBinary, DPTComparator, DPTWeekday
+from .dpt import DPTArray, DPTBase, DPTBinary, DPTComparator
 from .dpt_1byte_signed import (
     DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count)
 from .dpt_1byte_uint import (
-    DPTPercentU8, DPTDecimalFactor, DPTSceneNumber, DPTTariff, DPTValue1Ucount)
+    DPTDecimalFactor, DPTPercentU8, DPTSceneNumber, DPTTariff, DPTValue1Ucount)
 from .dpt_2byte_float import (
-    DPT2ByteFloat, DPTCurrent, DPTEnthalpy, DPTHumidity, DPTKelvinPerPercent, DPTLux, DPTPartsPerMillion, DPTPower2Byte,
-    DPTPowerDensity, DPTPressure2Byte, DPTRainAmount, DPTTemperature, DPTTemperatureA, DPTTemperatureDifference2Byte,
-    DPTTemperatureF, DPTTime1, DPTTime2, DPTVoltage, DPTVolumeFlow, DPTWsp, DPTWspKmh
-)
+    DPT2ByteFloat, DPTCurrent, DPTEnthalpy, DPTHumidity, DPTKelvinPerPercent,
+    DPTLux, DPTPartsPerMillion, DPTPower2Byte, DPTPowerDensity,
+    DPTPressure2Byte, DPTRainAmount, DPTTemperature, DPTTemperatureA,
+    DPTTemperatureDifference2Byte, DPTTemperatureF, DPTTime1, DPTTime2,
+    DPTVoltage, DPTVolumeFlow, DPTWsp, DPTWspKmh)
 from .dpt_2byte_signed import (
-    DPT2ByteSigned, DPTDeltaTimeHrs, DPTDeltaTimeMin, DPTDeltaTimeMsec, DPTDeltaTimeSec, DPTPercentV16,
-    DPTRotationAngle, DPTValue2Count
-)
+    DPT2ByteSigned, DPTDeltaTimeHrs, DPTDeltaTimeMin, DPTDeltaTimeMsec,
+    DPTDeltaTimeSec, DPTPercentV16, DPTRotationAngle, DPTValue2Count)
 from .dpt_2byte_uint import (
-    DPT2ByteUnsigned, DPT2Ucount, DPTBrightness, DPTColorTemperature, DPTLengthMm, DPTTimePeriod100Msec,
-    DPTTimePeriod10Msec, DPTTimePeriodHrs, DPTTimePeriodMin, DPTTimePeriodMsec, DPTTimePeriodSec, DPTUElCurrentmA
-)
+    DPT2ByteUnsigned, DPT2Ucount, DPTBrightness, DPTColorTemperature,
+    DPTLengthMm, DPTTimePeriod10Msec, DPTTimePeriod100Msec, DPTTimePeriodHrs,
+    DPTTimePeriodMin, DPTTimePeriodMsec, DPTTimePeriodSec, DPTUElCurrentmA)
 from .dpt_4byte_float import (
-    DPT4ByteFloat, DPTAcceleration, DPTAccelerationAngular, DPTActivationEnergy, DPTActivity, DPTMol, DPTAmplitude,
-    DPTAngleRad, DPTAngleDeg, DPTAngularMomentum, DPTAngularVelocity, DPTArea, DPTCapacitance, DPTChargeDensitySurface,
-    DPTChargeDensityVolume, DPTCompressibility, DPTConductance, DPTElectricalConductivity, DPTDensity,
-    DPTElectricCharge, DPTElectricCurrent, DPTElectricCurrentDensity, DPTElectricDipoleMoment, DPTElectricDisplacement,
-    DPTElectricFieldStrength, DPTElectricFlux, DPTElectricFluxDensity, DPTElectricPolarization, DPTElectricPotential,
-    DPTElectricPotentialDifference, DPTElectromagneticMoment, DPTElectromotiveForce, DPTEnergy, DPTForce, DPTFrequency,
-    DPTAngularFrequency, DPTHeatCapacity, DPTHeatFlowRate, DPTHeatQuantity, DPTImpedance, DPTLength, DPTLightQuantity,
-    DPTLuminance, DPTLuminousFlux, DPTLuminousIntensity, DPTMagneticFieldStrength, DPTMagneticFlux,
-    DPTMagneticFluxDensity, DPTMagneticMoment, DPTMagneticPolarization, DPTMagnetization, DPTMagnetomotiveForce,
-    DPTMass, DPTMassFlux, DPTMomentum, DPTPhaseAngleRad, DPTPhaseAngleDeg, DPTPower, DPTPowerFactor, DPTPressure,
-    DPTReactance, DPTResistance, DPTResistivity, DPTSelfInductance, DPTSolidAngle, DPTSoundIntensity, DPTSpeed,
-    DPTStress, DPTSurfaceTension, DPTCommonTemperature, DPTAbsoluteTemperature, DPTTemperatureDifference,
-    DPTThermalCapacity, DPTThermalConductivity, DPTThermoelectricPower, DPTTimeSeconds, DPTTorque, DPTVolume,
-    DPTVolumeFlux, DPTWeight, DPTWork
-)
-
+    DPT4ByteFloat, DPTAbsoluteTemperature, DPTAcceleration,
+    DPTAccelerationAngular, DPTActivationEnergy, DPTActivity, DPTAmplitude,
+    DPTAngleDeg, DPTAngleRad, DPTAngularFrequency, DPTAngularMomentum,
+    DPTAngularVelocity, DPTArea, DPTCapacitance, DPTChargeDensitySurface,
+    DPTChargeDensityVolume, DPTCommonTemperature, DPTCompressibility,
+    DPTConductance, DPTDensity, DPTElectricalConductivity, DPTElectricCharge,
+    DPTElectricCurrent, DPTElectricCurrentDensity, DPTElectricDipoleMoment,
+    DPTElectricDisplacement, DPTElectricFieldStrength, DPTElectricFlux,
+    DPTElectricFluxDensity, DPTElectricPolarization, DPTElectricPotential,
+    DPTElectricPotentialDifference, DPTElectromagneticMoment,
+    DPTElectromotiveForce, DPTEnergy, DPTForce, DPTFrequency, DPTHeatCapacity,
+    DPTHeatFlowRate, DPTHeatQuantity, DPTImpedance, DPTLength,
+    DPTLightQuantity, DPTLuminance, DPTLuminousFlux, DPTLuminousIntensity,
+    DPTMagneticFieldStrength, DPTMagneticFlux, DPTMagneticFluxDensity,
+    DPTMagneticMoment, DPTMagneticPolarization, DPTMagnetization,
+    DPTMagnetomotiveForce, DPTMass, DPTMassFlux, DPTMol, DPTMomentum,
+    DPTPhaseAngleDeg, DPTPhaseAngleRad, DPTPower, DPTPowerFactor, DPTPressure,
+    DPTReactance, DPTResistance, DPTResistivity, DPTSelfInductance,
+    DPTSolidAngle, DPTSoundIntensity, DPTSpeed, DPTStress, DPTSurfaceTension,
+    DPTTemperatureDifference, DPTThermalCapacity, DPTThermalConductivity,
+    DPTThermoelectricPower, DPTTimeSeconds, DPTTorque, DPTVolume,
+    DPTVolumeFlux, DPTWeight, DPTWork)
 from .dpt_4byte_int import (
-    DPT4ByteSigned, DPT4ByteUnsigned, DPTValue4Count, DPTFlowRateM3H, DPTActiveEnergy, DPTApparantEnergy,
-    DPTReactiveEnergy, DPTActiveEnergykWh, DPTApparantEnergykVAh, DPTReactiveEnergykVARh, DPTLongDeltaTimeSec
-)
+    DPT4ByteSigned, DPT4ByteUnsigned, DPTActiveEnergy, DPTActiveEnergykWh,
+    DPTApparantEnergy, DPTApparantEnergykVAh, DPTFlowRateM3H,
+    DPTLongDeltaTimeSec, DPTReactiveEnergy, DPTReactiveEnergykVARh,
+    DPTValue4Count)
 from .dpt_date import DPTDate
 from .dpt_datetime import DPTDateTime
 from .dpt_hvac_contr_mode import DPTHVACContrMode

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -1,6 +1,4 @@
 """Implementation of Basic KNX datatypes."""
-from enum import Enum
-
 from xknx.exceptions import ConversionError
 
 
@@ -142,16 +140,3 @@ class DPTComparator():
             return len(a.value) == 0 and b.value == 0
 
         raise TypeError()
-
-
-class DPTWeekday(Enum):
-    """Enum class for week days."""
-
-    MONDAY = 1
-    TUESDAY = 2
-    WEDNESDAY = 3
-    THURSDAY = 4
-    FRIDAY = 5
-    SATURDAY = 6
-    SUNDAY = 7
-    NONE = 0

--- a/xknx/dpt/dpt_date.py
+++ b/xknx/dpt/dpt_date.py
@@ -10,8 +10,10 @@ from .dpt import DPTBase
 class DPTDate(DPTBase):
     """Abstraction for KNX 3 octet date (DPT 11.001)."""
 
+    payload_length = 3
+
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw, 3)
 
@@ -27,15 +29,15 @@ class DPTDate(DPTBase):
         else:
             year += 2000
 
-        return {
-            'day': day,
-            'month': month,
-            'year': year
-        }
+        try:
+            # strptime conversion used for catching exceptions; filled with default values
+            return time.strptime("{} {} {}".format(year, month, day), "%Y %m %d")
+        except ValueError:
+            raise ConversionError("Cant parse DPTDate", raw=raw)
 
     @classmethod
-    def to_knx(cls, values):
-        """Serialize to KNX/IP raw data from dict with elements day,month,year."""
+    def to_knx(cls, value: time.struct_time):
+        """Serialize to KNX/IP raw data from time.struct_time."""
         def _knx_year(year):
             if 2000 <= year < 2090:
                 return year-2000
@@ -43,34 +45,12 @@ class DPTDate(DPTBase):
                 return year-1900
             raise ConversionError("Cant serialize DPTDate", year=year)
 
-        if not isinstance(values, dict):
-            raise ConversionError("Cant serialize DPTDate", values=values)
-        day = values.get('day', 0)
-        month = values.get('month', 0)
-        year = _knx_year(values.get('year', 0))
+        if not isinstance(value, time.struct_time):
+            raise ConversionError("Cant serialize DPTDate", value=value)
 
-        if not DPTDate._test_range(day, month, year):
-            raise ConversionError("Cant serialize DPTDate", values=values)
-
-        return day, month, year
-
-    @classmethod
-    def _current_date(cls):
-        """Return current local date as struct."""
-        localtime = time.localtime()
-        day = localtime.tm_mday
-        month = localtime.tm_mon
-        year = localtime.tm_year
-        return {
-            'day': day,
-            'month': month,
-            'year': year
-        }
-
-    @classmethod
-    def current_date_as_knx(cls):
-        """Return current local date as KNX bytes."""
-        return cls.to_knx(cls._current_date())
+        return (value.tm_mday,
+                value.tm_mon,
+                _knx_year(value.tm_year))
 
     @staticmethod
     def _test_range(day, month, year):

--- a/xknx/dpt/dpt_datetime.py
+++ b/xknx/dpt/dpt_datetime.py
@@ -4,15 +4,18 @@ import time
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase, DPTWeekday
+from .dpt import DPTBase
 
 
 class DPTDateTime(DPTBase):
     """Abstraction for KNX 8 octet datetime (DPT 19.001)."""
 
+    payload_length = 8
+
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
+        # pylint: disable-msg=too-many-locals
         cls.test_bytesarray(raw, 8)
 
         year = raw[0] + 1900
@@ -23,81 +26,68 @@ class DPTDateTime(DPTBase):
         minutes = raw[4] & 0x3F
         seconds = raw[5] & 0x3F
 
-        if not DPTDateTime._test_range(year, month, day, weekday, hours, minutes, seconds):
-            raise ConversionError("Could not parse DPTDateTime", raw=raw)
+        fault = raw[6] & 0x80
+        # workingday_invalid = raw[6] & 0x20
+        year_invalid = raw[6] & 0x10
+        date_invalid = raw[6] & 0x08  # month, day
+        weekday_invalid = (raw[6] & 0x04)
+        time_invalid = raw[6] & 0x02  # hours, minutes, seconds
 
-        return {
-            'year': year,
-            'month': month,
-            'day': day,
-            'weekday': DPTWeekday(weekday),
-            'hours': hours,
-            'minutes': minutes,
-            'seconds': seconds
-        }
+        if fault:
+            raise ConversionError("DPTDateTime received corrupted data", raw=raw)
+
+        try:
+            if weekday == 0:
+                # struct_time has no concept of "no/any day"
+                weekday_invalid = True
+            else:
+                # in knx Sunday is 7; in strftime %w its 0
+                if weekday == 7:
+                    weekday = 0
+            # string conversion used for catching exceptions and inferring invalid data
+            _time_strings = []
+            _time_formats = []
+            if not year_invalid:
+                _time_strings.append(str(year))
+                _time_formats.append("%Y")
+            if not date_invalid:
+                _time_strings.extend([str(month), str(day)])
+                _time_formats.extend(["%m", "%d"])
+            if not time_invalid:
+                _time_strings.extend([str(hours), str(minutes), str(seconds)])
+                _time_formats.extend(["%H", "%M", "%S"])
+            if not weekday_invalid:
+                _time_strings.append(str(weekday))
+                _time_formats.append("%w")
+            time_string = " ".join(_time_strings)
+            time_format = " ".join(_time_formats)
+
+            return time.strptime(time_string, time_format)
+
+        except ValueError:
+            raise ConversionError("Cant parse DPTDateTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, values):
-        """Serialize to KNX/IP raw data from dict with elements year,month,day,weekday,hours,minutes,seconds."""
-        if not isinstance(values, dict):
-            raise ConversionError("Cant serialize DPTDateTime", values=values)
+    def to_knx(cls, value: time.struct_time):
+        """Serialize to KNX/IP raw data from time.struct_time."""
+        if not isinstance(value, time.struct_time):
+            raise ConversionError("Cant serialize DPTDateTime", value=value)
 
-        year = values.get('year', 1900)
-        month = values.get('month', 1)
-        day = values.get('day', 1)
-        weekday = values.get('weekday', DPTWeekday.NONE).value
-        hours = values.get('hours', 0)
-        minutes = values.get('minutes', 0)
-        seconds = values.get('seconds', 0)
+        knx_year = (value.tm_year - 1900) & 0xFF
+        month = value.tm_mon
+        day = value.tm_mday
+        weekday = value.tm_wday + 1
+        hours = value.tm_hour
+        minutes = value.tm_min
+        seconds = value.tm_sec
+        dst = value.tm_isdst == 1  # tm_isdst can be -1
 
-        if not DPTDateTime._test_range(year, month, day, weekday, hours, minutes, seconds):
-            raise ConversionError("Cant serialize DPTDateTime", values=values)
-
-        return year - 1900, month, day, weekday << 5 | hours, minutes, seconds, 0, 0
-
-    @classmethod
-    def current_datetime_as_knx(cls):
-        """Return current local datetime as KNX bytes."""
-        return cls.to_knx(cls._current_datetime())
-
-    @classmethod
-    def _current_datetime(cls):
-        """Return current local time as struct."""
-        localtime = time.localtime()
-        year = localtime.tm_year
-        month = localtime.tm_mon
-        day = localtime.tm_mday
-        weekday = localtime.tm_wday + 1
-        hours = localtime.tm_hour
-        minutes = localtime.tm_min
-        seconds = localtime.tm_sec
-        return {
-            'year': year,
-            'month': month,
-            'day': day,
-            'weekday': DPTWeekday(weekday),
-            'hours': hours,
-            'minutes': minutes,
-            'seconds': seconds
-        }
-
-    @staticmethod
-    # pylint: disable=too-many-arguments
-    # pylint: disable=too-many-return-statements
-    def _test_range(year, month, day, weekday, hours, minutes, seconds):
-        """Test if the values are in the correct range."""
-        if year < 1900 or year > 2155:
-            return False
-        if month < 1 or month > 12:
-            return False
-        if day < 1 or day > 31:
-            return False
-        if weekday < 0 or weekday > 7:
-            return False
-        if hours < 0 or hours > 23:
-            return False
-        if minutes < 0 or minutes > 59:
-            return False
-        if seconds < 0 or seconds > 59:
-            return False
-        return True
+        return (knx_year,
+                month,
+                day,
+                weekday << 5 | hours,
+                minutes,
+                seconds,
+                0x20 | dst,  # 0x20 working day not valid
+                0x80  # assume clock with ext. sync signal
+                )

--- a/xknx/dpt/dpt_time.py
+++ b/xknx/dpt/dpt_time.py
@@ -4,7 +4,7 @@ import time
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase, DPTWeekday
+from .dpt import DPTBase
 
 
 class DPTTime(DPTBase):
@@ -14,8 +14,10 @@ class DPTTime(DPTBase):
     DPT 10.001
     """
 
+    payload_length = 3
+
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw, 3)
 
@@ -27,43 +29,36 @@ class DPTTime(DPTBase):
         if not DPTTime._test_range(weekday, hours, minutes, seconds):
             raise ConversionError("Cant parse DPTTime", raw=raw)
 
-        return {'weekday': DPTWeekday(weekday),
-                'hours': hours,
-                'minutes': minutes,
-                'seconds': seconds}
+        try:
+            if weekday == 0:
+                # struct_time has no concept of "no day"; default to monday (for %w this is 1)
+                weekday = 1
+            elif weekday == 7:
+                # in knx Sunday is 7; in strftime %w its 0
+                weekday = 0
+            # strptime conversion used for catching exceptions; filled with default values
+            return time.strptime("{} {} {} {}".format(hours, minutes, seconds, weekday), "%H %M %S %w")
+        except ValueError:
+            raise ConversionError("Cant parse DPTTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, values):
+    def to_knx(cls, value: time.struct_time):
         """Serialize to KNX/IP raw data from dict with elements weekday,hours,minutes,seconds."""
-        if not isinstance(values, dict):
-            raise ConversionError("Cant serialize DPTTime", values=values)
-        weekday = values.get('weekday', DPTWeekday.NONE).value
-        hours = values.get('hours', 0)
-        minutes = values.get('minutes', 0)
-        seconds = values.get('seconds', 0)
+        if not isinstance(value, time.struct_time):
+            raise ConversionError("Cant serialize DPTTime - time.struct_time expected", value=value)
 
-        if not DPTTime._test_range(weekday, hours, minutes, seconds):
-            raise ConversionError("Cant serialize DPTTime", values=values)
+        _default_time = time.strptime("", "")
+        weekday = 0
+        # if 0 year, 1 month, 2 day, 6 weekday, 7 yearday, 8 dst are equal to default assume "any weekday" (0)
+        for index in [0, 1, 2, 6, 7, 8]:
+            if value[index] is not _default_time[index]:
+                weekday = value.tm_wday + 1
+                break
 
-        return weekday << 5 | hours, minutes, seconds
-
-    @classmethod
-    def _current_time(cls):
-        """Return current local time as struct."""
-        localtime = time.localtime()
-        weekday = localtime.tm_wday + 1
-        hours = localtime.tm_hour
-        minutes = localtime.tm_min
-        seconds = localtime.tm_sec
-        return {'weekday': DPTWeekday(weekday),
-                'hours': hours,
-                'minutes': minutes,
-                'seconds': seconds}
-
-    @classmethod
-    def current_time_as_knx(cls):
-        """Return current local time as KNX bytes."""
-        return cls.to_knx(cls._current_time())
+        return (weekday << 5 | value.tm_hour,
+                value.tm_min,
+                value.tm_sec
+                )
 
     @staticmethod
     def _test_range(weekday, hours, minutes, seconds):

--- a/xknx/remote_value/__init__.py
+++ b/xknx/remote_value/__init__.py
@@ -4,6 +4,7 @@ from .remote_value import RemoteValue
 from .remote_value_1count import RemoteValue1Count
 from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_color_rgbw import RemoteValueColorRGBW
+from .remote_value_datetime import RemoteValueDateTime
 from .remote_value_dpt_2_byte_unsigned import RemoteValueDpt2ByteUnsigned
 from .remote_value_dpt_value_1_ucount import RemoteValueDptValue1Ucount
 from .remote_value_scaling import RemoteValueScaling

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -108,7 +108,7 @@ class RemoteValue():
         telegram.payload = self.payload
         await self.xknx.telegrams.put(telegram)
 
-    async def set(self, value):
+    async def set(self, value, response=False):
         """Set new value."""
         if not self.initialized:
             self.xknx.logger.info("Setting value of uninitialized device: %s (value: %s)", self.device_name, value)
@@ -122,7 +122,7 @@ class RemoteValue():
         if self.payload is None or payload != self.payload:
             self.payload = payload
             updated = True
-        await self.send()
+        await self.send(response)
         if updated and self.after_update_cb is not None:
             await self.after_update_cb()
 

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -1,0 +1,58 @@
+"""
+Module for managing a remote date and time values.
+
+DPT 10.001, 11.001 and 19.001
+"""
+import time
+from enum import Enum
+
+from xknx.dpt import DPTArray, DPTDate, DPTDateTime, DPTTime
+from xknx.exceptions import ConversionError
+
+from .remote_value import RemoteValue
+
+
+class DateTimeType(Enum):
+    """Enum class for the date or time value type."""
+
+    DATETIME = DPTDateTime
+    DATE = DPTDate
+    TIME = DPTTime
+
+
+class RemoteValueDateTime(RemoteValue):
+    """Abstraction for remote value of KNX 10.001, 11.001 and 19.001 time and date objects."""
+
+    def __init__(self,
+                 xknx,
+                 group_address=None,
+                 group_address_state=None,
+                 sync_state=True,
+                 value_type='time',
+                 device_name=None,
+                 after_update_cb=None):
+        """Initialize RemoteValueSensor class."""
+        # pylint: disable=too-many-arguments
+        try:
+            self.dpt_class = DateTimeType[value_type.upper()].value
+        except KeyError:
+            raise ConversionError("invalid datetime value type", value_type=value_type, device_name=device_name)
+        super().__init__(xknx,
+                         group_address,
+                         group_address_state,
+                         sync_state=sync_state,
+                         device_name=device_name,
+                         after_update_cb=after_update_cb)
+
+    def payload_valid(self, payload):
+        """Test if telegram payload may be parsed."""
+        return (isinstance(payload, DPTArray)
+                and len(payload.value) == self.dpt_class.payload_length)
+
+    def to_knx(self, value: time.struct_time):
+        """Convert value to payload."""
+        return DPTArray(self.dpt_class.to_knx(value))
+
+    def from_knx(self, payload) -> time.struct_time:
+        """Convert current payload to value."""
+        return self.dpt_class.from_knx(payload.value)


### PR DESCRIPTION
- use a RemoteValue in DateTime device
- use time.struct_time for internal time and date representation - this takes over some data validation
- enables time, date and datetime payloads that are not the current time (eg. for setting timers)

# Breaking changes:
- DateTime devices are initialized with sting for `broadcast_type`: "time", "date" or "datetime" instead of an Enum value.


closes #243 