### PR TITLE
BinarySensor: Remote value binary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,237 +1,194 @@
-Changelog
-=========
+# Changelog
 
-Upcoming version (unreleased)
------------------------------
-
-### New Features
-
-* Added config option ignore_internal_state in binary sensors (@andreasnanko #267)
-
-### Internals
-
-* Automatically publish packages to pypi (@Julius2342 #277)
-* keep xknx version in `xknx/__version__.py` (@farmio #278)
-* add raw_socket logger (@farmio #299)
-
-
-0.11.3 Sensor types galore!  2020-04-28
----------------------------------------
-
-### New Features
-
-* added a lot of DPTs now useable as sensor type (@eXtenZy #255) 
-
-### Bugfixes
-
-* DPT_Step correction (used in Cover) (@recMartin #260) 
-* prevent reconnects on unknown CEMI Messages (@farmio #271)
-* fix the parsing of operation mode strings to HVACOperationMode (@FredericMa #266) 
-* corrected binding to multicast address in Windows (Routing) (@FredericMa #256) 
-* finish tasks when stopping xknx (@farmio #264, #274) 
-
-### Internals
-
-* some code cleanup (dpt, telegram and remote_value module) (@farmio #232)
-* refactor Notification device (@farmio #245)
-
-
-0.11.2 Add invert for climate on_off; fixed RGBW lights and stability improvements  2019-09-29
-----------------------------------------------------------------------------------------------
-
-### New Features
-
-*  Sensor: add DPT 9.006 as pressure_2byte #223 (@michelde)
-*  Climate: add new attribute on_off_invert #225 (@tombbo)
-
-### Bugfixes
-
-* Light: Fix for wrong structure of RGBW DPT 251.600 #231 (@dstrigl)
-* Core: Correct handling of E_NO_MORE_CONNECTIONS within ConnectResponses #217 (@Julius2342)
-* Core: Fix exceptions #234 (@elupus)
-* Core: Avoid leaking ValueError exception on unknown APCI command #235 (@elupus)
-* add tests for Climate on_off_invert (#233) @farmio
-* merge HA plugin from upstream 0.97.2 (#224) @farmio 
-* Small adjustments to the sensor documentation and example (#219) @biggestj 
-* merge HA plugin from upstream @farmio
-
-
-0.11.1 Bugfix release 2019-07-08
---------------------------------
-
-* Optionally disable reading (GroupValueRead) for sensor and binary_sensor #216 @farmio
-
-
-0.11.0 Added new sensor types and fixed a couple of bugs 2019-06-12
--------------------------------------------------------------------
-
-### Features
-
-* Auto detection of local ip: #184 (@farmio )
-* Added new sensor types and fix existing: #189 (@farmio )
-        - binary mapped to RemoteValueSwitch
-        - angle DPT 5.003
-        - percentU8DPT 5.004 (1 byte unscaled)
-        - percentV8 DPT 6.001 (1 byte signed unscaled)
-        - counter_pulses DPT 6.010
-        - DPT 8.*** types (percentV16, delta_time_*, rotation_angle, 2byte_signed and DPT-8)
-        - luminous_flux DPT 14.042
-        - pressure DPT 14.058
-        - string DPT 16.000
-        - scene_number DPT 17.001
-* Binary values are now exposable
-* Add support for RGBW lights - DPT 251.600: #191 #206 (@phbaer )
-* Bump PyYAML to latest version (5.1): #204 (@Julius2342 )
-* Add DPT-8 support for Sensors and HA Sensors: #208 (@farmio )
+## Upcoming version (unreleased)
 
 ### Breaking changes
 
-* Scene: scene_number is now 1 indexed according to KNX standards
-* Replaced group_address in BinarySensor with group_address_state (not for Home Assistant component)
+- Removed significant_bit attribute in BinarySensor
+
+### New Features
+
+- Added config option ignore_internal_state in binary sensors (@andreasnanko #267)
+
+### Internals
+
+- Use RemoteValue class in BinarySensor device
+- Automatically publish packages to pypi (@Julius2342 #277)
+- keep xknx version in `xknx/__version__.py` (@farmio #278)
+- add raw_socket logger (@farmio #299)
+
+## 0.11.3 Sensor types galore! 2020-04-28
+
+### New Features
+
+- added a lot of DPTs now useable as sensor type (@eXtenZy #255)
 
 ### Bugfixes
 
-* Fix pulse sensor type: #187 (@farmio )
-* Fix climate device using setpoint_shift: #190 (@farmio )
-* Read binary sensors on startup: #199 (@farmio )
-* Updated YAML to use safe mode: #196 (@farmio )
-* Update README.md #195 (thanks @amp-man)
-* Code refactoring: #200 (@farmio )
-* Fix #194, #193, #129, #116, #114
-* Fix #183 and #148 through #190 (@farmio )
+- DPT_Step correction (used in Cover) (@recMartin #260)
+- prevent reconnects on unknown CEMI Messages (@farmio #271)
+- fix the parsing of operation mode strings to HVACOperationMode (@FredericMa #266)
+- corrected binding to multicast address in Windows (Routing) (@FredericMa #256)
+- finish tasks when stopping xknx (@farmio #264, #274)
 
+### Internals
 
-0.10.0 Bugfix release 2019-02-22
---------------------------------
+- some code cleanup (dpt, telegram and remote_value module) (@farmio #232)
+- refactor Notification device (@farmio #245)
 
-* Connection config can now be configured in xknx.yml (#179 @farmio )
-* (breaking change) Introduced target_temperature_state for climate devices (#175 @marvin-w )
-* Introduce a configurable rate limit (#178 @marvin-w)
-* updated HA plugin (#174 @marvin-w)
-* Migrate documentation in main project (#168 @marvin-w)
-* documentation updates (@farmio & @marvin-w)
+## 0.11.2 Add invert for climate on_off; fixed RGBW lights and stability improvements 2019-09-29
 
+### New Features
 
-0.9.4 - Release 2019-01-01
---------------------------
+- Sensor: add DPT 9.006 as pressure_2byte #223 (@michelde)
+- Climate: add new attribute on_off_invert #225 (@tombbo)
 
-* updated hass plugin (@marvin-w #162)
-* tunable white and color temperature for lights (@farmio #154)
+### Bugfixes
 
+- Light: Fix for wrong structure of RGBW DPT 251.600 #231 (@dstrigl)
+- Core: Correct handling of E_NO_MORE_CONNECTIONS within ConnectResponses #217 (@Julius2342)
+- Core: Fix exceptions #234 (@elupus)
+- Core: Avoid leaking ValueError exception on unknown APCI command #235 (@elupus)
+- add tests for Climate on_off_invert (#233) @farmio
+- merge HA plugin from upstream 0.97.2 (#224) @farmio
+- Small adjustments to the sensor documentation and example (#219) @biggestj
+- merge HA plugin from upstream @farmio
 
-0.9.3 - Release 2018-12-23
---------------------------
+## 0.11.1 Bugfix release 2019-07-08
 
-* updated requirements (added flake8-isort)
-* some more unit tests
-* Breaking Change:
+- Optionally disable reading (GroupValueRead) for sensor and binary_sensor #216 @farmio
+
+## 0.11.0 Added new sensor types and fixed a couple of bugs 2019-06-12
+
+### Features
+
+- Auto detection of local ip: #184 (@farmio )
+- Added new sensor types and fix existing: #189 (@farmio ) - binary mapped to RemoteValueSwitch - angle DPT 5.003 - percentU8DPT 5.004 (1 byte unscaled) - percentV8 DPT 6.001 (1 byte signed unscaled) - counter*pulses DPT 6.010 - DPT 8.\*\*\* types (percentV16, delta_time*\*, rotation_angle, 2byte_signed and DPT-8) - luminous_flux DPT 14.042 - pressure DPT 14.058 - string DPT 16.000 - scene_number DPT 17.001
+- Binary values are now exposable
+- Add support for RGBW lights - DPT 251.600: #191 #206 (@phbaer )
+- Bump PyYAML to latest version (5.1): #204 (@Julius2342 )
+- Add DPT-8 support for Sensors and HA Sensors: #208 (@farmio )
+
+### Breaking changes
+
+- Scene: scene_number is now 1 indexed according to KNX standards
+- Replaced group_address in BinarySensor with group_address_state (not for Home Assistant component)
+
+### Bugfixes
+
+- Fix pulse sensor type: #187 (@farmio )
+- Fix climate device using setpoint_shift: #190 (@farmio )
+- Read binary sensors on startup: #199 (@farmio )
+- Updated YAML to use safe mode: #196 (@farmio )
+- Update README.md #195 (thanks @amp-man)
+- Code refactoring: #200 (@farmio )
+- Fix #194, #193, #129, #116, #114
+- Fix #183 and #148 through #190 (@farmio )
+
+## 0.10.0 Bugfix release 2019-02-22
+
+- Connection config can now be configured in xknx.yml (#179 @farmio )
+- (breaking change) Introduced target_temperature_state for climate devices (#175 @marvin-w )
+- Introduce a configurable rate limit (#178 @marvin-w)
+- updated HA plugin (#174 @marvin-w)
+- Migrate documentation in main project (#168 @marvin-w)
+- documentation updates (@farmio & @marvin-w)
+
+## 0.9.4 - Release 2019-01-01
+
+- updated hass plugin (@marvin-w #162)
+- tunable white and color temperature for lights (@farmio #154)
+
+## 0.9.3 - Release 2018-12-23
+
+- updated requirements (added flake8-isort)
+- some more unit tests
+- Breaking Change:
   ClimateMode is now a member of Climate (the hass plugin
   needs this kind of dependency. Please note the updated xknx.yml)
 
+## 0.9.2 - Release 2018-12-22
 
-0.9.2 - Release 2018-12-22
---------------------------
+- Min and max values for Climate device
+- Splitted up Climate in Climate and ClimateMode
+- added **contains** method for Devices class.
+- fixed KeyError when action refers to a non existing device.
 
-* Min and max values for Climate device
-* Splitted up Climate in Climate and ClimateMode
-* added __contains__ method for Devices class.
-* fixed KeyError when action refers to a non existing device.
+## 0.9.1 - Release 2018-10-28
 
-
-0.9.1 - Release 2018-10-28
---------------------------
-
-* state_addresses of binary_sesor should return emty value if no
+- state_addresses of binary_sesor should return emty value if no
   state address is set.
-* state_address for notification device
+- state_address for notification device
 
+## 0.9.0 - Release 2018-09-23
 
-0.9.0 - Release 2018-09-23
---------------------------
+- Updated requirements
+- Feature: Added new DPTs for DPTEnthalpy, DPTPartsPerMillion, DPTVoltage. Thanks @magenbrot #146
+- Breaking Change: Only read explicit state addresses #140
+- Minor: Fixed some comments, @magenbrot #145
+- Minor: lowered loglevel from INFO to DEBUG for 'correct answer from KNX bus' @magenbrot #144
+- Feature: Add fan device, @itineric #139
+- Bugfix: Tunnel: Use the bus address assigned by the server, @M-o-a-T #141
+- Bugfix: Adde:wd a check for windows because windows does not support add_signal @pulse-mind #135
+- Bugfix: correct testing if xknx exists within self @FireFrei #131
+- Feature: Implement support to automatically reconnect KNX/IP tunnel, @rnixx #125
+- Feature: Adjusted to Home Assistant's changes to light colors @oliverblaha #128
+- Feature: Scan multiple gateways @DrMurx #111
+- Bugfix: Pylint errors @rnixx #132
+- Typo: @itineric #124
+- Feature: Add support for KNX DPT 20.105 @cian #122
 
-* Updated requirements
-* Feature: Added new DPTs for DPTEnthalpy, DPTPartsPerMillion, DPTVoltage. Thanks @magenbrot #146
-* Breaking Change: Only read explicit state addresses #140
-* Minor: Fixed some comments,  @magenbrot #145
-* Minor: lowered loglevel from INFO to DEBUG for 'correct answer from KNX bus' @magenbrot #144
-* Feature: Add fan device,  @itineric #139
-* Bugfix: Tunnel: Use the bus address assigned by the server,  @M-o-a-T #141
-* Bugfix: Adde:wd a check for windows because windows does not support add_signal  @pulse-mind #135
-* Bugfix: correct testing if xknx exists within self  @FireFrei #131  
-* Feature: Implement support to automatically reconnect KNX/IP tunnel,  @rnixx #125
-* Feature: Adjusted to Home Assistant's changes to light colors @oliverblaha #128
-* Feature: Scan multiple gateways @DrMurx #111
-* Bugfix: Pylint errors @rnixx #132
-* Typo: @itineric #124
-* Feature: Add support for KNX DPT 20.105  @cian #122
+## 0.8.5 -Release 2018-03-10
 
+- Bugfix: fixed string representation of GroupAddress https://github.com/home-assistant/home-assistant/issues/13049
 
-0.8.5 -Release 2018-03-10
--------------------------
+## 0.8.4 -Release 2018-03-04
 
-* Bugfix: fixed string representation of GroupAddress https://github.com/home-assistant/home-assistant/issues/13049
+- Bugfix: invert scaling value #114
+- Minor: current_brightness and current_color are now properties
+- Feature: Added DPT 5.010 DPTValue1Ucount @andreasnanko #109
 
+## 0.8.3 - Release 2018-02-05
 
-0.8.4 -Release 2018-03-04
---------------------------
+- Color support for HASS plugin
+- Bugfixes (esp problem with unhashable exceptions)
+- Refactoring: splitted up remote_value.py
+- Better test coverage
 
-* Bugfix: invert scaling value #114
-* Minor: current_brightness and current_color are now properties
-* Feature: Added DPT 5.010 DPTValue1Ucount @andreasnanko #109
+## 0.8.1 - Release 2018-02-03
 
+- Basic support for colored lights
+- Better unit test coverage
 
-0.8.3 - Release 2018-02-05
---------------------------
+## 0.8.0 - Release 2018-01-27
 
-* Color support for HASS plugin
-* Bugfixes (esp problem with unhashable exceptions)
-* Refactoring: splitted up remote_value.py
-* Better test coverage  
-
-
-0.8.1 - Release 2018-02-03
---------------------------
-
-* Basic support for colored lights
-* Better unit test coverage
-
-
-0.8.0 - Release 2018-01-27
----------------------------
-
-* New example for MQTT forwarder (thanks @JohanElmis)
-* Splitted up Address into GroupAddress and PhysicalAddress (thanks @encbladexp) 
-* Time object was renamed to Datetime and does now support different broadcast types "time", "date" and "datetime" (thanks @Roemer)
-* Many new DTP datapoints esp for physical values (thanks @Straeng and @JohanElmis)
-* new asyncio `await` syntax
-* new device "ExposeSensor" to read a local value from KNX bus or to expose a local value to KNX bus.
-* Support for KNX-scenes
-* better test coverage
-* Fixed versions for dependencies (@encbladexp)
+- New example for MQTT forwarder (thanks @JohanElmis)
+- Splitted up Address into GroupAddress and PhysicalAddress (thanks @encbladexp)
+- Time object was renamed to Datetime and does now support different broadcast types "time", "date" and "datetime" (thanks @Roemer)
+- Many new DTP datapoints esp for physical values (thanks @Straeng and @JohanElmis)
+- new asyncio `await` syntax
+- new device "ExposeSensor" to read a local value from KNX bus or to expose a local value to KNX bus.
+- Support for KNX-scenes
+- better test coverage
+- Fixed versions for dependencies (@encbladexp)
 
 And many more smaller improvements :-)
 
+## 0.7.7-0.7.18 - Release 2017-11-05
 
-0.7.7-0.7.18 - Release 2017-11-05
----------------------------------
+- Many iterations and bugfixes to get climate support with setpoint shift working.
+- Support for invert-position and invert-angle within cover.
+- State updater may be switched of within home assistant plugin
 
-* Many iterations and bugfixes to get climate support with setpoint shift working.
-* Support for invert-position and invert-angle within cover.
-* State updater may be switched of within home assistant plugin
-
-
-0.7.6 - Release 2017-08-09
---------------------------
+## 0.7.6 - Release 2017-08-09
 
 Introduced KNX HVAC/Climate support with operation modes (Frost protection, night, comfort).
 
-
-0.7.0 - Released 2017-07-30
----------------------------
+## 0.7.0 - Released 2017-07-30
 
 ### More asyncio:
 
-More intense usage of asyncio. All device operations and callback functions are now async. 
+More intense usage of asyncio. All device operations and callback functions are now async.
 
 E.g. to switch on a light you have to do:
 
@@ -251,8 +208,8 @@ Renamed class `Thermostat` to `Climate` . Plase rename the section within config
 
 ```yaml
 groups:
-    climate:
-        Cellar.Thermostat: {group_address_temperature: '6/2/0'}
+  climate:
+    Cellar.Thermostat: { group_address_temperature: "6/2/0" }
 ```
 
 #### Cover
@@ -261,8 +218,16 @@ Renamed class `Shutter` to `Cover`. Plase rename the section within configuratio
 
 ```yaml
 groups:
-   cover:
-        Livingroom.Shutter_1: {group_address_long: '1/4/1', group_address_short: '1/4/2', group_address_position_feedback: '1/4/3', group_address_position: '1/4/4', travel_time_down: 50, travel_time_up: 60 }
+  cover:
+    Livingroom.Shutter_1:
+      {
+        group_address_long: "1/4/1",
+        group_address_short: "1/4/2",
+        group_address_position_feedback: "1/4/3",
+        group_address_position: "1/4/4",
+        travel_time_down: 50,
+        travel_time_up: 60,
+      }
 ```
 
 #### Binary Sensor
@@ -271,26 +236,28 @@ Renamed class `Switch` to `BinarySensor`. Plase rename the section within config
 
 ```yaml
 groups:
-    binary_sensor:
-        Kitchen.3Switch1:
-            group_address: '5/0/0'
+  binary_sensor:
+    Kitchen.3Switch1:
+      group_address: "5/0/0"
 ```
 
 Sensors with `value_type=binary` are now integrated into the `BinarySensor` class:
 
 ```yaml
 groups:
-    binary_sensor:
-        SleepingRoom.Motion.Sensor: {group_address: '6/0/0', device_class: 'motion'}
-        ExtraRoom.Motion.Sensor: {group_address: '6/0/1', device_class: 'motion'}
+  binary_sensor:
+    SleepingRoom.Motion.Sensor:
+      { group_address: "6/0/0", device_class: "motion" }
+    ExtraRoom.Motion.Sensor: { group_address: "6/0/1", device_class: "motion" }
 ```
 
 The attribute `significant_bit` is now only possible within `binary_sensors`:
 
 ```yaml
 groups:
-    binary_sensor_motion_dection:
-        Kitchen.Thermostat.Presence: {group_address: '3/0/2', device_class: 'motion', significant_bit: 2}
+  binary_sensor_motion_dection:
+    Kitchen.Thermostat.Presence:
+      { group_address: "3/0/2", device_class: "motion", significant_bit: 2 }
 ```
 
 #### Switch
@@ -299,23 +266,18 @@ Renamed `Outlet` to `Switch` (Sorry for the confusion...). The configuration now
 
 ```yaml
 groups:
-    switch:
-        Livingroom.Outlet_1: {group_address: '1/3/1'}
-        Livingroom.Outlet_2: {group_address: '1/3/2'}
+  switch:
+    Livingroom.Outlet_1: { group_address: "1/3/1" }
+    Livingroom.Outlet_2: { group_address: "1/3/2" }
 ```
-
 
 Within `Light` class i introduced an attribute `group_address_brightness_state`. The attribute `group_address_state` was renamed to `group_address_switch_state`. I also removed the attribute `group_address_dimm` (which did not have any implemented logic).
 
-
-Version 0.6.2 - Released 2017-07-24
------------------------------------
+## Version 0.6.2 - Released 2017-07-24
 
 XKNX Tunnel now does hartbeat - and reopens connections which are no longer valid.
 
-
-Version 0.6.0 - Released 2017-07-23
------------------------------------
+## Version 0.6.0 - Released 2017-07-23
 
 Using `asyncio` interface, XKNX has now to be stated and stopped asynchronously:
 
@@ -345,5 +307,4 @@ loop.close()
 ````python
 await sensor2.sync()
 ```
-
-
+````

--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -2,10 +2,9 @@
 layout: default
 ---
 
-Binary Sensor
-=============
+# Binary Sensor
 
-Binary sensors which have either the state "on" or "off". Binary sensors could be e.g. a switch in the wall (the thing you press on when switching on the light) or a motion detector. 
+Binary sensors which have either the state "on" or "off". Binary sensors could be e.g. a switch in the wall (the thing you press on when switching on the light) or a motion detector.
 
 Switches are mainly intended to act on input, which means to execute so called `Actions`. An action can be toggling a switch or a light or the moving of a cover.
 
@@ -17,13 +16,12 @@ The logic within switches can further handle if a button is pressed once or twic
 binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', device_class='motion')
 ```
 
-* `xknx` is the XKNX object.
-* `name` is the name of the object.
-* `group_address_state` is the KNX group address of the sensor device.
-* `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
-* `significant_bit` Defining which bit should be relevant for the binary state. Defaults to `1`
-* `reset_after` may be used to reset the internal state to `OFF` again after given time in ms. Defaults to `None`
-* `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
+- `xknx` is the XKNX object.
+- `name` is the name of the object.
+- `group_address_state` is the KNX group address of the sensor device.
+- `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
+- `reset_after` may be used to reset the internal state to `OFF` again after given time in ms. Defaults to `None`
+- `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
 ## [](#header-2)Example
 
@@ -45,7 +43,7 @@ action_off = Action(
     method='off')
 binarysensor.actions.append(action_off)
 xknx.devices.add(binarysensor)
-``` 
+```
 
 ## [](#header-2)Configuration via **xknx.yaml**
 
@@ -53,42 +51,45 @@ Binary sensor objects are usually configured via [`xknx.yaml`](/configuration):
 
 ```yaml
 groups:
+  binary_sensor:
+    Livingroom.Switch_1:
+      group_address_state: "1/2/7"
+      actions:
+        - { target: Livingroom.Outlet_1, method: "on" }
+        - { target: Livingroom.Outlet_2, method: "on" }
 
-    binary_sensor:
-        Livingroom.Switch_1:
-            group_address_state: "1/2/7"
-            actions:
-              - {target: Livingroom.Outlet_1, method: "on"}
-              - {target: Livingroom.Outlet_2, method: "on"}
+    Livingroom.Switch_2:
+      group_address_state: "1/2/8"
+      actions:
+        - { target: Livingroom.Outlet_1, method: "off" }
+        - { target: Livingroom.Outlet_2, method: "off" }
 
-        Livingroom.Switch_2:
-            group_address_state: "1/2/8"
-            actions:
-              - {target: Livingroom.Outlet_1, method: "off"}
-              - {target: Livingroom.Outlet_2, method: "off"}
+    Livingroom.Switch_3:
+      group_address_state: "1/2/5"
+      actions:
+        - { target: Livingroom.Shutter_1, method: up }
+        # Only executed if the button was switched twice:
+        - { counter: 2, target: Livingroom.Shutter_1, method: short_up }
 
-        Livingroom.Switch_3:
-            group_address_state: "1/2/5"
-            actions:
-              - {target: Livingroom.Shutter_1, method: up}
-              # Only executed if the button was switched twice:
-              - {counter: 2, target: Livingroom.Shutter_1, method: short_up}
+    Livingroom.Switch_4:
+      group_address_state: "1/2/6"
+      actions:
+        - { target: Livingroom.Shutter_1, method: down }
+        # Only executed if the button was switched twice:
+        - { counter: 2, target: Livingroom.Shutter_1, method: short_down }
 
-        Livingroom.Switch_4:
-            group_address_state: "1/2/6"
-            actions:
-              - {target: Livingroom.Shutter_1, method: down}
-              # Only executed if the button was switched twice:
-              - {counter: 2, target: Livingroom.Shutter_1, method: short_down}
+  switch:
+    Livingroom.Outlet_1: { group_address: "1/3/1" }
+    Livingroom.Outlet_2: { group_address: "1/3/2" }
 
-
-    switch:
-        Livingroom.Outlet_1: {group_address: '1/3/1'}
-        Livingroom.Outlet_2: {group_address: '1/3/2'}
-
-    cover:
-        Livingroom.Shutter_1: {group_address_long: 3171, group_address_short: 3172, group_address_position_state: 3173, group_address_position: 3174, travelling_time_down: 51, travelling_time_up: 61}
+  cover:
+    Livingroom.Shutter_1:
+      {
+        group_address_long: 3171,
+        group_address_short: 3172,
+        group_address_position_state: 3173,
+        group_address_position: 3174,
+        travelling_time_down: 51,
+        travelling_time_up: 61,
+      }
 ```
-
-
-

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,13 +2,11 @@
 layout: default
 ---
 
-Configuration
-=============
+# Configuration
 
-Overview
---------
+## Overview
 
-XKNX is controlled via a configuration file. Per default the configuration file is  named `xknx.yaml`. 
+XKNX is controlled via a configuration file. Per default the configuration file is named `xknx.yaml`.
 
 The configuration file can contain three sections.
 
@@ -23,10 +21,9 @@ The configuration file can contain three sections.
     - `local_ip` (optional) sets the ip address that is used by xknx
   - `routing` for a UDP multicast connection
     - `local_ip` (optional) sets the ip address that is used by xknx
-- Within the `groups` sections all devices are defined. For each type of device more then one section might be specified. You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique. 
+- Within the `groups` sections all devices are defined. For each type of device more then one section might be specified. You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
 
-How to use
-----------
+## How to use
 
 Use the `config` attribute when initializing `XKNX` to spefify a configuration file:
 
@@ -41,92 +38,120 @@ for device in xknx.devices:
 
 ```yaml
 general:
-    own_address: '15.15.249'
+  own_address: "15.15.249"
 
 connection:
-    routing:
+  routing:
 
 groups:
+  binary_sensor:
+    Livingroom.Switch_1:
+      group_address_state: "1/2/7"
+      actions:
+        - { target: Livingroom.Outlet_1, method: "on" }
+        - { target: Livingroom.Outlet_2, counter: 2, method: "on" }
 
-    binary_sensor:
+    Livingroom.Switch_2:
+      group_address_state: "1/2/8"
+      actions:
+        - { target: Livingroom.Outlet_1, method: "off" }
+        - { target: Livingroom.Outlet_2, counter: 2, method: "off" }
 
-        Livingroom.Switch_1:
-            group_address_state: '1/2/7'
-            actions:
-              - {target: Livingroom.Outlet_1, method: 'on'}
-              - {target: Livingroom.Outlet_2, counter: 2, method: 'on'}
+    Livingroom.Switch_3:
+      group_address_state: "1/2/2"
+      actions:
+        - { hook: "off", target: Livingroom.Shutter_1, method: short_up }
+        - { hook: "off", counter: 2, target: Livingroom.Shutter_1, method: up } # Pressing more then 2 seconds
 
-        Livingroom.Switch_2:
-            group_address_state: '1/2/8'
-            actions:
-              - {target: Livingroom.Outlet_1, method: 'off'}
-              - {target: Livingroom.Outlet_2, counter: 2, method: 'off'}
+    Livingroom.Switch_4:
+      group_address_state: "1/2/3"
+      actions:
+        - { hook: "off", target: Livingroom.Shutter_1, method: short_down }
+        - {
+            hook: "off",
+            counter: 2,
+            target: Livingroom.Shutter_1,
+            method: down,
+          } # Pressing more then 2 seconds
 
+  binary_sensor_motion_dection:
+    Kitchen.Motion.Sensor:
+      { group_address_state: "3/0/0", device_class: "motion" }
+    DiningRoom.Motion.Sensor:
+      { group_address_state: "3/0/1", device_class: "motion" }
+    Kitchen.Presence: { group_address_state: "3/0/2", device_class: "motion" }
+    Kitchen.ThermostatNightMode:
+      { group_address_state: "3/0/2", device_class: "motion" }
 
-        Livingroom.Switch_3:
-            group_address_state: '1/2/2'
-            actions:
-              - {hook: 'off', target: Livingroom.Shutter_1, method: short_up}
-              - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: up} # Pressing more then 2 seconds
+  switch:
+    Livingroom.Outlet_1: { group_address: "1/3/1" }
+    Livingroom.Outlet_2: { group_address: "1/3/2" }
 
-        Livingroom.Switch_4:
-            group_address_state: '1/2/3'
-            actions:
-              - {hook: 'off', target: Livingroom.Shutter_1, method: short_down}
-              - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: down} # Pressing more then 2 seconds
+  switch 2:
+    Kitchen.Outlet_1: { group_address: "1/3/7" }
+    Kitchen.Outlet_2: { group_address: "1/3/8" }
+    Kitchen.Outlet_3: { group_address: "1/3/9" }
+    Kitchen.Outlet_4: { group_address: "1/3/10" }
 
+  cover:
+    Livingroom.Shutter_1:
+      {
+        group_address_long: "1/4/1",
+        group_address_short: "1/4/2",
+        group_address_position_feedback: "1/4/3",
+        group_address_position: "1/4/4",
+        travel_time_down: 50,
+        travel_time_up: 60,
+      }
+    Livingroom.Shutter_2:
+      {
+        group_address_long: "1/4/5",
+        group_address_short: "1/4/6",
+        group_address_position_feedback: "1/4/7",
+        group_address_position: "1/4/8",
+        travel_time_down: 50,
+        travel_time_up: 60,
+      }
 
-    binary_sensor_motion_dection:
-        Kitchen.Motion.Sensor: {group_address_state: '3/0/0', device_class: 'motion'}
-        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', device_class: 'motion'}
+    # Covers without direct positioning:
+    Livingroom.Shutter_3:
+      {
+        group_address_long: "1/4/9",
+        group_address_short: "1/4/10",
+        group_address_position_feedback: "1/4/11",
+        travel_time_down: 50,
+        travel_time_up: 60,
+      }
 
-        # Some states are encoded into different bits of the same group_address
-        # Defining which bit should be relevant for the binary state via the "significant_bit" option
-        Kitchen.Presence: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 2}
-        Kitchen.ThermostatNightMode: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 1}
+    # Central Shutters dont have short or position address
+    Central.Shutter: { group_address_long: "1/5/1" }
 
+  light:
+    Kitchen.Light_1:
+      { group_address_switch: "1/6/1", group_address_brightness: "1/6/3" }
+    Diningroom.Light_1:
+      { group_address_switch: "1/6/4", group_address_brightness: "1/6/6" }
+    Living-Room.Light_1: { group_address_switch: "1/6/7" }
+    # Light with extra addresses for states:
+    Office.Light_1:
+      {
+        group_address_switch: "1/7/4",
+        group_address_switch_state: "1/7/5",
+        group_address_brightness: "1/7/6",
+        group_address_brightness_state: "1/7/7",
+      }
 
-    switch:
+  climate:
+    Kitchen.Climate_1: { group_address_temperature: "1/7/1" }
+    Livingroom.Climate_2:
+      { group_address_temperature: "1/7/2", group_address_setpoint: "1/7/3" }
 
-        Livingroom.Outlet_1: {group_address: '1/3/1'}
-        Livingroom.Outlet_2: {group_address: '1/3/2'}
+  # Cyclic sending of time to the KNX bus
+  time:
+    General.Time: { group_address: "2/1/2" }
 
-    switch 2:
-        Kitchen.Outlet_1: {group_address: '1/3/7'}
-        Kitchen.Outlet_2: {group_address: '1/3/8'}
-        Kitchen.Outlet_3: {group_address: '1/3/9'}
-        Kitchen.Outlet_4: {group_address: '1/3/10'}
-
-    cover:
-        Livingroom.Shutter_1: {group_address_long: '1/4/1', group_address_short: '1/4/2', group_address_position_feedback: '1/4/3', group_address_position: '1/4/4', travel_time_down: 50, travel_time_up: 60 }
-        Livingroom.Shutter_2: {group_address_long: '1/4/5', group_address_short: '1/4/6', group_address_position_feedback: '1/4/7', group_address_position: '1/4/8', travel_time_down: 50, travel_time_up: 60 }
-
-        # Covers without direct positioning:
-        Livingroom.Shutter_3: {group_address_long: '1/4/9', group_address_short: '1/4/10', group_address_position_feedback: '1/4/11', travel_time_down: 50, travel_time_up: 60 }
-
-        # Central Shutters dont have short or position address
-        Central.Shutter: {group_address_long: '1/5/1' }
-
-    light:
-
-        Kitchen.Light_1:     {group_address_switch: '1/6/1', group_address_brightness: '1/6/3'}
-        Diningroom.Light_1:  {group_address_switch: '1/6/4', group_address_brightness: '1/6/6'}
-        Living-Room.Light_1: {group_address_switch: '1/6/7'}
-        # Light with extra addresses for states:
-        Office.Light_1:  {group_address_switch: '1/7/4', group_address_switch_state: '1/7/5', group_address_brightness: '1/7/6', group_address_brightness_state: '1/7/7'}
-
-    climate:
-        Kitchen.Climate_1: {group_address_temperature: '1/7/1'}
-        Livingroom.Climate_2: {group_address_temperature: '1/7/2', group_address_setpoint: '1/7/3'}
-
-    # Cyclic sending of time to the KNX bus
-    time:
-        General.Time: {group_address: '2/1/2'}
-
-
-    sensor:
-        Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent'}
-        Some.Other.Value: {group_address_state: '2/0/2'}
-
+  sensor:
+    Heating.Valve1: { group_address_state: "2/0/0", value_type: "percent" }
+    Heating.Valve2: { group_address_state: "2/0/1", value_type: "percent" }
+    Some.Other.Value: { group_address_state: "2/0/2" }
 ```

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -10,8 +10,6 @@ import homeassistant.helpers.config_validation as cv
 from . import ATTR_DISCOVER_DEVICES, DATA_XKNX, KNXAutomation
 
 CONF_STATE_ADDRESS = "state_address"
-CONF_SIGNIFICANT_BIT = "significant_bit"
-CONF_DEFAULT_SIGNIFICANT_BIT = 1
 CONF_SYNC_STATE = "sync_state"
 CONF_IGNORE_INTERNAL_STATE = "ignore_internal_state"
 CONF_AUTOMATION = "automation"
@@ -38,9 +36,6 @@ AUTOMATIONS_SCHEMA = vol.All(cv.ensure_list, [AUTOMATION_SCHEMA])
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(
-            CONF_SIGNIFICANT_BIT, default=CONF_DEFAULT_SIGNIFICANT_BIT
-        ): cv.positive_int,
         vol.Optional(CONF_SYNC_STATE, default=True): cv.boolean,
         vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=False): cv.boolean,
         vol.Required(CONF_STATE_ADDRESS): cv.string,
@@ -81,7 +76,6 @@ def async_add_entities_config(hass, config, async_add_entities):
         sync_state=config[CONF_SYNC_STATE],
         ignore_internal_state=config[CONF_IGNORE_INTERNAL_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
-        significant_bit=config[CONF_SIGNIFICANT_BIT],
         reset_after=config.get(CONF_RESET_AFTER),
     )
     hass.data[DATA_XKNX].xknx.devices.add(binary_sensor)

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -432,17 +432,6 @@ class TestConfig(unittest.TestCase):
                          device_class='motion',
                          device_updated_cb=TestConfig.xknx.devices.device_updated))
 
-    def test_config_sensor_binary_significant_bit(self):
-        """Test reading Sensor with differing significant bit from config file."""
-        self.assertEqual(
-            TestConfig.xknx.devices['Kitchen.Presence'],
-            BinarySensor(TestConfig.xknx,
-                         'Kitchen.Presence',
-                         group_address_state='3/0/2',
-                         significant_bit=2,
-                         device_class='motion',
-                         device_updated_cb=TestConfig.xknx.devices.device_updated))
-
     def test_config_scene(self):
         """Test reading Scene from config file."""
         self.assertEqual(

--- a/test/devices_tests/action_test.py
+++ b/test/devices_tests/action_test.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import (
-    Action, ActionBase, ActionCallback, BinarySensorState, Light)
+    Action, ActionBase, ActionCallback, Light)
 
 
 class TestAction(unittest.TestCase):
@@ -49,22 +49,22 @@ class TestAction(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         action = ActionBase(xknx, counter=2, hook="on")
         self.assertTrue(action.test_if_applicable(
-            BinarySensorState.ON, 2))
+            True, 2))
         self.assertFalse(action.test_if_applicable(
-            BinarySensorState.ON, 3))
+            True, 3))
         self.assertFalse(action.test_if_applicable(
-            BinarySensorState.OFF, 2))
+            False, 2))
 
     def test_if_applicable_hook_off(self):
         """Test test_if_applicable method with hook set to 'off'."""
         xknx = XKNX(loop=self.loop)
         action = ActionBase(xknx, counter=2, hook="off")
         self.assertTrue(action.test_if_applicable(
-            BinarySensorState.OFF, 2))
+            False, 2))
         self.assertFalse(action.test_if_applicable(
-            BinarySensorState.OFF, 3))
+            False, 3))
         self.assertFalse(action.test_if_applicable(
-            BinarySensorState.ON, 2))
+            True, 2))
 
     #
     # TEST EXECUTE

--- a/test/devices_tests/action_test.py
+++ b/test/devices_tests/action_test.py
@@ -4,8 +4,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from xknx import XKNX
-from xknx.devices import (
-    Action, ActionBase, ActionCallback, Light)
+from xknx.devices import Action, ActionBase, ActionCallback, Light
 
 
 class TestAction(unittest.TestCase):

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import Mock, patch
 
 from xknx import XKNX
-from xknx.devices import Action, BinarySensor, BinarySensorState, Switch
+from xknx.devices import Action, BinarySensor, Switch
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
@@ -37,51 +37,55 @@ class TestBinarySensor(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3')
 
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.assertEqual(binaryinput.state, False)
 
-        telegram_on = Telegram()
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_on.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
 
-        self.assertEqual(binaryinput.state, BinarySensorState.ON)
+        self.assertEqual(binaryinput.state, True)
 
-        telegram_off = Telegram()
+        telegram_off = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_off.payload = DPTBinary(0)
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_off)))
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.assertEqual(binaryinput.state, False)
 
     def test_process_reset_after(self):
         """Test process / reading telegrams from telegram queue."""
         xknx = XKNX(loop=self.loop)
-        binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3', reset_after=0.01)
-        telegram_on = Telegram(payload=DPTBinary(1))
+        reset_after_ms = 0.01
+        binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3', reset_after=reset_after_ms)
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
+        telegram_on.payload = DPTBinary(1)
+
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.loop.run_until_complete(asyncio.sleep(reset_after_ms*2/1000))
+        self.assertEqual(binaryinput.state, False)
 
     def test_process_significant_bit(self):
         """Test process / reading telegrams from telegram queue with specific significant bit set."""
         xknx = XKNX(loop=self.loop)
         binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3', significant_bit=3)
 
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.assertEqual(binaryinput.state, False)
 
         # Wrong significant bit: 0000 1011 = 11
-        telegram_on = Telegram()
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_on.payload = DPTBinary(11)
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.assertEqual(binaryinput.state, False)
 
         # Correct significant bit: 0000 1101 = 13
-        telegram_on = Telegram()
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_on.payload = DPTBinary(13)
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.assertEqual(binaryinput.state, BinarySensorState.ON)
+        self.assertEqual(binaryinput.state, True)
 
         # Resetting, significant bit: 0000 0011 = 3
-        telegram_off = Telegram()
+        telegram_off = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_off.payload = DPTBinary(3)
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_off)))
-        self.assertEqual(binaryinput.state, BinarySensorState.OFF)
+        self.assertEqual(binaryinput.state, False)
 
     def test_process_action(self):
         """Test process / reading telegrams from telegram queue. Test if action is executed."""
@@ -106,29 +110,29 @@ class TestBinarySensor(unittest.TestCase):
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.OFF)
+            False)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             False)
 
-        telegram_on = Telegram()
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_on.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_on)))
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.ON)
+            True)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             True)
 
-        telegram_off = Telegram()
+        telegram_off = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_off.payload = DPTBinary(0)
         self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_off)))
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.OFF)
+            False)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             False)
@@ -136,10 +140,10 @@ class TestBinarySensor(unittest.TestCase):
     def test_process_action_ignore_internal_state(self):
         """Test process / reading telegrams from telegram queue. Test if action is executed."""
         xknx = XKNX(loop=self.loop)
-        switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
+        switch = Switch(xknx, 'TestOutlet', group_address='5/5/5')
         xknx.devices.add(switch)
 
-        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/5', ignore_internal_state=True)
+        binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', ignore_internal_state=True)
         action_on = Action(
             xknx,
             hook='on',
@@ -150,18 +154,18 @@ class TestBinarySensor(unittest.TestCase):
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.OFF)
+            False)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             False)
 
-        telegram_on = Telegram()
+        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
         telegram_on.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_on)))
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.ON)
+            True)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             True)
@@ -172,14 +176,14 @@ class TestBinarySensor(unittest.TestCase):
             False)
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.ON)
+            True)
 
         self.loop.run_until_complete(asyncio.sleep(1))
         self.loop.run_until_complete(asyncio.Task(binary_sensor.process(telegram_on)))
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
-            BinarySensorState.ON)
+            True)
         self.assertEqual(
             xknx.devices['TestOutlet'].state,
             True)
