### PR TITLE
merge HA custom component from 0.110

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -14,10 +14,10 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STOP,
-    STATE_ON,
     STATE_OFF,
+    STATE_ON,
     STATE_UNAVAILABLE,
-    STATE_UNKNOWN
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import discovery
@@ -262,8 +262,13 @@ class KNXModule:
                 self.exposures.append(exposure)
             else:
                 exposure = KNXExposeSensor(
-                    self.hass, self.xknx, expose_type, entity_id,
-                    attribute, default, address
+                    self.hass,
+                    self.xknx,
+                    expose_type,
+                    entity_id,
+                    attribute,
+                    default,
+                    address,
                 )
                 exposure.async_register()
                 self.exposures.append(exposure)
@@ -356,10 +361,7 @@ class KNXExposeSensor:
         else:
             _name = self.entity_id
         self.device = ExposeSensor(
-            self.xknx,
-            name=_name,
-            group_address=self.address,
-            value_type=self.type,
+            self.xknx, name=_name, group_address=self.address, value_type=self.type,
         )
         self.xknx.devices.add(self.device)
         async_track_state_change(self.hass, self.entity_id, self._async_entity_changed)

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -206,7 +206,7 @@ class KNXModule:
 
     def connection_config_tunneling(self):
         """Return the connection_config if tunneling is configured."""
-        gateway_ip = self.config[DOMAIN][CONF_XKNX_TUNNELING].get(CONF_HOST)
+        gateway_ip = self.config[DOMAIN][CONF_XKNX_TUNNELING][CONF_HOST]
         gateway_port = self.config[DOMAIN][CONF_XKNX_TUNNELING].get(CONF_PORT)
         local_ip = self.config[DOMAIN][CONF_XKNX_TUNNELING].get(CONF_XKNX_LOCAL_IP)
         if gateway_port is None:
@@ -216,6 +216,7 @@ class KNXModule:
             gateway_ip=gateway_ip,
             gateway_port=gateway_port,
             local_ip=local_ip,
+            auto_reconnect=True,
         )
 
     def connection_config_auto(self):

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -2,7 +2,7 @@
 import voluptuous as vol
 from xknx.devices import BinarySensor
 
-from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorDevice
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -13,7 +13,6 @@ CONF_STATE_ADDRESS = "state_address"
 CONF_SIGNIFICANT_BIT = "significant_bit"
 CONF_DEFAULT_SIGNIFICANT_BIT = 1
 CONF_SYNC_STATE = "sync_state"
-CONF_IGNORE_INTERNAL_STATE = "ignore_internal_state"
 CONF_AUTOMATION = "automation"
 CONF_HOOK = "hook"
 CONF_DEFAULT_HOOK = "on"
@@ -42,7 +41,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
         ): cv.positive_int,
         vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
-        vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=False): cv.boolean,
         vol.Required(CONF_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_DEVICE_CLASS): cv.string,
         vol.Optional(CONF_RESET_AFTER): cv.positive_int,
@@ -79,7 +77,6 @@ def async_add_entities_config(hass, config, async_add_entities):
         name=name,
         group_address_state=config[CONF_STATE_ADDRESS],
         sync_state=config[CONF_SYNC_STATE],
-        ignore_internal_state=config[CONF_IGNORE_INTERNAL_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER),
@@ -105,7 +102,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     async_add_entities([entity])
 
 
-class KNXBinarySensor(BinarySensorDevice):
+class KNXBinarySensor(BinarySensorEntity):
     """Representation of a KNX binary sensor."""
 
     def __init__(self, device):
@@ -119,7 +116,7 @@ class KNXBinarySensor(BinarySensorDevice):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 from xknx.devices import Climate as XknxClimate, ClimateMode as XknxClimateMode
 from xknx.dpt import HVACOperationMode
 
-from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateDevice
+from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
     HVAC_MODE_COOL,
@@ -66,7 +66,7 @@ OPERATION_MODES = {
     "Dry": HVAC_MODE_DRY,
 }
 
