### PR TITLE
HA expose entity state attributes

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN
 )
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
@@ -36,6 +38,8 @@ CONF_XKNX_STATE_UPDATER = "state_updater"
 CONF_XKNX_RATE_LIMIT = "rate_limit"
 CONF_XKNX_EXPOSE = "expose"
 CONF_XKNX_EXPOSE_TYPE = "type"
+CONF_XKNX_EXPOSE_ATTRIBUTE = "attribute"
+CONF_XKNX_EXPOSE_DEFAULT = "default"
 CONF_XKNX_EXPOSE_ADDRESS = "address"
 
 SERVICE_XKNX_SEND = "send"
@@ -58,6 +62,8 @@ EXPOSE_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_XKNX_EXPOSE_TYPE): cv.string,
         vol.Optional(CONF_ENTITY_ID): cv.entity_id,
+        vol.Optional(CONF_XKNX_EXPOSE_ATTRIBUTE): cv.string,
+        vol.Optional(CONF_XKNX_EXPOSE_DEFAULT): cv.match_all,
         vol.Required(CONF_XKNX_EXPOSE_ADDRESS): cv.string,
     }
 )
@@ -244,6 +250,8 @@ class KNXModule:
         for to_expose in self.config[DOMAIN][CONF_XKNX_EXPOSE]:
             expose_type = to_expose.get(CONF_XKNX_EXPOSE_TYPE)
             entity_id = to_expose.get(CONF_ENTITY_ID)
+            attribute = to_expose.get(CONF_XKNX_EXPOSE_ATTRIBUTE)
+            default = to_expose.get(CONF_XKNX_EXPOSE_DEFAULT)
             address = to_expose.get(CONF_XKNX_EXPOSE_ADDRESS)
             if expose_type in ["time", "date", "datetime"]:
                 exposure = KNXExposeTime(self.xknx, expose_type, address)
@@ -251,7 +259,8 @@ class KNXModule:
                 self.exposures.append(exposure)
             else:
                 exposure = KNXExposeSensor(
-                    self.hass, self.xknx, expose_type, entity_id, address
+                    self.hass, self.xknx, expose_type, entity_id,
+                    attribute, default, address
                 )
                 exposure.async_register()
                 self.exposures.append(exposure)
@@ -325,21 +334,27 @@ class KNXExposeTime:
 class KNXExposeSensor:
     """Object to Expose Home Assistant entity to KNX bus."""
 
-    def __init__(self, hass, xknx, expose_type, entity_id, address):
+    def __init__(self, hass, xknx, expose_type, entity_id, attribute, default, address):
         """Initialize of Expose class."""
         self.hass = hass
         self.xknx = xknx
         self.type = expose_type
         self.entity_id = entity_id
+        self.expose_attribute = attribute
+        self.expose_default = default
         self.address = address
         self.device = None
 
     @callback
     def async_register(self):
         """Register listener."""
+        if self.expose_attribute is not None:
+            _name = self.entity_id + "__" + self.expose_attribute
+        else:
+            _name = self.entity_id
         self.device = ExposeSensor(
             self.xknx,
-            name=self.entity_id,
+            name=_name,
             group_address=self.address,
             value_type=self.type,
         )
@@ -350,13 +365,31 @@ class KNXExposeSensor:
         """Handle entity change."""
         if new_state is None:
             return
-        if new_state.state == "unknown":
+        if new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return
 
-        if self.type == "binary":
-            if new_state.state == "on":
-                await self.device.set(True)
-            elif new_state.state == "off":
-                await self.device.set(False)
+        if self.expose_attribute is not None:
+            new_attribute = new_state.attributes.get(self.expose_attribute)
+            if old_state is not None:
+                old_attribute = old_state.attributes.get(self.expose_attribute)
+                if old_attribute == new_attribute:
+                    # don't send same value sequentially and spam the bus
+                    return
+            await self._async_set_knx_value(new_attribute)
         else:
-            await self.device.set(new_state.state)
+            await self._async_set_knx_value(new_state.state)
+
+    async def _async_set_knx_value(self, value):
+        """Set new value on xknx ExposeSensor."""
+        if value is None:
+            if self.expose_default is None:
+                return
+            value = self.expose_default
+
+        if self.type == "binary":
+            if value == "on":
+                value = True
+            elif value == "off":
+                value = False
+
+        await self.device.set(value)

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -14,6 +14,8 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
+    STATE_ON,
+    STATE_OFF,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN
 )
@@ -373,7 +375,7 @@ class KNXExposeSensor:
             if old_state is not None:
                 old_attribute = old_state.attributes.get(self.expose_attribute)
                 if old_attribute == new_attribute:
-                    # don't send same value sequentially and spam the bus
+                    # don't send same value sequentially
                     return
             await self._async_set_knx_value(new_attribute)
         else:
@@ -387,9 +389,9 @@ class KNXExposeSensor:
             value = self.expose_default
 
         if self.type == "binary":
-            if value == "on":
+            if value == STATE_ON:
                 value = True
-            elif value == "off":
+            elif value == STATE_OFF:
                 value = False
 
         await self.device.set(value)


### PR DESCRIPTION
- expose state attributes (eg. `brightness` of a light) directly to a knx group address
- set a default value if the state or attribute is `None`(eg. light with state `off` has no brightness attribute)
- state attributes are not sent twice if they have not changed - states do (eg. for push buttons)
- if state is "unavailable" no value is sent now (in additon to "unknown")

 example configuration:
```yaml
xknx:
  expose:
    - type: 'percentU8'
      entity_id: 'light.buero'
      attribute: 'brightness'
      default: 0
      address: '0/3/1'
    - type: 'binary'
      entity_id: 'light.buero'
      address: '0/3/0'
      default: False
```