### PR TITLE
Register group

### DIFF
--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -1,0 +1,64 @@
+"""Unit test for Sensor objects."""
+import asyncio
+import unittest
+import pathlib
+import os
+from unittest.mock import Mock
+
+from xknx import XKNX
+from xknx.devices import Device
+
+class CustomDevice(Device):
+    def __init__(self,
+                 xknx,
+                 name,
+                 group_address_state=None,
+                 my_custom_attribute=""):
+        """Initialize CustomDevice class."""
+        # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
+        super().__init__(xknx, name)
+        self.group_address_state = group_address_state
+        self.my_custom_attribute = my_custom_attribute
+
+    @classmethod
+    def from_config(cls, xknx, name, config):
+        """Initialize object from configuration structure."""
+        group_address_state = \
+            config.get('group_address_state')
+        my_custom_attribute = \
+            config.get('my_custom_attribute')
+
+        return cls(xknx,
+                   name,
+                   group_address_state=group_address_state,
+                   my_custom_attribute=my_custom_attribute)
+
+        
+    def get_my_custom_attribute(self):
+        return self.my_custom_attribute
+
+class TestRegisterDeviceClass(unittest.TestCase):
+    """Test class for registering new device classes"""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+    #
+    # test registration of custom devices
+    #
+    def test_register_device_class(self):
+        """Test resolve state with binary sensor."""
+        xknx = XKNX(
+                loop=self.loop,
+                custom_device_classes = { "custom_device" : CustomDevice },
+                config= os.path.join(pathlib.Path(__file__).parent.absolute(),"device_class_test.yaml")
+            )
+        self.assertTrue("my_example_device" in xknx.devices)
+        self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")
+        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute() == "hello world")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -61,4 +61,4 @@ class TestRegisterDeviceClass(unittest.TestCase):
             )
         self.assertTrue("my_example_device" in xknx.devices)
         self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")
-        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute() == "hello world")
+        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute(), "hello world")

--- a/test/devices_tests/device_class_test.yaml
+++ b/test/devices_tests/device_class_test.yaml
@@ -1,0 +1,9 @@
+general:
+    own_address: '15.15.249'
+connection:
+    routing:
+groups:
+    custom_device:
+        my_example_device:
+            group_address_state: '1/2/7'
+            my_custom_attribute: 'hello world'

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -79,7 +79,7 @@ class Config:
                 and hasattr(doc["groups"], '__iter__'):
             for group in doc["groups"]:
                 device_class = self.identify_registered_device_class(group)
-                if device_class != None:
+                if device_class is not None:
                     self.parse_group(device_class, doc["groups"][group])
 
     def identify_registered_device_class(self, group):

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -1,0 +1,16 @@
+import copy
+
+class ReadOnlyDict(dict):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("Cannot modify ReadOnlyDict")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop         = __readonly__
+    popitem     = __readonly__
+    clear       = __readonly__
+    update      = __readonly__
+    setdefault  = __readonly__
+    del __readonly__
+    __copy__    = dict.copy 
+    __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -164,29 +164,35 @@ class Climate(Device):
         min_temp = config.get('min_temp')
         max_temp = config.get('max_temp')
 
+        devices = []
         climate_mode = None
         if "mode" in config:
             climate_mode = ClimateMode.from_config(
                 xknx=xknx,
                 name=None,
                 config=config['mode'])
+            devices.append(climate_mode)
 
-        return cls(xknx,
-                   name,
-                   group_address_temperature=group_address_temperature,
-                   group_address_target_temperature=group_address_target_temperature,
-                   group_address_target_temperature_state=group_address_target_temperature_state,
-                   group_address_setpoint_shift=group_address_setpoint_shift,
-                   group_address_setpoint_shift_state=group_address_setpoint_shift_state,
-                   setpoint_shift_step=setpoint_shift_step,
-                   setpoint_shift_max=setpoint_shift_max,
-                   setpoint_shift_min=setpoint_shift_min,
-                   group_address_on_off=group_address_on_off,
-                   group_address_on_off_state=group_address_on_off_state,
-                   on_off_invert=on_off_invert,
-                   min_temp=min_temp,
-                   max_temp=max_temp,
-                   mode=climate_mode)
+        devices.append(
+            cls(xknx,
+                name,
+                group_address_temperature=group_address_temperature,
+                group_address_target_temperature=group_address_target_temperature,
+                group_address_target_temperature_state=group_address_target_temperature_state,
+                group_address_setpoint_shift=group_address_setpoint_shift,
+                group_address_setpoint_shift_state=group_address_setpoint_shift_state,
+                setpoint_shift_step=setpoint_shift_step,
+                setpoint_shift_max=setpoint_shift_max,
+                setpoint_shift_min=setpoint_shift_min,
+                group_address_on_off=group_address_on_off,
+                group_address_on_off_state=group_address_on_off_state,
+                on_off_invert=on_off_invert,
+                min_temp=min_temp,
+                max_temp=max_temp,
+                mode=climate_mode
+                )
+            )
+        return devices
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""


### PR DESCRIPTION
Allow configuration of custom devices via the main yaml.
Also config.py is fully independent from any specific device implementation now.

Usage example:
        xknx = XKNX(
                loop=self.loop,
                custom_device_classes = { "custom_device" : CustomDevice },
                config= "xknx.yaml")