@@ -200,7 +204,7 @@ class TestBinarySensor(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3')
         # pylint: disable=protected-access
-        self.loop.run_until_complete(asyncio.Task(binaryinput._set_internal_state(BinarySensorState.ON)))
+        self.loop.run_until_complete(asyncio.Task(binaryinput._set_internal_state(True)))
         self.assertTrue(binaryinput.is_on())
         self.assertFalse(binaryinput.is_off())
 
@@ -212,7 +216,7 @@ class TestBinarySensor(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3')
         # pylint: disable=protected-access
-        self.loop.run_until_complete(asyncio.Task(binaryinput._set_internal_state(BinarySensorState.OFF)))
+        self.loop.run_until_complete(asyncio.Task(binaryinput._set_internal_state(False)))
         self.assertFalse(binaryinput.is_on())
         self.assertTrue(binaryinput.is_off())
 
@@ -232,7 +236,7 @@ class TestBinarySensor(unittest.TestCase):
             after_update_callback(device)
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram()
+        telegram = Telegram(group_address=GroupAddress('1/2/3'))
         telegram.payload = DPTBinary(1)
         self.loop.run_until_complete(asyncio.Task(switch.process(telegram)))
         after_update_callback.assert_called_with(switch)
@@ -246,25 +250,25 @@ class TestBinarySensor(unittest.TestCase):
         switch = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
         with patch('time.time') as mock_time:
             mock_time.return_value = 1517000000.0
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.ON), 1)
+            self.assertEqual(switch.bump_and_get_counter(True), 1)
 
             mock_time.return_value = 1517000000.1
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.ON), 2)
+            self.assertEqual(switch.bump_and_get_counter(True), 2)
 
             mock_time.return_value = 1517000000.2
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.OFF), 1)
+            self.assertEqual(switch.bump_and_get_counter(False), 1)
 
             mock_time.return_value = 1517000000.3
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.ON), 3)
+            self.assertEqual(switch.bump_and_get_counter(True), 3)
 
             mock_time.return_value = 1517000000.4
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.OFF), 2)
+            self.assertEqual(switch.bump_and_get_counter(False), 2)
 
             mock_time.return_value = 1517000002.0  # TIME OUT ...
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.ON), 1)
+            self.assertEqual(switch.bump_and_get_counter(True), 1)
 
             mock_time.return_value = 1517000004.1  # TIME OUT ...
