### PR TITLE
Register group

### DIFF
--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -463,7 +463,7 @@ class TestConfig(unittest.TestCase):
     def test_config_file_error(self):
         """Test error message when reading an errornous config file."""
         with patch('logging.Logger.error') as mock_err, \
-                patch('xknx.core.Config.parse_group_light') as mock_parse:
+                patch('xknx.devices.Light.from_config') as mock_parse:
             mock_parse.side_effect = XKNXException()
             XKNX(config='xknx.yaml', loop=self.loop)
             self.assertEqual(mock_err.call_count, 1)

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -56,7 +56,7 @@ class TestRegisterDeviceClass(unittest.TestCase):
         """Test registration of a custom device class."""
         xknx = XKNX(
                 loop=self.loop,
-                custom_device_classes = {"custom_device":CustomDevice},
+                custom_device_classes = {"custom_device": CustomDevice},
                 config= os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
             )
         self.assertTrue("my_example_device" in xknx.devices)

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -56,7 +56,7 @@ class TestRegisterDeviceClass(unittest.TestCase):
         """Test registration of a custom device class."""
         xknx = XKNX(
                 loop=self.loop,
-                custom_device_classes = {"custom_device": CustomDevice},
+                custom_device_classes={"custom_device": CustomDevice},
                 config= os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
             )
         self.assertTrue("my_example_device" in xknx.devices)

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -1,12 +1,12 @@
-"""Unit test for Sensor objects."""
+"""Unit test for registering custom Device classes"""
 import asyncio
 import unittest
 import pathlib
 import os
-from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Device
+
 
 class CustomDevice(Device):
     def __init__(self,
@@ -33,12 +33,12 @@ class CustomDevice(Device):
                    group_address_state=group_address_state,
                    my_custom_attribute=my_custom_attribute)
 
-        
     def get_my_custom_attribute(self):
         return self.my_custom_attribute
 
+
 class TestRegisterDeviceClass(unittest.TestCase):
-    """Test class for registering new device classes"""
+    """Test class for registering new device classes."""
 
     def setUp(self):
         """Set up test class."""
@@ -53,11 +53,11 @@ class TestRegisterDeviceClass(unittest.TestCase):
     # test registration of custom devices
     #
     def test_register_device_class(self):
-        """Test resolve state with binary sensor."""
+        """Test registration of a custom device class."""
         xknx = XKNX(
                 loop=self.loop,
-                custom_device_classes = { "custom_device" : CustomDevice },
-                config= os.path.join(pathlib.Path(__file__).parent.absolute(),"device_class_test.yaml")
+                custom_device_classes = {"custom_device":CustomDevice},
+                config= os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
             )
         self.assertTrue("my_example_device" in xknx.devices)
         self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -58,7 +58,7 @@ class TestRegisterDeviceClass(unittest.TestCase):
         xknx = XKNX(
                 loop=self.loop,
                 custom_device_classes={"custom_device": CustomDevice},
-                config=os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
+                config=os.path.join(str(pathlib.Path(__file__).parent.absolute()), "device_class_test.yaml")
             )
         self.assertTrue("my_example_device" in xknx.devices)
         self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -1,0 +1,64 @@
+"""Unit test for Sensor objects."""
+import asyncio
+import unittest
+import pathlib
+import os
+from unittest.mock import Mock
+
+from xknx import XKNX
+from xknx.devices import Device
+
+class CustomDevice(Device):
+    def __init__(self,
+                 xknx,
+                 name,
+                 group_address_state=None,
+                 my_custom_attribute=""):
+        """Initialize CustomDevice class."""
+        # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
+        super().__init__(xknx, name)
+        self.group_address_state = group_address_state
+        self.my_custom_attribute = my_custom_attribute
+
+    @classmethod
+    def from_config(cls, xknx, name, config):
+        """Initialize object from configuration structure."""
+        group_address_state = \
+            config.get('group_address_state')
+        my_custom_attribute = \
+            config.get('my_custom_attribute')
+
+        return cls(xknx,
+                   name,
+                   group_address_state=group_address_state,
+                   my_custom_attribute=my_custom_attribute)
+
+        
+    def get_my_custom_attribute(self):
+        return self.my_custom_attribute
+
+class TestRegisterDeviceClass(unittest.TestCase):
+    """Test class for registering new device classes"""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+    #
+    # test registration of custom devices
+    #
+    def test_register_device_class(self):
+        """Test resolve state with binary sensor."""
+        xknx = XKNX(
+                loop=self.loop,
+                custom_device_classes = { "custom_device" : CustomDevice },
+                config= os.path.join(pathlib.Path(__file__).parent.absolute(),"device_class_test.yaml")
+            )
+        self.assertTrue("my_example_device" in xknx.devices)
+        self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")
+        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute() == "hello world")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -1,4 +1,5 @@
 """Unit test for registering custom Device classes"""
