### PR TITLE
properly stop StateUpdater

### DIFF
--- a/xknx/core/stateupdater.py
+++ b/xknx/core/stateupdater.py
@@ -21,6 +21,16 @@ class StateUpdater():
         self.run_task = self.xknx.loop.create_task(
             self.run())
 
+    async def stop(self):
+        """Stop StateUpdater."""
+        if self.run_task:
+            self.xknx.logger.debug("Stopping StateUpdater")
+            self.run_task.cancel()
+            try:
+                await self.run_task
+            except asyncio.CancelledError:
+                self.run_task = None
+
     async def run(self):
         """Worker thread. Endless loop for updating states."""
         await asyncio.sleep(self.start_timeout)

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -98,6 +98,8 @@ class XKNX:
 
     async def stop(self):
         """Stop XKNX module."""
+        if self.state_updater:
+            await self.state_updater.stop()
         await self.join()
         await self.telegram_queue.stop()
         await self._stop_knxip_interface_if_exists()


### PR DESCRIPTION
to avoid

> ERROR:asyncio:Task was destroyed but it is pending!
task: <Task pending coro=<StateUpdater.run() done, defined at ...

after `await xknx.stop()`