-            self.assertEqual(switch.bump_and_get_counter(BinarySensorState.OFF), 1)
+            self.assertEqual(switch.bump_and_get_counter(False), 1)
 
     #
     # STATE ADDRESSES

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -22,13 +22,6 @@ class TestBinarySensor(unittest.TestCase):
         """Tear down test class."""
         self.loop.close()
 
-    def test_initialization_wrong_significant_bit(self):
-        """Test initialization with wrong significant_bit parameter."""
-        # pylint: disable=invalid-name
-        xknx = XKNX(loop=self.loop)
-        with self.assertRaises(TypeError):
-            BinarySensor(xknx, 'TestInput', '1/2/3', significant_bit="1")
-
     #
     # TEST PROCESS
     #
@@ -60,31 +53,6 @@ class TestBinarySensor(unittest.TestCase):
 
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
         self.loop.run_until_complete(asyncio.sleep(reset_after_ms*2/1000))
-        self.assertEqual(binaryinput.state, False)
-
-    def test_process_significant_bit(self):
-        """Test process / reading telegrams from telegram queue with specific significant bit set."""
-        xknx = XKNX(loop=self.loop)
-        binaryinput = BinarySensor(xknx, 'TestInput', '1/2/3', significant_bit=3)
-
-        self.assertEqual(binaryinput.state, False)
-
-        # Wrong significant bit: 0000 1011 = 11
-        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
-        telegram_on.payload = DPTBinary(11)
-        self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.assertEqual(binaryinput.state, False)
-
-        # Correct significant bit: 0000 1101 = 13
-        telegram_on = Telegram(group_address=GroupAddress('1/2/3'))
-        telegram_on.payload = DPTBinary(13)
-        self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.assertEqual(binaryinput.state, True)
-
-        # Resetting, significant bit: 0000 0011 = 3
-        telegram_off = Telegram(group_address=GroupAddress('1/2/3'))
-        telegram_off.payload = DPTBinary(3)
-        self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_off)))
         self.assertEqual(binaryinput.state, False)
 
     def test_process_action(self):

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -77,14 +77,12 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=2)
+                               group_address_state='3/0/1')
         devices.add(sensor1)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=3)