-OPERATION_MODES_INV = dict((reversed(item) for item in OPERATION_MODES.items()))
+OPERATION_MODES_INV = dict(reversed(item) for item in OPERATION_MODES.items())
 
 PRESET_MODES = {
     # Map DPT 201.100 HVAC operating modes to HA presets
@@ -76,7 +76,7 @@ PRESET_MODES = {
     "Comfort": PRESET_COMFORT,
 }
 
-PRESET_MODES_INV = dict((reversed(item) for item in PRESET_MODES.items()))
+PRESET_MODES_INV = dict(reversed(item) for item in PRESET_MODES.items())
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -108,7 +108,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
         vol.Optional(CONF_OPERATION_MODES): vol.All(
-            cv.ensure_list, [vol.In(OPERATION_MODES)]
+            cv.ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
         ),
         vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
         vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
@@ -139,7 +139,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     """Set up climate for KNX platform configured within platform."""
     climate_mode = XknxClimateMode(
         hass.data[DATA_XKNX].xknx,
-        name=config[CONF_NAME] + " Mode",
+        name=f"{config[CONF_NAME]} Mode",
         group_address_operation_mode=config.get(CONF_OPERATION_MODE_ADDRESS),
         group_address_operation_mode_state=config.get(
             CONF_OPERATION_MODE_STATE_ADDRESS
@@ -192,7 +192,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     async_add_entities([KNXClimate(climate)])
 
 
-class KNXClimate(ClimateDevice):
+class KNXClimate(ClimateEntity):
     """Representation of a KNX climate device."""
 
     def __init__(self, device):
@@ -210,7 +210,7 @@ class KNXClimate(ClimateDevice):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
         self.device.mode.register_device_updated_cb(after_update_callback)
@@ -266,7 +266,7 @@ class KNXClimate(ClimateDevice):
         if temperature is None:
             return
         await self.device.set_target_temperature(temperature)
-        await self.async_update_ha_state()
+        self.async_write_ha_state()
 
     @property
     def hvac_mode(self) -> Optional[str]:
@@ -304,7 +304,7 @@ class KNXClimate(ClimateDevice):
         elif self.device.mode.supports_operation_mode:
             knx_operation_mode = HVACOperationMode(OPERATION_MODES_INV.get(hvac_mode))
             await self.device.mode.set_operation_mode(knx_operation_mode)
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
     @property
     def preset_mode(self) -> Optional[str]:
@@ -334,4 +334,4 @@ class KNXClimate(ClimateDevice):
         if self.device.mode.supports_operation_mode:
             knx_operation_mode = HVACOperationMode(PRESET_MODES_INV.get(preset_mode))
             await self.device.mode.set_operation_mode(knx_operation_mode)
-            await self.async_update_ha_state()
+            self.async_write_ha_state()

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -284,7 +284,8 @@ class KNXClimate(ClimateEntity):
             return OPERATION_MODES.get(
                 self.device.mode.operation_mode.value, HVAC_MODE_HEAT
             )
-        return None
+        # default to "heat"
+        return HVAC_MODE_HEAT
 
     @property
     def hvac_modes(self) -> Optional[List[str]]:
@@ -298,7 +299,9 @@ class KNXClimate(ClimateEntity):
             _operations.append(HVAC_MODE_HEAT)
             _operations.append(HVAC_MODE_OFF)
 
-        return [op for op in _operations if op is not None]
+        _modes = list(filter(None, _operations))
+        # default to ["heat"]
+        return _modes if _modes else [HVAC_MODE_HEAT]
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """Set operation mode."""

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -11,7 +11,7 @@ from homeassistant.components.cover import (
     SUPPORT_SET_POSITION,
     SUPPORT_SET_TILT_POSITION,
     SUPPORT_STOP,
-    CoverDevice,
+    CoverEntity,
 )
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
@@ -94,7 +94,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     async_add_entities([KNXCover(cover)])
 
 
-class KNXCover(CoverDevice):
+class KNXCover(CoverEntity):
     """Representation of a KNX cover."""
 
     def __init__(self, device):
@@ -108,7 +108,7 @@ class KNXCover(CoverDevice):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
 
@@ -204,7 +204,7 @@ class KNXCover(CoverDevice):
     @callback
     def auto_updater_hook(self, now):
         """Call for the autoupdater."""
-        self.async_schedule_update_ha_state()
+        self.async_write_ha_state()
         if self.device.position_reached():
             self.stop_auto_updater()
 

--- a/home-assistant-plugin/custom_components/xknx/light.py
+++ b/home-assistant-plugin/custom_components/xknx/light.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
     SUPPORT_COLOR,
     SUPPORT_COLOR_TEMP,
     SUPPORT_WHITE_VALUE,
-    Light,
+    LightEntity,
 )
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import callback
@@ -132,7 +132,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     async_add_entities([KNXLight(light)])
 
 
-class KNXLight(Light):
+class KNXLight(LightEntity):
     """Representation of a KNX light."""
 
     def __init__(self, device):
@@ -154,7 +154,7 @@ class KNXLight(Light):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
 
@@ -180,9 +180,13 @@ class KNXLight(Light):
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
-        if not self.device.supports_brightness:
-            return None
-        return self.device.current_brightness
+        if self.device.supports_brightness:
+            return self.device.current_brightness
+        hsv_color = self._hsv_color
+        if self.device.supports_color and hsv_color:
+            # pylint: disable=unsubscriptable-object
+            return round(hsv_color[-1] / 100 * 255)
+        return None
 
     @property
     def hs_color(self):
@@ -191,6 +195,14 @@ class KNXLight(Light):
         if self.device.supports_rgbw or self.device.supports_color:
             rgb, _ = self.device.current_color
         return color_util.color_RGB_to_hs(*rgb) if rgb else None
+
+    @property
+    def _hsv_color(self):
+        """Return the HSV color value."""
+        rgb = None
+        if self.device.supports_rgbw or self.device.supports_color:
+            rgb, _ = self.device.current_color
+        return color_util.color_RGB_to_hsv(*rgb) if rgb else None
 
     @property
     def white_value(self):

--- a/home-assistant-plugin/custom_components/xknx/manifest.json
+++ b/home-assistant-plugin/custom_components/xknx/manifest.json
@@ -3,6 +3,5 @@
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
   "requirements": [],
-  "dependencies": [],
   "codeowners": ["@Julius2342"]
 }

--- a/home-assistant-plugin/custom_components/xknx/scene.py
+++ b/home-assistant-plugin/custom_components/xknx/scene.py
@@ -1,4 +1,6 @@
 """Support for KNX scenes."""
+from typing import Any
+
 import voluptuous as vol
 from xknx.devices import Scene as XknxScene
 
@@ -65,6 +67,6 @@ class KNXScene(Scene):
         """Return the name of the scene."""
         return self.scene.name
 
-    async def async_activate(self):
+    async def async_activate(self, **kwargs: Any) -> None:
         """Activate the scene."""
         await self.scene.run()

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -69,7 +69,7 @@ class KNXSensor(Entity):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/home-assistant-plugin/custom_components/xknx/switch.py
+++ b/home-assistant-plugin/custom_components/xknx/switch.py
@@ -2,7 +2,7 @@
 import voluptuous as vol
 from xknx.devices import Switch as XknxSwitch
 
-from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchDevice
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
 from homeassistant.const import CONF_ADDRESS, CONF_NAME
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
@@ -52,7 +52,7 @@ def async_add_entities_config(hass, config, async_add_entities):
     async_add_entities([KNXSwitch(switch)])
 
 
-class KNXSwitch(SwitchDevice):
+class KNXSwitch(SwitchEntity):
     """Representation of a KNX switch."""
 
     def __init__(self, device):
@@ -65,7 +65,7 @@ class KNXSwitch(SwitchDevice):
 
         async def after_update_callback(device):
             """Call after device was updated."""
-            await self.async_update_ha_state()
+            self.async_write_ha_state()
 
         self.device.register_device_updated_cb(after_update_callback)
 

--- a/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
+++ b/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:
 
 # Defines the column order of the printed table.
 # ["dpt_number", "value_type", "dpt_size", "unit", "dpt_range"]
-COLUMN_ORDER = ["dpt_number", "value_type", "dpt_size", "unit"]
+COLUMN_ORDER = ["dpt_number", "value_type", "dpt_size", "dpt_range", "unit"]
 
 # Defines the column adjustment of the printed table.
 # "left", "right" or "center"


### PR DESCRIPTION
this includes the change of Entity Class names in HA from `*` to `*Entity` (eg. Light to LightEntity)
I'm not sure when this will hit HA. I suppose in 0.110
see https://github.com/home-assistant/core/pull/34593