+
 import asyncio
 import unittest
 import pathlib
@@ -57,7 +58,7 @@ class TestRegisterDeviceClass(unittest.TestCase):
         xknx = XKNX(
                 loop=self.loop,
                 custom_device_classes={"custom_device": CustomDevice},
-                config= os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
+                config=os.path.join(pathlib.Path(__file__).parent.absolute(), "device_class_test.yaml")
             )
         self.assertTrue("my_example_device" in xknx.devices)
         self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -61,4 +61,4 @@ class TestRegisterDeviceClass(unittest.TestCase):
             )
         self.assertTrue("my_example_device" in xknx.devices)
         self.assertTrue(xknx.devices["my_example_device"].__class__.__name__ == "CustomDevice")
-        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute() == "hello world")
+        self.assertEqual(xknx.devices["my_example_device"].get_my_custom_attribute(), "hello world")

--- a/test/devices_tests/device_class_test.py
+++ b/test/devices_tests/device_class_test.py
@@ -1,9 +1,9 @@
 """Unit test for registering custom Device classes"""
 
 import asyncio
-import unittest
-import pathlib
 import os
+import pathlib
+import unittest
 
 from xknx import XKNX
 from xknx.devices import Device

--- a/test/devices_tests/device_class_test.yaml
+++ b/test/devices_tests/device_class_test.yaml
@@ -1,0 +1,9 @@
+general:
+    own_address: '15.15.249'
+connection:
+    routing:
+groups:
+    custom_device:
+        my_example_device:
+            group_address_state: '1/2/7'
+            my_custom_attribute: 'hello world'

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -83,7 +83,7 @@ class Config:
                     self.parse_group(device_class, doc["groups"][group])
 
     def identify_registered_device_class_from_group(self, group):
-        """ returns the device class for the passed group name or None if not found """
+        """Return the device class for the passed group name or None if not found."""
         registered_device_classes = self.xknx.registered_device_classes()
         # standard handling with well formed group names
         if group in registered_device_classes:
@@ -96,7 +96,8 @@ class Config:
 
     def parse_group(self, device_class, entries):
         """Parse a group entry of xknx.yaml."""
-        def as_list(item): return item if isinstance(item, list) else [item]
+        def as_list(item):
+            return item if isinstance(item, list) else [item]
         try:
             for entry in entries:
                 devices = as_list(
@@ -111,6 +112,6 @@ class Config:
             self.xknx.logger.error("Error while reading config file: Could not parse %s: %s", device_class.__name__, ex)
 
     def add_devices(self, devices):
-        """ add the passed list of devices to the XKNX device list """
+        """Add the passed list of devices to the XKNX device list."""
         for device in devices:
             self.xknx.devices.add(device)

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -79,7 +79,7 @@ class Config:
                 and hasattr(doc["groups"], '__iter__'):
             for group in doc["groups"]:
                 device_class = self.identify_registered_device_class(group)
-                if device_class != None:
+                if device_class is not None:
                     self.parse_group(device_class, doc["groups"][group])
 
     def identify_registered_device_class(self, group):

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -78,11 +78,12 @@ class Config:
         if "groups" in doc \
                 and hasattr(doc["groups"], '__iter__'):
             for group in doc["groups"]:
-                device_class = self.identify_registered_device_class(group)
+                device_class = self.identify_registered_device_class_from_group(group)
                 if device_class is not None:
                     self.parse_group(device_class, doc["groups"][group])
 
-    def identify_registered_device_class(self, group):
+    def identify_registered_device_class_from_group(self, group):
+        """ returns the device class for the passed group name or None if not found """
         registered_device_classes = self.xknx.registered_device_classes()
         # standard handling with well formed group names
         if group in registered_device_classes:
@@ -91,10 +92,8 @@ class Config:
         for reg_group, device_class in registered_device_classes.items():
             if group.startswith(reg_group):
                 return device_class
-            else:
-                return None
+        return None
 
-        
     def parse_group(self, device_class, entries):
         """Parse a group entry of xknx.yaml."""
         def as_list(item): return item if isinstance(item, list) else [item]
@@ -109,8 +108,9 @@ class Config:
                 )
                 self.add_devices(devices)
         except XKNXException as ex:
-            self.xknx.logger.error("Error while reading config file: Could not parse %s: %s", group, ex)
+            self.xknx.logger.error("Error while reading config file: Could not parse %s: %s", device_class.__name__, ex)
 
     def add_devices(self, devices):
+        """ add the passed list of devices to the XKNX device list """
         for device in devices:
             self.xknx.devices.add(device)

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -4,9 +4,9 @@ import copy
 
 class ReadOnlyDict(dict):
     """Dictionary which doesn't allow to add or remove items."""
-	# pylint: disable=no-self-use
+    # pylint: disable=no-self-use
     def __readonly__(self, *args, **kwargs):
-		"""Throw runtime error when trying to modify the dict."""
+        """Throw runtime error when trying to modify the dict."""
         raise RuntimeError("Cannot modify ReadOnlyDict")
 
     __setitem__ = __readonly__
@@ -18,5 +18,5 @@ class ReadOnlyDict(dict):
     setdefault = __readonly__
     del __readonly__
     __copy__ = dict.copy
-	# pylint: disable-protected-access
+    # pylint: disable-protected-access
     __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -1,0 +1,16 @@
+import copy
+
+class ReadOnlyDict(dict):
+    def __readonly__(self, *args, **kwargs):
+        raise RuntimeError("Cannot modify ReadOnlyDict")
+
+    __setitem__ = __readonly__
+    __delitem__ = __readonly__
+    pop         = __readonly__
+    popitem     = __readonly__
+    clear       = __readonly__
+    update      = __readonly__
+    setdefault  = __readonly__
+    del __readonly__
+    __copy__    = dict.copy 
+    __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -1,16 +1,17 @@
 import copy
 
+
 class ReadOnlyDict(dict):
     def __readonly__(self, *args, **kwargs):
         raise RuntimeError("Cannot modify ReadOnlyDict")
 
     __setitem__ = __readonly__
     __delitem__ = __readonly__
-    pop         = __readonly__
-    popitem     = __readonly__
-    clear       = __readonly__
-    update      = __readonly__
-    setdefault  = __readonly__
+    pop = __readonly__
+    popitem = __readonly__
+    clear = __readonly__
+    update = __readonly__
+    setdefault = __readonly__
     del __readonly__
-    __copy__    = dict.copy 
+    __copy__ = dict.copy 
     __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -1,8 +1,12 @@
+"""Module for the ReadOnlyDict class."""
 import copy
 
 
 class ReadOnlyDict(dict):
+    """Dictionary which doesn't allow to add or remove items."""
+	# pylint: disable=no-self-use
     def __readonly__(self, *args, **kwargs):
+		"""Throw runtime error when trying to modify the dict."""
         raise RuntimeError("Cannot modify ReadOnlyDict")
 
     __setitem__ = __readonly__
@@ -13,5 +17,6 @@ class ReadOnlyDict(dict):
     update = __readonly__
     setdefault = __readonly__
     del __readonly__
-    __copy__ = dict.copy 
+    __copy__ = dict.copy
+	# pylint: disable-protected-access
     __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/core/readonlydict.py
+++ b/xknx/core/readonlydict.py
@@ -4,6 +4,7 @@ import copy
 
 class ReadOnlyDict(dict):
     """Dictionary which doesn't allow to add or remove items."""
+
     # pylint: disable=no-self-use
     def __readonly__(self, *args, **kwargs):
         """Throw runtime error when trying to modify the dict."""