+                               group_address_state='3/0/1')
         devices.add(sensor2)
 
         light2 = Light(xknx,
@@ -114,14 +112,12 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=2)
+                               group_address_state='3/0/1')
         devices.add(sensor1)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=3)
+                               group_address_state='3/0/1')
         devices.add(sensor2)
 
         light2 = Light(xknx,
@@ -148,15 +144,13 @@ class TestDevices(unittest.TestCase):
 
         sensor1 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=2)
+                               group_address_state='3/0/1')
         devices.add(sensor1)
         self.assertEqual(len(devices), 2)
 
         sensor2 = BinarySensor(xknx,
                                'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1',
-                               significant_bit=3)
+                               group_address_state='3/0/1')
         devices.add(sensor2)
         self.assertEqual(len(devices), 3)
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -62,7 +62,7 @@ class TestStringRepresentations(unittest.TestCase):
             device_class='motion')
         self.assertEqual(
             str(binary_sensor),
-            '<BinarySensor group_address_state="GroupAddress("1/2/3")" name="Fnord" state="BinarySensorState.OFF"/>')
+            '<BinarySensor name="Fnord" remote_value="None/GroupAddress("1/2/3")/None/None" state="False"/>')
 
     def test_climate(self):
         """Test string representation of climate object."""

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -1,133 +1,237 @@
-
 general:
-    own_address: '15.15.249'
+    own_address: "15.15.249"
     rate_limit: 18
 
 connection:
     auto:
-    
+
 groups:
-
     binary_sensor:
-
         Livingroom.Switch_1:
-            group_address_state: '1/2/7'
+            group_address_state: "1/2/7"
             actions:
-              - {target: Livingroom.Outlet_1, method: 'on'}
-              - {target: Livingroom.Outlet_2, counter: 2, method: 'on'}
+                - { target: Livingroom.Outlet_1, method: "on" }
+                - { target: Livingroom.Outlet_2, counter: 2, method: "on" }
 
         Livingroom.Switch_2:
-            group_address_state: '1/2/8'
+            group_address_state: "1/2/8"
             actions:
-              - {target: Livingroom.Outlet_1, method: 'off'}
-              - {target: Livingroom.Outlet_2, counter: 2, method: 'off'}
-
+                - { target: Livingroom.Outlet_1, method: "off" }
+                - { target: Livingroom.Outlet_2, counter: 2, method: "off" }
 
         Livingroom.Switch_3:
-            group_address_state: '1/2/2'
+            group_address_state: "1/2/2"
             actions:
-              - {hook: 'off', target: Livingroom.Shutter_1, method: short_up}
-              - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: up} # Pressing more then 2 seconds
+                - {
+                      hook: "off",
+                      target: Livingroom.Shutter_1,
+                      method: short_up,
+                  }
+                - {
+                      hook: "off",
+                      counter: 2,
+                      target: Livingroom.Shutter_1,
+                      method: up,
+                  } # Pressing more then 2 seconds
 
         Livingroom.Switch_4:
-            group_address_state: '1/2/3'
+            group_address_state: "1/2/3"
             actions:
-              - {hook: 'off', target: Livingroom.Shutter_1, method: short_down}
-              - {hook: 'off', counter: 2, target: Livingroom.Shutter_1, method: down} # Pressing more then 2 seconds
-
+                - {
+                      hook: "off",
+                      target: Livingroom.Shutter_1,
+                      method: short_down,
+                  }
+                - {
+                      hook: "off",
+                      counter: 2,
+                      target: Livingroom.Shutter_1,
+                      method: down,
+                  } # Pressing more then 2 seconds
 
     binary_sensor_motion_dection:
-        Kitchen.Motion.Sensor: {group_address_state: '3/0/0', device_class: 'motion'}
-        DiningRoom.Motion.Sensor: {group_address_state: '3/0/1', sync_state: False, device_class: 'motion'}
-
-        # Some states are encoded into different bits of the same group_address
-        # Defining which bit should be relevant for the binary state via the "significant_bit" option
-        Kitchen.Presence: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 2}
-        Kitchen.ThermostatNightMode: {group_address_state: '3/0/2', device_class: 'motion', significant_bit: 1}
-
+        Kitchen.Motion.Sensor:
+            { group_address_state: "3/0/0", device_class: "motion" }
+        DiningRoom.Motion.Sensor:
+            {
+                group_address_state: "3/0/1",
+                sync_state: False,
+                device_class: "motion",
+            }
+        Kitchen.Presence:
+            { group_address_state: "3/0/2", device_class: "motion" }
+        Kitchen.ThermostatNightMode:
+            { group_address_state: "3/0/2", device_class: "motion" }
 
     switch:
-
-        Livingroom.Outlet_1: {group_address: '1/3/1'}
-        Livingroom.Outlet_2: {group_address: '1/3/2'}
+        Livingroom.Outlet_1: { group_address: "1/3/1" }
+        Livingroom.Outlet_2: { group_address: "1/3/2" }
 
     switch 2:
-        Kitchen.Outlet_1: {group_address: '1/3/7'}
-        Kitchen.Outlet_2: {group_address: '1/3/8'}
-        Kitchen.Outlet_3: {group_address: '1/3/9'}
-        Kitchen.Outlet_4: {group_address: '1/3/10'}
+        Kitchen.Outlet_1: { group_address: "1/3/7" }
+        Kitchen.Outlet_2: { group_address: "1/3/8" }
+        Kitchen.Outlet_3: { group_address: "1/3/9" }
+        Kitchen.Outlet_4: { group_address: "1/3/10" }
 
     fan:
-        Kitchen.Fan_1: {group_address_speed: 1/3/21, group_address_speed_state: '1/3/22'}
-        
+        Kitchen.Fan_1:
+            { group_address_speed: 1/3/21, group_address_speed_state: "1/3/22" }
+
     cover:
-        Livingroom.Shutter_1: {group_address_long: '1/4/1', group_address_short: '1/4/2', group_address_position_state: '1/4/3', group_address_position: '1/4/4', travel_time_down: 50, travel_time_up: 60 }
-        Livingroom.Shutter_2: {group_address_long: '1/4/5', group_address_short: '1/4/6', group_address_position_state: '1/4/7', group_address_position: '1/4/8', travel_time_down: 50, travel_time_up: 60 }
+        Livingroom.Shutter_1:
+            {
+                group_address_long: "1/4/1",
+                group_address_short: "1/4/2",
+                group_address_position_state: "1/4/3",
+                group_address_position: "1/4/4",
+                travel_time_down: 50,
+                travel_time_up: 60,
+            }
+        Livingroom.Shutter_2:
+            {
+                group_address_long: "1/4/5",
+                group_address_short: "1/4/6",
+                group_address_position_state: "1/4/7",
+                group_address_position: "1/4/8",
+                travel_time_down: 50,
+                travel_time_up: 60,
+            }
 
         # Covers without direct positioning:
-        Livingroom.Shutter_3: {group_address_long: '1/4/9', group_address_short: '1/4/10', group_address_position_state: '1/4/11', travel_time_down: 50, travel_time_up: 60 }
+        Livingroom.Shutter_3:
+            {
+                group_address_long: "1/4/9",
+                group_address_short: "1/4/10",
+                group_address_position_state: "1/4/11",
+                travel_time_down: 50,
+                travel_time_up: 60,
+            }
 
         # Central Shutters dont have short or position address
