### PR TITLE
Timeout-only gateway scanning

### DIFF
--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -145,7 +145,7 @@ class TestGatewayScanner(unittest.TestCase):
         self.assertEqual(test_scan, [])
 
 
-def fake_router_search_response(xknx: XKNX) -> SearchResponse:
+def fake_router_search_response(xknx: XKNX) -> KNXIPFrame:
     """Return the SearchResponse of a KNX/IP Router."""
     _frame_header = KNXIPHeader(xknx)
     _frame_header.service_type_ident = KNXIPServiceType.SEARCH_RESPONSE

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -146,7 +146,7 @@ class TestGatewayScanner(unittest.TestCase):
 
 
 def fake_router_search_response(xknx: XKNX) -> KNXIPFrame:
-    """Return the SearchResponse of a KNX/IP Router."""
+    """Return the KNXIPFrame of a KNX/IP Router with a SearchResponse body."""
     _frame_header = KNXIPHeader(xknx)
     _frame_header.service_type_ident = KNXIPServiceType.SEARCH_RESPONSE
     _frame_body = SearchResponse(xknx)

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -94,7 +94,7 @@ class GatewayScanner():
         self.timeout_in_seconds = timeout_in_seconds
         self.stop_on_found = stop_on_found
         self.scan_filter = scan_filter
-        self.found_gateways = []  # List[GatewayDescriptor]
+        self.found_gateways = []  # type: List[GatewayDescriptor]
         self._udp_clients = []
         self._response_received_or_timeout = asyncio.Event()
         self._timeout_handle = None

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -7,7 +7,7 @@ GatewayScanner is an abstraction for searching for KNX/IP devices on the local n
 """
 
 import asyncio
-from typing import List
+from typing import List, Optional
 
 import netifaces
 
@@ -87,7 +87,7 @@ class GatewayScanner():
     def __init__(self,
                  xknx,
                  timeout_in_seconds: int = 4,
-                 stop_on_found: int = 1,
+                 stop_on_found: Optional[int] = 1,
                  scan_filter: GatewayScanFilter = GatewayScanFilter()) -> None:
         """Initialize GatewayScanner class."""
         self.xknx = xknx
@@ -172,6 +172,8 @@ class GatewayScanner():
     def _add_found_gateway(self, gateway):
         if self.scan_filter.match(gateway):
             self.found_gateways.append(gateway)
+            if self.stop_on_found is None or self.stop_on_found <= 0:
+                return
             if len(self.found_gateways) >= self.stop_on_found:
                 self._response_received_or_timeout.set()
 

--- a/xknx/knxip/search_response.py
+++ b/xknx/knxip/search_response.py
@@ -13,7 +13,7 @@ from .knxip_enum import KNXIPServiceType
 
 
 class SearchResponse(KNXIPBody):
-    """Representation of a KNX Connect Request."""
+    """Representation of a KNX Connect Response."""
 
     # pylint: disable=too-many-instance-attributes
 


### PR DESCRIPTION
This adds an additional scanning mode to the GatewayScanner, namely timeout-only scanning.
In some cases it is not desirable to limit the amount of gateways that can be scanned.

Passing `None` or an integer less than or equal to zero to the `stop_on_found` parameter now causes the scanner to only stop once the timeout is reached.