@@ -18,5 +19,5 @@ class ReadOnlyDict(dict):
     setdefault = __readonly__
     del __readonly__
     __copy__ = dict.copy
-    # pylint: disable-protected-access
+    # pylint: disable=protected-access
     __deepcopy__ = copy._deepcopy_dispatch.get(dict)

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -164,29 +164,35 @@ class Climate(Device):
         min_temp = config.get('min_temp')
         max_temp = config.get('max_temp')
 
+        devices = []
         climate_mode = None
         if "mode" in config:
             climate_mode = ClimateMode.from_config(
                 xknx=xknx,
                 name=None,
                 config=config['mode'])
+            devices.append(climate_mode)
 
-        return cls(xknx,
-                   name,
-                   group_address_temperature=group_address_temperature,
-                   group_address_target_temperature=group_address_target_temperature,
-                   group_address_target_temperature_state=group_address_target_temperature_state,
-                   group_address_setpoint_shift=group_address_setpoint_shift,
-                   group_address_setpoint_shift_state=group_address_setpoint_shift_state,
-                   setpoint_shift_step=setpoint_shift_step,
-                   setpoint_shift_max=setpoint_shift_max,
-                   setpoint_shift_min=setpoint_shift_min,
-                   group_address_on_off=group_address_on_off,
-                   group_address_on_off_state=group_address_on_off_state,
-                   on_off_invert=on_off_invert,
-                   min_temp=min_temp,
-                   max_temp=max_temp,
-                   mode=climate_mode)
+        devices.append(
+            cls(xknx,
+                name,
+                group_address_temperature=group_address_temperature,
+                group_address_target_temperature=group_address_target_temperature,
+                group_address_target_temperature_state=group_address_target_temperature_state,
+                group_address_setpoint_shift=group_address_setpoint_shift,
+                group_address_setpoint_shift_state=group_address_setpoint_shift_state,
+                setpoint_shift_step=setpoint_shift_step,
+                setpoint_shift_max=setpoint_shift_max,
+                setpoint_shift_min=setpoint_shift_min,
+                group_address_on_off=group_address_on_off,
+                group_address_on_off_state=group_address_on_off_state,
+                on_off_invert=on_off_invert,
+                min_temp=min_temp,
+                max_temp=max_temp,
+                mode=climate_mode
+                )
+            )
+        return devices
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -19,9 +19,10 @@ from .__version__ import __version__ as VERSION
 
 
 def standard_device_classes():
-    """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
-    
-       Group names within the xknx config file start with one of the available device class names
+    """Return the dictionary of standard device classes.
+
+       Group names within the xknx config file start with one of the available
+       device class names.
     """
     return {
         "binary_sensor": BinarySensor,

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -17,8 +17,10 @@ from xknx.telegram import GroupAddressType, PhysicalAddress
 
 from .__version__ import __version__ as VERSION
 
+
 def standard_device_classes():
     """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