-        Central.Shutter: {group_address_long: '1/5/1' }
+        Central.Shutter: { group_address_long: "1/5/1" }
 
         # Covers with angle position
-        Children.Venetian: {group_address_long: '1/4/14', group_address_short: '1/4/15', group_address_position: '1/4/16', group_address_position_state: '1/4/17', group_address_angle: '1/4/18', group_address_angle_state: '1/4/19'}
+        Children.Venetian:
+            {
+                group_address_long: "1/4/14",
+                group_address_short: "1/4/15",
+                group_address_position: "1/4/16",
+                group_address_position_state: "1/4/17",
+                group_address_angle: "1/4/18",
+                group_address_angle_state: "1/4/19",
+            }
 
         # Covers with inverted position and angle_position
-        Children.Venetian2: {group_address_long: '1/4/14', group_address_short: '1/4/15', group_address_position: '1/4/16', group_address_position_state: '1/4/17', group_address_angle: '1/4/18', group_address_angle_state: '1/4/19', invert_position: True, invert_angle: True}
-
+        Children.Venetian2:
+            {
+                group_address_long: "1/4/14",
+                group_address_short: "1/4/15",
+                group_address_position: "1/4/16",
+                group_address_position_state: "1/4/17",
+                group_address_angle: "1/4/18",
+                group_address_angle_state: "1/4/19",
+                invert_position: True,
+                invert_angle: True,
+            }
 
     light:
-
-        Kitchen.Light_1:     {group_address_switch: '1/6/1', group_address_brightness: '1/6/3'}
-        Living-Room.Light_1: {group_address_switch: '1/6/9'}
+        Kitchen.Light_1:
+            { group_address_switch: "1/6/1", group_address_brightness: "1/6/3" }
+        Living-Room.Light_1: { group_address_switch: "1/6/9" }
         # Light with extra addresses for states:
-        Office.Light_1:  {group_address_switch: '1/7/4', group_address_switch_state: '1/7/5', group_address_brightness: '1/7/6', group_address_brightness_state: '1/7/7'}
+        Office.Light_1:
+            {
+                group_address_switch: "1/7/4",
+                group_address_switch_state: "1/7/5",
+                group_address_brightness: "1/7/6",
+                group_address_brightness_state: "1/7/7",
+            }
         # Light with color
-        Diningroom.Light_1:  {group_address_switch: '1/6/4', group_address_brightness: '1/6/6', group_address_color: '1/6/7',  group_address_color_state: '1/6/8'}
+        Diningroom.Light_1:
+            {
+                group_address_switch: "1/6/4",
+                group_address_brightness: "1/6/6",
+                group_address_color: "1/6/7",
+                group_address_color_state: "1/6/8",
+            }
         # Light with color temperature
-        Living-Room.Light_CT:  {group_address_switch: '1/6/11', group_address_switch_state: '1/6/10', group_address_brightness: '1/6/12', group_address_brightness_state: '1/6/13', group_address_color_temperature: '1/6/14',  group_address_color_temperature_state: '1/6/15'}
-        Living-Room.Light_TW:  {group_address_switch: '1/6/21', group_address_switch_state: '1/6/20', group_address_brightness: '1/6/22', group_address_brightness_state: '1/6/23', group_address_tunable_white: '1/6/24',  group_address_tunable_white_state: '1/6/25'}
+        Living-Room.Light_CT:
+            {
+                group_address_switch: "1/6/11",
+                group_address_switch_state: "1/6/10",
+                group_address_brightness: "1/6/12",
+                group_address_brightness_state: "1/6/13",
+                group_address_color_temperature: "1/6/14",
+                group_address_color_temperature_state: "1/6/15",
+            }
+        Living-Room.Light_TW:
+            {
+                group_address_switch: "1/6/21",
+                group_address_switch_state: "1/6/20",
+                group_address_brightness: "1/6/22",
+                group_address_brightness_state: "1/6/23",
+                group_address_tunable_white: "1/6/24",
+                group_address_tunable_white_state: "1/6/25",
+            }
 
     climate:
-        Kitchen.Climate: {group_address_temperature: '1/7/1'}
-        Children.Climate: {group_address_temperature: '1/7/2', group_address_target_temperature: '1/7/4', group_address_setpoint_shift: '1/7/3', group_address_setpoint_shift_state: '1/7/14', setpoint_shift_step: 0.1, setpoint_shift_min: -10, setpoint_shift_max: 10}
+        Kitchen.Climate: { group_address_temperature: "1/7/1" }
+        Children.Climate:
+            {
+                group_address_temperature: "1/7/2",
+                group_address_target_temperature: "1/7/4",
+                group_address_setpoint_shift: "1/7/3",
+                group_address_setpoint_shift_state: "1/7/14",
+                setpoint_shift_step: 0.1,
+                setpoint_shift_min: -10,
+                setpoint_shift_max: 10,
+            }
 
         Office.Climate:
-            group_address_temperature: '1/7/5'
+            group_address_temperature: "1/7/5"
             mode:
-                group_address_operation_mode: '1/7/6'
+                group_address_operation_mode: "1/7/6"
         Bath.Climate:
             mode:
-                group_address_operation_mode: '1/7/6'
-                group_address_operation_mode_state: '1/7/7'
+                group_address_operation_mode: "1/7/6"
+                group_address_operation_mode_state: "1/7/7"
         Attic.Climate:
             mode:
-                group_address_operation_mode_protection: '1/7/8'
-                group_address_operation_mode_night: '1/7/9'
-                group_address_operation_mode_comfort: '1/7/10'
+                group_address_operation_mode_protection: "1/7/8"
+                group_address_operation_mode_night: "1/7/9"
+                group_address_operation_mode_comfort: "1/7/10"
         Cellar.Climate:
             mode:
-                group_address_controller_status: '1/7/12'
-                group_address_controller_status_state: '1/7/13'
+                group_address_controller_status: "1/7/12"
+                group_address_controller_status_state: "1/7/13"
 
     # Cyclic sending of time objects to the KNX bus
     datetime:
-        General.Time: {group_address: '2/1/1'}
-        General.DateTime: {group_address: '2/1/2', broadcast_type: 'datetime'}
-        General.Date: {group_address: '2/1/3', broadcast_type: 'date'}
+        General.Time: { group_address: "2/1/1" }
+        General.DateTime: { group_address: "2/1/2", broadcast_type: "datetime" }
+        General.Date: { group_address: "2/1/3", broadcast_type: "date" }
 
     notification:
-        AlarmWindow: {group_address: '2/7/1', group_address_state: '2/7/2'}
+        AlarmWindow: { group_address: "2/7/1", group_address_state: "2/7/2" }
 
     sensor:
-        Heating.Valve1: {group_address_state: '2/0/0', value_type: 'percent'}
-        Heating.Valve2: {group_address_state: '2/0/1', value_type: 'percent', sync_state: False}
-        Kitchen.Temperature: {group_address_state: '2/0/2', value_type: 'temperature', sync_state: True}
+        Heating.Valve1: { group_address_state: "2/0/0", value_type: "percent" }
+        Heating.Valve2:
+            {
+                group_address_state: "2/0/1",
+                value_type: "percent",
+                sync_state: False,
+            }
+        Kitchen.Temperature:
+            {
+                group_address_state: "2/0/2",
+                value_type: "temperature",
+                sync_state: True,
+            }
 
     expose_sensor:
-        Outside.Temperature: {group_address: '2/0/3', value_type: 'temperature'}
-
+        Outside.Temperature:
+            { group_address: "2/0/3", value_type: "temperature" }
 
     scene:
-        Romantic: {group_address: '7/0/1', scene_number: 23}
+        Romantic: { group_address: "7/0/1", scene_number: 23 }

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -1,7 +1,7 @@
 """Module for handling devices like Lights, Switches or Covers."""
 # flake8: noqa
 from .action import Action, ActionBase, ActionCallback
-from .binary_sensor import BinarySensor, BinarySensorState
+from .binary_sensor import BinarySensor
 from .climate import Climate
 from .climate_mode import ClimateMode
 from .cover import Cover

--- a/xknx/devices/action.py
+++ b/xknx/devices/action.py
@@ -24,15 +24,10 @@ class ActionBase():
 
     def test_if_applicable(self, state, counter=None):
         """Test if should be executed for this state and this counter number."""
