### PR TITLE
Multicast on macOS, routing bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ venv
 .vscode/
 .sass-cache/
 .pytest_cache/
+.mypy_cache/

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,15 @@ Changelog
 Upcoming version (unreleased)
 -----------------------------
 
+### New Features
+
+* Added config option ignore_internal_state in binary sensors (@andreasnanko #267)
+
+### Internals
+
+* Automatically publish packages to pypi (@Julius2342 #277)
+* keep xknx version in `xknx/__version__.py` (@farmio #278)
+
 
 0.11.3 Sensor types galore!  2020-04-28
 ---------------------------------------

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,14 @@ Upcoming version (unreleased)
 
 * Added config option ignore_internal_state in binary sensors (@andreasnanko #267)
 
+### Breaking changes
+
+* Removed `bind_to_multicast` option in ConnectionConfig and UDPClient
+
+### Bugfixes
+
+* enable multicast on macOS and fix a bug where unknown cemi frames raise a TypeError on routing connections
+
 ### Internals
 
 * Automatically publish packages to pypi (@Julius2342 #277)

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -4,7 +4,8 @@ import unittest
 
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTTime
-from xknx.knxip import CEMIFrame, KNXIPFrame, KNXIPServiceType
+from xknx.knxip import (
+    CEMIFrame, KNXIPFrame, KNXIPServiceType, RoutingIndication)
 from xknx.telegram import GroupAddress, PhysicalAddress, Telegram, TelegramType
 
 
@@ -31,13 +32,14 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
 
-        self.assertTrue(isinstance(knxipframe.body, CEMIFrame))
+        self.assertTrue(isinstance(knxipframe.body, RoutingIndication))
+        self.assertTrue(isinstance(knxipframe.body.cemi, CEMIFrame))
 
-        self.assertEqual(knxipframe.body.src_addr, PhysicalAddress("1.2.2"))
-        self.assertEqual(knxipframe.body.dst_addr, GroupAddress(337))
+        self.assertEqual(knxipframe.body.cemi.src_addr, PhysicalAddress("1.2.2"))
+        self.assertEqual(knxipframe.body.cemi.dst_addr, GroupAddress(337))
 
-        self.assertEqual(len(knxipframe.body.payload.value), 1)
-        self.assertEqual(knxipframe.body.payload.value[0], 0xf0)
+        self.assertEqual(len(knxipframe.body.cemi.payload.value), 1)
+        self.assertEqual(knxipframe.body.cemi.payload.value[0], 0xf0)
 
     def test_from_knx_to_knx(self):
         """Test parsing and streaming CEMIFrame KNX/IP."""
@@ -59,7 +61,7 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe.body.src_addr = PhysicalAddress("1.2.2")
+        knxipframe.body.cemi.src_addr = PhysicalAddress("1.2.2")
 
         telegram = Telegram()
         telegram.group_address = GroupAddress(337)
@@ -67,9 +69,9 @@ class Test_KNXIP(unittest.TestCase):
         telegram.payload = DPTArray(DPTTime().to_knx(
             {'hours': 13, 'minutes': 23, 'seconds': 42}))
 
-        knxipframe.body.telegram = telegram
+        knxipframe.body.cemi.telegram = telegram
 
-        knxipframe.body.set_hops(5)
+        knxipframe.body.cemi.set_hops(5)
         knxipframe.normalize()
 
         raw = ((0x06, 0x10, 0x05, 0x30, 0x00, 0x14, 0x29, 0x00,
@@ -89,7 +91,7 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
 
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
 
         self.assertEqual(telegram.group_address, GroupAddress(337))
 
@@ -113,15 +115,15 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("329"), payload=DPTBinary(1)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("15.15.249")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -137,15 +139,15 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("329"), payload=DPTBinary(0)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("15.15.249")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -161,15 +163,15 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("331"), payload=DPTArray(0x65)))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("15.15.249")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -185,7 +187,7 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("2049"),
                                   payload=DPTArray(
@@ -193,9 +195,9 @@ class Test_KNXIP(unittest.TestCase):
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("1.4.2")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("1.4.2")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -211,15 +213,15 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("440"), TelegramType.GROUP_READ))
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("15.15.249")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("15.15.249")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -235,7 +237,7 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
-        telegram = knxipframe.body.telegram
+        telegram = knxipframe.body.cemi.telegram
         self.assertEqual(telegram,
                          Telegram(GroupAddress("392"),
                                   TelegramType.GROUP_RESPONSE,
@@ -243,9 +245,9 @@ class Test_KNXIP(unittest.TestCase):
 
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe2.body.src_addr = PhysicalAddress("1.3.1")
-        knxipframe2.body.telegram = telegram
-        knxipframe2.body.set_hops(5)
+        knxipframe2.body.cemi.src_addr = PhysicalAddress("1.3.1")
+        knxipframe2.body.cemi.telegram = telegram
+        knxipframe2.body.cemi.set_hops(5)
         knxipframe2.normalize()
 
         self.assertEqual(knxipframe2.header.to_knx(), list(raw[0:6]))
@@ -260,9 +262,9 @@ class Test_KNXIP(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         knxipframe = KNXIPFrame(xknx)
         knxipframe.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe.body.src_addr = PhysicalAddress("1.3.1")
-        knxipframe.body.telegram = telegram
-        knxipframe.body.set_hops(5)
+        knxipframe.body.cemi.src_addr = PhysicalAddress("1.3.1")
+        knxipframe.body.cemi.telegram = telegram
+        knxipframe.body.cemi.set_hops(5)
         knxipframe.normalize()
 
         raw = ((0x06, 0x10, 0x05, 0x30, 0x00, 0x11, 0x29, 0x00,
@@ -273,4 +275,4 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe2 = KNXIPFrame(xknx)
         knxipframe2.init(KNXIPServiceType.ROUTING_INDICATION)
         knxipframe2.from_knx(knxipframe.to_knx())
-        self.assertEqual(knxipframe2.body.telegram, telegram)
+        self.assertEqual(knxipframe2.body.cemi.telegram, telegram)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -551,8 +551,8 @@ class TestStringRepresentations(unittest.TestCase):
         tunnelling_request.sequence_counter = 42
         self.assertEqual(
             str(tunnelling_request),
-            '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="<CEMIFrame SourceAddress="GroupAddress("0/0/0")" Destina'
-            'tionAddress="GroupAddress("0/0/0")" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />')
+            '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="<CEMIFrame SourceAddress="PhysicalAddress("0.0.0")"'
+            ' DestinationAddress="GroupAddress("0/0/0")" Flags="               0" Command="APCICommand.GROUP_READ" payload="None" />" />')
 
     def test_tunnelling_ack(self):
         """Test string representation of KNX/IP TunnellingAck."""

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -154,12 +154,11 @@ class GatewayScanner():
             self.xknx.logger.warning("Cant understand knxipframe")
             return
 
-        (found_local_ip, _) = udp_client.getsockname()
         gateway = GatewayDescriptor(name=knx_ip_frame.body.device_name,
                                     ip_addr=knx_ip_frame.body.control_endpoint.ip_addr,
                                     port=knx_ip_frame.body.control_endpoint.port,
                                     local_interface=udp_client.local_addr[2],
-                                    local_ip=found_local_ip)
+                                    local_ip=udp_client.local_addr[0])
         try:
             dib = knx_ip_frame.body[DIBSuppSVCFamilies]
             gateway.supports_routing = dib.supports(DIBServiceFamily.ROUTING)

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -8,7 +8,6 @@ KNXIPInterface manages KNX/IP Tunneling or Routing connections.
 """
 import ipaddress
 from enum import Enum
-from platform import system as get_os_name
 
 import netifaces
 
@@ -43,7 +42,6 @@ class ConnectionConfig:
     * auto_reconnect: Auto reconnect to KNX/IP tunneling device if connection cannot be established.
     * auto_reconnect_wait: Wait n seconds before trying to reconnect to KNX/IP tunneling device.
     * scan_filter: For AUTOMATIC connection, limit scan with the given filter
-    * bind_to_multicast_addr: Bind to the multicast address instead of the local IP (ROUTING only)
     """
 
     # pylint: disable=too-few-public-methods,too-many-instance-attributes
@@ -55,8 +53,7 @@ class ConnectionConfig:
                  gateway_port: int = DEFAULT_MCAST_PORT,
                  auto_reconnect: bool = False,
                  auto_reconnect_wait: int = 3,
-                 scan_filter: GatewayScanFilter = GatewayScanFilter(),
-                 bind_to_multicast_addr: bool = True):
+                 scan_filter: GatewayScanFilter = GatewayScanFilter()):
         """Initialize ConnectionConfig class."""
         # pylint: disable=too-many-arguments
         self.connection_type = connection_type
@@ -65,7 +62,6 @@ class ConnectionConfig:
         self.gateway_port = gateway_port
         self.auto_reconnect = auto_reconnect
         self.auto_reconnect_wait = auto_reconnect_wait
-        self.bind_to_multicast_addr = bind_to_multicast_addr
         if connection_type == ConnectionType.TUNNELING:
             scan_filter.tunnelling = True
         elif connection_type == ConnectionType.ROUTING:
@@ -90,9 +86,7 @@ class KNXIPInterface():
         """Start interface. Connecting KNX/IP device with the selected method."""
         if self.connection_config.connection_type == ConnectionType.ROUTING and \
                 self.connection_config.local_ip is not None:
-            await self.start_routing(
-                self.connection_config.local_ip,
-                self.connection_config.bind_to_multicast_addr)
+            await self.start_routing(self.connection_config.local_ip)
         elif self.connection_config.connection_type == ConnectionType.TUNNELING:
             await self.start_tunnelling(
                 self.connection_config.local_ip,
@@ -120,8 +114,7 @@ class KNXIPInterface():
                                         self.connection_config.auto_reconnect,
                                         self.connection_config.auto_reconnect_wait)
         elif gateway.supports_routing:
-            bind_to_multicast_addr = get_os_name() != "Darwin"  # = Mac OS
-            await self.start_routing(gateway.local_ip, bind_to_multicast_addr)
+            await self.start_routing(gateway.local_ip)
 
     async def start_tunnelling(self, local_ip, gateway_ip, gateway_port,
                                auto_reconnect, auto_reconnect_wait):
@@ -143,15 +136,14 @@ class KNXIPInterface():
             auto_reconnect_wait=auto_reconnect_wait)
         await self.interface.start()
 
-    async def start_routing(self, local_ip, bind_to_multicast_addr):
+    async def start_routing(self, local_ip):
         """Start KNX/IP Routing."""
         validate_ip(local_ip, address_name="Local IP address")
         self.xknx.logger.debug("Starting Routing from %s", local_ip)
         self.interface = Routing(
             self.xknx,
             self.telegram_received,
-            local_ip,
-            bind_to_multicast_addr)
+            local_ip)
         await self.interface.start()
 
     async def stop(self):

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -13,7 +13,7 @@ from .udp_client import UDPClient
 class Routing():
     """Class for handling KNX/IP routing."""
 
-    def __init__(self, xknx, telegram_received_callback, local_ip, bind_to_multicast_addr):
+    def __init__(self, xknx, telegram_received_callback, local_ip):
         """Initialize Routing class."""
         self.xknx = xknx
         self.telegram_received_callback = telegram_received_callback
@@ -22,8 +22,7 @@ class Routing():
         self.udpclient = UDPClient(self.xknx,
                                    (local_ip, 0),
                                    (DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT),
-                                   multicast=True,
-                                   bind_to_multicast_addr=bind_to_multicast_addr)
+                                   multicast=True)
 
         self.udpclient.register_callback(
             self.response_rec_callback,

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -63,10 +63,11 @@ class Tunnel():
             self.xknx.logger.warning("Service not implemented: %s", knxipframe)
         else:
             self.send_ack(knxipframe.body.communication_channel_id, knxipframe.body.sequence_counter)
-            telegram = knxipframe.body.cemi.telegram
-            telegram.direction = TelegramDirection.INCOMING
-            if self.telegram_received_callback is not None:
-                self.telegram_received_callback(telegram)
+            if knxipframe.body.cemi is not None:
+                telegram = knxipframe.body.cemi.telegram
+                telegram.direction = TelegramDirection.INCOMING
+                if self.telegram_received_callback is not None:
+                    self.telegram_received_callback(telegram)
 
     def send_ack(self, communication_channel_id, sequence_counter):
         """Send tunnelling ACK after tunnelling request received."""

--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -8,7 +8,8 @@ import asyncio
 import socket
 from sys import platform
 
-from xknx.exceptions import CouldNotParseKNXIP, XKNXException
+from xknx.exceptions import (
+    CouldNotParseKNXIP, UnsupportedCEMIMessage, XKNXException)
 from xknx.knxip import KNXIPFrame
 
 
@@ -89,6 +90,8 @@ class UDPClient:
                 self.handle_knxipframe(knxipframe)
             except CouldNotParseKNXIP as couldnotparseknxip:
                 self.xknx.logger.exception(couldnotparseknxip)
+            except UnsupportedCEMIMessage as unsupported_cemi_err:
+                self.xknx.logger.debug("Ignoring Frame with unsupported CEMI: %s", unsupported_cemi_err)
 
     def handle_knxipframe(self, knxipframe):
         """Handle KNXIP Frame and call all callbacks which watch for the service type ident."""

--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -121,36 +121,34 @@ class UDPClient:
         sock.setblocking(False)
 
         sock.setsockopt(
-            socket.SOL_IP,
+            socket.IPPROTO_IP,
             socket.IP_MULTICAST_IF,
             socket.inet_aton(own_ip))
         sock.setsockopt(
-            socket.SOL_IP,
+            socket.IPPROTO_IP,
             socket.IP_ADD_MEMBERSHIP,
             socket.inet_aton(remote_addr[0]) +
             socket.inet_aton(own_ip))
         sock.setsockopt(
             socket.IPPROTO_IP,
             socket.IP_MULTICAST_TTL, 2)
-        sock.setsockopt(
-            socket.IPPROTO_IP,
-            socket.IP_MULTICAST_IF,
-            socket.inet_aton(own_ip))
 
-        # I have no idea why we have to use different bind calls here
-        # - bind() with multicast addr does not work with gateway search requests
-        #   on some machines. It only works if called with own ip. It also doesn't
-        #   work on Mac OS.
-        # - bind() with own_ip does not work with ROUTING_INDICATIONS on Gira
-        #   knx router - for an unknown reason.
         if platform == "win32":
+            # '' represents INADDR_ANY
             sock.bind(('', remote_addr[1]))
         elif platform == "darwin":
-            sock.bind((own_ip, 0))
+            # allows multiple sockets to the same port by multiple processes
+            # behaves like SO_REUSEADDR for bind for INADDR_ANY
+            # (GatewayScanner opens multiple sockets)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+            sock.bind(('', remote_addr[1]))
         else:
             sock.bind((remote_addr[0], remote_addr[1]))
 
+        # ignore multicast datagrams sent by the host itself
+        # don't use when running multiple routing instances on a single host (interface)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, 0)
+
         return sock
 
     async def connect(self):

--- a/xknx/io/udp_client.py
+++ b/xknx/io/udp_client.py
@@ -8,8 +8,7 @@ import asyncio
 import socket
 from sys import platform
 
-from xknx.exceptions import (
-    CouldNotParseKNXIP, UnsupportedCEMIMessage, XKNXException)
+from xknx.exceptions import CouldNotParseKNXIP, XKNXException
 from xknx.knxip import KNXIPFrame
 
 
@@ -90,8 +89,6 @@ class UDPClient:
                 self.handle_knxipframe(knxipframe)
             except CouldNotParseKNXIP as couldnotparseknxip:
                 self.xknx.logger.exception(couldnotparseknxip)
-            except UnsupportedCEMIMessage as unsupported_cemi_err:
-                self.xknx.logger.debug("Ignoring Frame with unsupported CEMI: %s", unsupported_cemi_err)
 
     def handle_knxipframe(self, knxipframe):
         """Handle KNXIP Frame and call all callbacks which watch for the service type ident."""

--- a/xknx/knxip/__init__.py
+++ b/xknx/knxip/__init__.py
@@ -16,6 +16,7 @@ from .knxip import KNXIPFrame
 from .knxip_enum import (
     APCICommand, CEMIFlags, CEMIMessageCode, ConnectRequestType,
     DIBServiceFamily, DIBTypeCode, KNXIPServiceType, KNXMedium)
+from .routing_indication import RoutingIndication
 from .search_request import SearchRequest
 from .search_response import SearchResponse
 from .tunnelling_ack import TunnellingAck

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -107,19 +107,15 @@ class CEMIFrame(KNXIPBody):
     def from_knx(self, raw):
         """Parse/deserialize from KNX/IP raw data."""
         try:
-            try:
-                self.code = CEMIMessageCode(raw[0])
-            except ValueError:
-                raise UnsupportedCEMIMessage("CEMIMessageCode not implemented: {0} ".format(raw[0]))
+            self.code = CEMIMessageCode(raw[0])
+        except ValueError:
+            raise UnsupportedCEMIMessage("CEMIMessageCode not implemented: {0} ".format(raw[0]))
 
-            if self.code == CEMIMessageCode.L_DATA_IND or \
-                    self.code == CEMIMessageCode.L_Data_REQ or \
-                    self.code == CEMIMessageCode.L_DATA_CON:
-                return self.from_knx_data_link_layer(raw)
-            raise UnsupportedCEMIMessage("Could not handle CEMIMessageCode: {0} / {1}".format(self.code, raw[0]))
-        except UnsupportedCEMIMessage as unsupported_cemi_err:
-            self.xknx.logger.warning("Ignoring not implemented CEMI: %s", unsupported_cemi_err)
-            return len(raw)
+        if self.code in (CEMIMessageCode.L_DATA_IND,
+                         CEMIMessageCode.L_Data_REQ,
+                         CEMIMessageCode.L_DATA_CON):
+            return self.from_knx_data_link_layer(raw)
+        raise UnsupportedCEMIMessage("Could not handle CEMIMessageCode: {0} / {1}".format(self.code, raw[0]))
 
     def from_knx_data_link_layer(self, cemi):
         """Parse L_DATA_IND, CEMIMessageCode.L_Data_REQ, CEMIMessageCode.L_DATA_CON."""

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -107,15 +107,19 @@ class CEMIFrame(KNXIPBody):
     def from_knx(self, raw):
         """Parse/deserialize from KNX/IP raw data."""
         try:
-            self.code = CEMIMessageCode(raw[0])
-        except ValueError:
-            raise UnsupportedCEMIMessage("CEMIMessageCode not implemented: {0} ".format(raw[0]))
+            try:
+                self.code = CEMIMessageCode(raw[0])
+            except ValueError:
+                raise UnsupportedCEMIMessage("CEMIMessageCode not implemented: {0} ".format(raw[0]))
 
-        if self.code in (CEMIMessageCode.L_DATA_IND,
-                         CEMIMessageCode.L_Data_REQ,
-                         CEMIMessageCode.L_DATA_CON):
-            return self.from_knx_data_link_layer(raw)
-        raise UnsupportedCEMIMessage("Could not handle CEMIMessageCode: {0} / {1}".format(self.code, raw[0]))
+            if self.code == CEMIMessageCode.L_DATA_IND or \
+                    self.code == CEMIMessageCode.L_Data_REQ or \
+                    self.code == CEMIMessageCode.L_DATA_CON:
+                return self.from_knx_data_link_layer(raw)
+            raise UnsupportedCEMIMessage("Could not handle CEMIMessageCode: {0} / {1}".format(self.code, raw[0]))
+        except UnsupportedCEMIMessage as unsupported_cemi_err:
+            self.xknx.logger.warning("Ignoring not implemented CEMI: %s", unsupported_cemi_err)
+            return len(raw)
 
     def from_knx_data_link_layer(self, cemi):
         """Parse L_DATA_IND, CEMIMessageCode.L_Data_REQ, CEMIMessageCode.L_DATA_CON."""

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -31,7 +31,7 @@ class CEMIFrame(KNXIPBody):
         self.code = CEMIMessageCode.L_DATA_IND
         self.flags = 0
         self.cmd = APCICommand.GROUP_READ
-        self.src_addr = GroupAddress(None)
+        self.src_addr = PhysicalAddress(None)
         self.dst_addr = GroupAddress(None)
         self.mpdu_len = 0
         self.payload = None
@@ -112,13 +112,13 @@ class CEMIFrame(KNXIPBody):
             except ValueError:
                 raise UnsupportedCEMIMessage("CEMIMessageCode not implemented: {0} ".format(raw[0]))
 
-            if self.code == CEMIMessageCode.L_DATA_IND or \
-                    self.code == CEMIMessageCode.L_Data_REQ or \
-                    self.code == CEMIMessageCode.L_DATA_CON:
+            if self.code in (CEMIMessageCode.L_DATA_IND,
+                             CEMIMessageCode.L_Data_REQ,
+                             CEMIMessageCode.L_DATA_CON):
                 return self.from_knx_data_link_layer(raw)
             raise UnsupportedCEMIMessage("Could not handle CEMIMessageCode: {0} / {1}".format(self.code, raw[0]))
         except UnsupportedCEMIMessage as unsupported_cemi_err:
-            self.xknx.logger.warning("Ignoring not implemented CEMI: %s", unsupported_cemi_err)
+            self.xknx.logger.warning("CEMI not supported: %s", unsupported_cemi_err)
             return len(raw)
 
     def from_knx_data_link_layer(self, cemi):

--- a/xknx/knxip/knxip.py
+++ b/xknx/knxip/knxip.py
@@ -6,7 +6,6 @@ Depending on the service_type_ident different types of body classes are instanci
 """
 from xknx.exceptions import CouldNotParseKNXIP
 
-from .cemi_frame import CEMIFrame
 from .connect_request import ConnectRequest
 from .connect_response import ConnectResponse
 from .connectionstate_request import ConnectionStateRequest
@@ -15,6 +14,7 @@ from .disconnect_request import DisconnectRequest
 from .disconnect_response import DisconnectResponse
 from .header import KNXIPHeader
 from .knxip_enum import KNXIPServiceType
+from .routing_indication import RoutingIndication
 from .search_request import SearchRequest
 from .search_response import SearchResponse
 from .tunnelling_ack import TunnellingAck
@@ -36,7 +36,7 @@ class KNXIPFrame:
 
         if service_type_ident == \
                 KNXIPServiceType.ROUTING_INDICATION:
-            self.body = CEMIFrame(self.xknx)
+            self.body = RoutingIndication(self.xknx)
         elif service_type_ident == \
                 KNXIPServiceType.CONNECT_REQUEST:
             self.body = ConnectRequest(self.xknx)

--- a/xknx/knxip/routing_indication.py
+++ b/xknx/knxip/routing_indication.py
@@ -1,0 +1,45 @@
+"""
+Module for Serialization and Deserialization of KNX Routing Indications.
+
+Routing indications are used to transport CEMI Messages.
+"""
+from xknx.exceptions import UnsupportedCEMIMessage
+
+from .body import KNXIPBody
+from .cemi_frame import CEMIFrame
+from .knxip_enum import KNXIPServiceType
+
+
+class RoutingIndication(KNXIPBody):
+    """Representation of a KNX Routing Indication."""
+
+    # pylint: disable=too-many-instance-attributes
+
+    service_type = KNXIPServiceType.ROUTING_INDICATION
+
+    def __init__(self, xknx):
+        """Initialize SearchRequest object."""
+        super().__init__(xknx)
+        self.cemi = CEMIFrame(xknx)
+
+    def calculated_length(self):
+        """Get length of KNX/IP body."""
+        return self.cemi.calculated_length()
+
+    def from_knx(self, raw):
+        """Parse/deserialize from KNX/IP raw data."""
+        try:
+            return self.cemi.from_knx(raw)
+        except UnsupportedCEMIMessage as unsupported_cemi_err:
+            self.xknx.logger.warning("CEMI not supported: %s", unsupported_cemi_err)
+            self.cemi = None
+            return len(raw)
+
+    def to_knx(self):
+        """Serialize to KNX/IP raw data."""
+        return self.cemi.to_knx()
+
+    def __str__(self):
+        """Return object as readable string."""
+        return '<RoutingIndication cemi="{0}" />' \
+            .format(self.cemi)


### PR DESCRIPTION
- This should enable multicast on macOS and fix a bug where unknown cemi frames raise a TypeError on routing connections.
- Removed `bind_to_multicast` option as it seemed to only be useful on macOS. (see conversation in #256 )
- adds RoutingIndication class
- RoutingIndication and TunnellingRequest class catch UnsupportedCEMIError and set their self.cemi to None. When unpacking the telegram in Tunnel() or Routing() this ich checked for None to handle it correctly (Routing: drop / Tunneling: send ACK, drop)

fixes #293 