+    
        Group names within the xknx config file start with one of the available device class names
     """
     return {

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -6,15 +6,15 @@ import signal
 from inspect import isclass
 from sys import platform
 
-from xknx.core.readonlydict import ReadOnlyDict
 from xknx.core import Config, TelegramQueue
+from xknx.core.readonlydict import ReadOnlyDict
+from xknx.devices import (
+    BinarySensor, Climate, Cover, DateTime, Device, ExposeSensor, Fan, Light,
+    Notification, Scene, Sensor, Switch)
 from xknx.devices import Devices
+from xknx.exceptions import XKNXException
 from xknx.io import ConnectionConfig, KNXIPInterface
 from xknx.telegram import GroupAddressType, PhysicalAddress
-from xknx.exceptions import XKNXException
-from xknx.devices import (
-    Device, BinarySensor, Climate, Cover, DateTime, ExposeSensor, Fan, Light,
-    Notification, Scene, Sensor, Switch)
 
 from .__version__ import __version__ as VERSION
 
@@ -100,7 +100,7 @@ class XKNX:
             "scene": Scene,
             "sensor": Sensor,
             "switch": Switch
-        }
+            }
 
     def __del__(self):
         """Destructor. Cleaning up if this was not done before."""

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -54,7 +54,7 @@ class XKNX:
         self.telegram_logger = logging.getLogger('xknx.telegram')
         self.connection_config = None
         self.version = VERSION
-        self._device_classes = standard_device_classes()
+        self._device_classes = XKNX.standard_device_classes()
         if custom_device_classes is not None:
             for device_class, cls in custom_device_classes.items():
                 self.register_device_class(device_class, cls)
@@ -83,6 +83,7 @@ class XKNX:
         """Return a read only dictionary with all registered device classes."""
         return ReadOnlyDict(self._device_classes)
 
+    @staticmethod
     def standard_device_classes():
         """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
            Group names within the xknx config file start with one of the availabel device class names"""

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -1,4 +1,5 @@
 """XKNX is an Asynchronous Python module for reading and writing KNX/IP packets."""
+
 import asyncio
 import logging
 import signal

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -2,15 +2,15 @@
 import asyncio
 import logging
 import signal
-
 from inspect import isclass
 from sys import platform
+
 from xknx.core.readonlydict import ReadOnlyDict
 from xknx.core import Config, TelegramQueue
 from xknx.devices import Devices
 from xknx.io import ConnectionConfig, KNXIPInterface
 from xknx.telegram import GroupAddressType, PhysicalAddress
-from xknx.exception import XKNXException
+from xknx.exceptions import XKNXException
 from xknx.devices import (
     Device, BinarySensor, Climate, Cover, DateTime, ExposeSensor, Fan, Light,
     Notification, Scene, Sensor, Switch)
@@ -53,7 +53,7 @@ class XKNX:
         self.telegram_logger = logging.getLogger('xknx.telegram')
         self.connection_config = None
         self.version = VERSION
-        self._device_classes = self.standard_device_classes()
+        self._device_classes = standard_device_classes()
         if custom_device_classes is not None:
             for device_class, cls in custom_device_classes.items():
                 self.register_device_class(device_class, cls)
@@ -68,7 +68,7 @@ class XKNX:
             self.devices.register_device_updated_cb(device_updated_cb)
 
     def register_device_class(self, name, cls):
-        """registers a new device class within xknx"""
+        """Register a new device class within xknx."""
         if name in self._device_classes:
             raise XKNXException("`device class` %s was already registered." % name)
         elif not isclass(cls):
@@ -79,12 +79,12 @@ class XKNX:
             self._device_classes[name] = cls
 
     def registered_device_classes(self):
-        """return a read only dictionary with all registered device classes"""
+        """Return a read only dictionary with all registered device classes."""
         return ReadOnlyDict(self._device_classes)
 
     def standard_device_classes():
-        """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value"""
-        """Group names within the xknx config file start with one of the availabel device class names"""
+        """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
+           Group names within the xknx config file start with one of the availabel device class names"""
         return {
             "binary_sensor": BinarySensor,
             "climate": Climate,

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -54,9 +54,9 @@ class XKNX:
         self.connection_config = None
         self.version = VERSION
         self._device_classes = self.standard_device_classes()
-		if custom_device_classes is not None:
-			for device_class, cls in custom_device_classes.items():
-				self.register_device_class(device_class, cls)
+        if custom_device_classes is not None:
+            for device_class, cls in custom_device_classes.items():
+                self.register_device_class(device_class, cls)
 
         if config is not None:
             Config(self).read(config)
@@ -66,7 +66,7 @@ class XKNX:
 
         if device_updated_cb is not None:
             self.devices.register_device_updated_cb(device_updated_cb)
-            
+
     def register_device_class(self, name, cls):
         """registers a new device class within xknx"""
         if name in self._device_classes:
@@ -79,7 +79,7 @@ class XKNX:
             self._device_classes[name] = cls
 
     def registered_device_classes(self):
-		"""return a read only dictionary with all registered device classes"""
+        """return a read only dictionary with all registered device classes"""
         return ReadOnlyDict(self._device_classes)
 
     def standard_device_classes():
@@ -87,16 +87,16 @@ class XKNX:
         """Group names within the xknx config file start with one of the availabel device class names"""
         return {
             "binary_sensor": BinarySensor,
-            "climate":Climate,
-            "cover":Cover,
-            "datetime":DateTime,
-            "expose_sensor":ExposeSensor,
-            "fan":Fan,
-            "light":Light,
-            "notification":Notification,
-            "scene":Scene,
-            "sensor":Sensor,
-            "switch":Switch
+            "climate": Climate,
+            "cover": Cover,
+            "datetime": DateTime,
+            "expose_sensor": ExposeSensor,
+            "fan": Fan,
+            "light": Light,
+            "notification": Notification,
+            "scene": Scene,
+            "sensor": Sensor,
+            "switch": Switch
         }
 
     def __del__(self):

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -72,12 +72,11 @@ class XKNX:
         """Register a new device class within xknx."""
         if name in self._device_classes:
             raise XKNXException("`device class` %s was already registered." % name)
-        elif not isclass(cls):
+        if not isclass(cls):
             raise XKNXException("%s instance cannot be registered as a device class" % cls.__class__.__name__)
-        elif not issubclass(cls, Device):
+        if not issubclass(cls, Device):
             raise XKNXException("%s cannot be registered as a device class" % cls.__name__)
-        else:
-            self._device_classes[name] = cls
+        self._device_classes[name] = cls
 
     def registered_device_classes(self):
         """Return a read only dictionary with all registered device classes."""
@@ -86,7 +85,9 @@ class XKNX:
     @staticmethod
     def standard_device_classes():
         """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