-        from .binary_sensor import BinarySensorState
-        if (state == BinarySensorState.ON) \
-                and (self.hook == "on") \
-                and self.test_counter(counter):
-            return True
-        if (state == BinarySensorState.OFF) \
-                and (self.hook == "off") \
-                and self.test_counter(counter):
-            return True
+        if state and (self.hook == "on"):
+            return self.test_counter(counter)
+        if not state and (self.hook == "off"):
+            return self.test_counter(counter)
         return False
 
     async def execute(self):

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -10,22 +10,11 @@ A BinarySensor may also have Actions attached which are executed after state was
 """
 import asyncio
 import time
-from enum import Enum
 
-from xknx.dpt import DPTBinary
-from xknx.exceptions import CouldNotParseTelegram
-from xknx.telegram import GroupAddress
+from xknx.remote_value import RemoteValueSwitch
 
 from .action import Action
 from .device import Device
-
-
-# pylint: disable=invalid-name
-class BinarySensorState(Enum):
-    """Enum class for the state of a binary sensor."""
-
-    ON = 1
-    OFF = 2
 
 
 class BinarySensor(Device):
@@ -42,31 +31,38 @@ class BinarySensor(Device):
                  sync_state=True,
                  ignore_internal_state=False,
                  device_class=None,
-                 significant_bit=1,
                  reset_after=None,
                  actions=None,
                  device_updated_cb=None):
         """Initialize BinarySensor class."""
         # pylint: disable=too-many-arguments
         super().__init__(xknx, name, device_updated_cb)
-        if isinstance(group_address_state, (str, int)):
-            group_address_state = GroupAddress(group_address_state)
-        if not isinstance(significant_bit, int):
-            raise TypeError()
         if actions is None:
             actions = []
 
-        self.group_address_state = group_address_state
-        self.sync_state = sync_state
-        self.device_class = device_class
-        self.significant_bit = significant_bit
-        self.reset_after = reset_after
-        self.state = BinarySensorState.OFF
         self.actions = actions
+        self.device_class = device_class
         self.ignore_internal_state = ignore_internal_state
-        self.last_set = None
-        self.count_set_on = 0
-        self.count_set_off = 0
+        self.reset_after = reset_after
+        self.state = False
+
+        self._count_set_on = 0
+        self._count_set_off = 0
+        self._last_set = None
+        self._reset_task = None
+        # TODO: log a warning if reset_after and sync_state are true ? This would cause actions to self-fire.
+        self.remote_value = RemoteValueSwitch(xknx,
+                                              group_address_state=group_address_state,
+                                              sync_state=sync_state,
+                                              device_name=self.name,
+                                              # after_update called internally
+                                              after_update_cb=self._state_from_remote_value
+                                              )
+
+    def __del__(self):
+        """Destructor. Cleaning up if this was not done before."""
+        if self._reset_task:
+            self._reset_task.cancel()
 
     @classmethod
     def from_config(cls, xknx, name, config):
@@ -77,8 +73,6 @@ class BinarySensor(Device):
             config.get('sync_state', True)
         device_class = \
             config.get('device_class')
-        significant_bit = \
-            config.get('significant_bit', 1)
         ignore_internal_state = \
             config.get('ignore_internal_state', False)
         actions = []
@@ -93,22 +87,22 @@ class BinarySensor(Device):
                    sync_state=sync_state,
                    ignore_internal_state=ignore_internal_state,
                    device_class=device_class,
-                   significant_bit=significant_bit,
                    actions=actions)
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""
-        return group_address in [self.group_address_state]
+        return self.remote_value.has_group_address(group_address)
 
     def state_addresses(self):
         """Return group addresses which should be requested to sync state."""
-        if self.sync_state and \
-                self.group_address_state is not None:
-            return [self.group_address_state, ]
-        return []
+        return self.remote_value.state_addresses()
+
+    async def _state_from_remote_value(self):
+        """Callback from ReomteValue. Sets the internal state."""
+        await self._set_internal_state(self.remote_value.value)
 
     async def _set_internal_state(self, state):
-        """Set the internal state of the device. If state was changed after update hooks and connected Actions are executed."""
+        """Set the internal state of the device. If state was changed after_update hooks and connected Actions are executed."""
         if state != self.state or self.ignore_internal_state:
             self.state = state
             counter = self.bump_and_get_counter(state)
@@ -122,55 +116,56 @@ class BinarySensor(Device):
         """Bump counter and return the number of times a state was set to the same value within CONTEXT_TIMEOUT."""
         def within_same_context():
             """Check if state change was within same context (e.g. 'Button was pressed twice')."""
-            if self.last_set is None:
-                self.last_set = time.time()
+            if self._last_set is None:
+                self._last_set = time.time()
                 return False
             new_set_time = time.time()
-            time_diff = new_set_time - self.last_set
-            self.last_set = new_set_time
+            time_diff = new_set_time - self._last_set
+            self._last_set = new_set_time
             return time_diff < self.CONTEXT_TIMEOUT
 
         if within_same_context():
-            if state == BinarySensorState.ON:
-                self.count_set_on = self.count_set_on + 1
-                return self.count_set_on
-            self.count_set_off = self.count_set_off + 1
-            return self.count_set_off
+            if state:
+                self._count_set_on = self._count_set_on + 1
+                return self._count_set_on
+            self._count_set_off = self._count_set_off + 1
+            return self._count_set_off
 
-        if state == BinarySensorState.ON:
-            self.count_set_on = 1
-            self.count_set_off = 0
+        if state:
+            self._count_set_on = 1
+            self._count_set_off = 0
         else:
-            self.count_set_on = 0
-            self.count_set_off = 1
+            self._count_set_on = 0
+            self._count_set_off = 1
         return 1
 
     async def process_group_write(self, telegram):
         """Process incoming GROUP WRITE telegram."""
-        if not isinstance(telegram.payload, DPTBinary):
-            raise CouldNotParseTelegram("invalid payload", payload=telegram.payload, device_name=self.name)
+        if await self.remote_value.process(telegram, always_callback=True):
 
-        bit_masq = 1 << (self.significant_bit-1)
-        if telegram.payload.value & bit_masq == 0:
-            await self._set_internal_state(BinarySensorState.OFF)
-        else:
-            await self._set_internal_state(BinarySensorState.ON)
-            if self.reset_after is not None:
-                await asyncio.sleep(self.reset_after/1000)
-                await self._set_internal_state(BinarySensorState.OFF)
+            if self.reset_after is not None and \
+                    self.state:
+                if self._reset_task:
+                    self._reset_task.cancel()
+                self._reset_task = self.xknx.loop.create_task(
+                    self._reset_state(self.reset_after/1000))
+
+    async def _reset_state(self, wait_seconds):
+        await asyncio.sleep(wait_seconds)
+        await self._set_internal_state(False)
 
     def is_on(self):
         """Return if binary sensor is 'on'."""
-        return self.state == BinarySensorState.ON
+        return self.state
 
     def is_off(self):
         """Return if binary sensor is 'off'."""
-        return self.state == BinarySensorState.OFF
+        return not self.state
 
     def __str__(self):
         """Return object as readable string."""
-        return '<BinarySensor group_address_state="{0}" name="{1}" state="{2}"/>' \
-            .format(self.group_address_state.__repr__(), self.name, self.state)
+        return '<BinarySensor name="{0}" remote_value="{1}" state="{2}"/>' \
+            .format(self.name, self.remote_value.group_addr_str(), self.state)
 
     def __eq__(self, other):
         """Equal operator."""

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -98,7 +98,7 @@ class BinarySensor(Device):
         return self.remote_value.state_addresses()
 
     async def _state_from_remote_value(self):
-        """Callback from ReomteValue. Sets the internal state."""
+        """Update the internal state from ReomteValue (Callback)."""
         await self._set_internal_state(self.remote_value.value)
 
     async def _set_internal_state(self, state):

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -77,7 +77,7 @@ class RemoteValue():
         # pylint: disable=unused-argument
         self.xknx.logger.warning("to_knx not implemented for %s", self.__class__.__name__)
 
-    async def process(self, telegram):
+    async def process(self, telegram, always_callback=False):
         """Process incoming telegram."""
         if not self.has_group_address(telegram.group_address):
             return False
@@ -86,7 +86,8 @@ class RemoteValue():
                                         payload=telegram.payload,
                                         group_address=telegram.group_address,
                                         device_name=self.device_name)
-        if self.payload != telegram.payload or self.payload is None:
+        if self.payload is None or always_callback \
+                or self.payload != telegram.payload:
             self.payload = telegram.payload
             if self.after_update_cb is not None:
                 await self.after_update_cb()

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -16,6 +16,7 @@ class RemoteValueSwitch(RemoteValue):
                  xknx,
                  group_address=None,
                  group_address_state=None,
+                 sync_state=True,
                  device_name=None,
                  after_update_cb=None,
                  invert=False):
@@ -24,6 +25,7 @@ class RemoteValueSwitch(RemoteValue):
         super().__init__(xknx,
                          group_address,
                          group_address_state,
+                         sync_state=sync_state,
                          device_name=device_name,
                          after_update_cb=after_update_cb)
         self.invert = invert


### PR DESCRIPTION
- use a RemoteValue in BinarySensor device
- use a regular Bool type for state (this also avoids imports outside toplevel)
- reset_after is now implemented as asyncio.Task to prevent blocking the loop
- RemoteValue.process has `always_callback` attribute to run the callbacks on every process even if the payload didn't change

# Breaking changes:

- significant_bit attribute is removed

closes #241 
fixes #298 