-           Group names within the xknx config file start with one of the availabel device class names"""
+
+           Group names within the xknx config file start with one of the available device class names
+        """
         return {
             "binary_sensor": BinarySensor,
             "climate": Climate,

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -21,8 +21,8 @@ from .__version__ import __version__ as VERSION
 def standard_device_classes():
     """Return the dictionary of standard device classes.
 
-       Group names within the xknx config file start with one of the available
-       device class names.
+    Group names within the xknx config file start with one of the available
+    device class names.
     """
     return {
         "binary_sensor": BinarySensor,

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -9,9 +9,8 @@ from sys import platform
 from xknx.core import Config, TelegramQueue
 from xknx.core.readonlydict import ReadOnlyDict
 from xknx.devices import (
-    BinarySensor, Climate, Cover, DateTime, Device, ExposeSensor, Fan, Light,
-    Notification, Scene, Sensor, Switch)
-from xknx.devices import Devices
+    BinarySensor, Climate, Cover, DateTime, Device, Devices, ExposeSensor, Fan,
+    Light, Notification, Scene, Sensor, Switch)
 from xknx.exceptions import XKNXException
 from xknx.io import ConnectionConfig, KNXIPInterface
 from xknx.telegram import GroupAddressType, PhysicalAddress

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -2,19 +2,19 @@
 import asyncio
 import logging
 import signal
-import copy
-from xknx.core.readonlydict import ReadOnlyDict
+
 from inspect import isclass
 from sys import platform
-
+from xknx.core.readonlydict import ReadOnlyDict
 from xknx.core import Config, TelegramQueue
 from xknx.devices import Devices
 from xknx.io import ConnectionConfig, KNXIPInterface
 from xknx.telegram import GroupAddressType, PhysicalAddress
+from xknx.exception import XKNXException
 from xknx.devices import (
     Device, BinarySensor, Climate, Cover, DateTime, ExposeSensor, Fan, Light,
     Notification, Scene, Sensor, Switch)
-    
+
 from .__version__ import __version__ as VERSION
 
 
@@ -29,7 +29,7 @@ class XKNX:
     def __init__(self,
                  config=None,
                  loop=None,
-                 custom_device_classes={},
+                 custom_device_classes=None,
                  own_address=PhysicalAddress(DEFAULT_ADDRESS),
                  address_format=GroupAddressType.LONG,
                  telegram_received_cb=None,
@@ -54,8 +54,9 @@ class XKNX:
         self.connection_config = None
         self.version = VERSION
         self._device_classes = self.standard_device_classes()
-        for device_class, cls in custom_device_classes.items():
-            self.register_device_class(device_class, cls)
+		if custom_device_classes is not None:
+			for device_class, cls in custom_device_classes.items():
+				self.register_device_class(device_class, cls)
 
         if config is not None:
             Config(self).read(config)
@@ -67,7 +68,7 @@ class XKNX:
             self.devices.register_device_updated_cb(device_updated_cb)
             
     def register_device_class(self, name, cls):
-        """ registers a new device class within xknx """
+        """registers a new device class within xknx"""
         if name in self._device_classes:
             raise XKNXException("`device class` %s was already registered." % name)
         elif not isclass(cls):
@@ -78,23 +79,24 @@ class XKNX:
             self._device_classes[name] = cls
 
     def registered_device_classes(self):
+		"""return a read only dictionary with all registered device classes"""
         return ReadOnlyDict(self._device_classes)
-		
-    def standard_device_classes(self):
-        """ Return the dictionary of standard device classes with group/class name as key and corresponding device class as value """
-        """ Group names within the xknx config file start with one of the availabel device class names """
+
+    def standard_device_classes():
+        """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value"""
+        """Group names within the xknx config file start with one of the availabel device class names"""
         return {
-            "binary_sensor" : BinarySensor,
-            "climate"       : Climate,
-            "cover"         : Cover,
-            "datetime"      : DateTime,
-            "expose_sensor" : ExposeSensor,
-            "fan"           : Fan,
-            "light"         : Light,
-            "notification"  : Notification,
-            "scene"         : Scene,
-            "sensor"        : Sensor,
-            "switch"        : Switch
+            "binary_sensor": BinarySensor,
+            "climate":Climate,
+            "cover":Cover,
+            "datetime":DateTime,
+            "expose_sensor":ExposeSensor,
+            "fan":Fan,
+            "light":Light,
+            "notification":Notification,
+            "scene":Scene,
+            "sensor":Sensor,
+            "switch":Switch
         }
 
     def __del__(self):

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -18,6 +18,24 @@ from xknx.telegram import GroupAddressType, PhysicalAddress
 
 from .__version__ import __version__ as VERSION
 
+def standard_device_classes():
+    """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
+       Group names within the xknx config file start with one of the available device class names
+    """
+    return {
+        "binary_sensor": BinarySensor,
+        "climate": Climate,
+        "cover": Cover,
+        "datetime": DateTime,
+        "expose_sensor": ExposeSensor,
+        "fan": Fan,
+        "light": Light,
+        "notification": Notification,
+        "scene": Scene,
+        "sensor": Sensor,
+        "switch": Switch
+        }
+
 
 class XKNX:
     """Class for reading and writing KNX/IP packets."""
@@ -54,7 +72,7 @@ class XKNX:
         self.telegram_logger = logging.getLogger('xknx.telegram')
         self.connection_config = None
         self.version = VERSION
-        self._device_classes = XKNX.standard_device_classes()
+        self._device_classes = standard_device_classes()
         if custom_device_classes is not None:
             for device_class, cls in custom_device_classes.items():
                 self.register_device_class(device_class, cls)
@@ -81,26 +99,6 @@ class XKNX:
     def registered_device_classes(self):
         """Return a read only dictionary with all registered device classes."""
         return ReadOnlyDict(self._device_classes)
-
-    @staticmethod
-    def standard_device_classes():
-        """Return the dictionary of standard device classes with group/class name as key and corresponding device class as value.
-
-           Group names within the xknx config file start with one of the available device class names
-        """
-        return {
-            "binary_sensor": BinarySensor,
-            "climate": Climate,
-            "cover": Cover,
-            "datetime": DateTime,
-            "expose_sensor": ExposeSensor,
-            "fan": Fan,
-            "light": Light,
-            "notification": Notification,
-            "scene": Scene,
-            "sensor": Sensor,
-            "switch": Switch
-            }
 
     def __del__(self):
         """Destructor. Cleaning up if this was not done before."""


### PR DESCRIPTION
Enable registration of customized Device classes.

Customized device classes can also be configured within the same yaml configuration.
Usage example:
xknx = XKNX(
loop=self.loop,
custom_device_classes={"custom_device": CustomDevice},
config="xknx.yaml")
)

config.py does not contain device dependencies any more.