### PR TITLE
Multicast address configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,8 @@ The configuration file can contain three sections.
 - The `general` section can contain:
   - `own_address` the individual / physical address of the XKNX daemon
   - `rate_limit` a rate limit for telegrams sent to the bus
+  - `multicast_group` to override the default multicast address (`224.0.23.12`)
+  - `multicast_port` to override the default multicast port (`3671`)
 - The `connection` section can be used to specify the connection to the KNX interface.
   - `auto` for automatic discovery of a KNX interface
   - `tunneling` for a UDP unicast connection

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -23,7 +23,9 @@ xknx = XKNX(config='xknx.yaml',
             address_format=GroupAddressType.LONG
             telegram_received_cb=None,
             device_updated_cb=None,
-            rate_limit=DEFAULT_RATE_LIMIT)
+            rate_limit=DEFAULT_RATE_LIMIT,
+            multicast_group=DEFAULT_MCAST_GRP,
+            multicast_port=DEFAULT_MCAST_PORT)
 ```
 
 The constructor of the XKNX object takes several parameters:
@@ -38,6 +40,8 @@ The constructor of the XKNX object takes several parameters:
 * `telegram_received_cb` is a callback which is called after every received KNX telegram. See [callbacks](#callbacks) documentation for details.
 * `device_updated_cb` is an async callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
 * `rate_limit` in telegrams per second - can be used to limit the outgoing traffic to the KNX/IP interface. The default value is 20 packets per second.
+* `multicast_group` is the multicast IP address - can be used to override the default multicast address (`224.0.23.12`)
+* `multicast_port` is the multicast port - can be used to override the default multicast port (`3671`)
 
 # [](#header-2)Starting
 

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -37,6 +37,8 @@ class TestConfig(unittest.TestCase):
         """Test reading general section from config file."""
         self.assertEqual(TestConfig.xknx.own_address, PhysicalAddress('15.15.249'))
         self.assertEqual(TestConfig.xknx.rate_limit, 18)
+        self.assertEqual(TestConfig.xknx.multicast_group, "224.1.2.3")
+        self.assertEqual(TestConfig.xknx.multicast_port, 1337)
 
     #
     # XKNX Connection Config

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -2,6 +2,8 @@
 general:
     own_address: '15.15.249'
     rate_limit: 18
+    multicast_group: '224.1.2.3'
+    multicast_port: 1337
 
 connection:
     auto:

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -43,6 +43,12 @@ class Config:
             if "rate_limit" in doc["general"]:
                 self.xknx.rate_limit = \
                     doc["general"]["rate_limit"]
+            if "multicast_group" in doc["general"]:
+                self.xknx.multicast_group = \
+                    doc["general"]["multicast_group"]
+            if "multicast_port" in doc["general"]:
+                self.xknx.multicast_port = \
+                    doc["general"]["multicast_port"]
 
     def parse_connection(self, doc):
         """Parse the connection section of xknx.yaml."""

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -15,7 +15,6 @@ from xknx.knxip import (
     HPAI, DIBServiceFamily, DIBSuppSVCFamilies, KNXIPFrame, KNXIPServiceType,
     SearchResponse)
 
-from .const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from .udp_client import UDPClient
 
 
@@ -131,7 +130,7 @@ class GatewayScanner():
 
         udp_client = UDPClient(self.xknx,
                                (ip_addr, 0, interface),
-                               (DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT),
+                               (self.xknx.multicast_group, self.xknx.multicast_port),
                                multicast=True)
 
         udp_client.register_callback(

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -6,7 +6,6 @@ Routing uses UDP Multicast to broadcast and receive KNX/IP messages.
 from xknx.knxip import APCICommand, KNXIPFrame, KNXIPServiceType
 from xknx.telegram import TelegramDirection
 
-from .const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from .udp_client import UDPClient
 
 
@@ -21,7 +20,7 @@ class Routing():
 
         self.udpclient = UDPClient(self.xknx,
                                    (local_ip, 0),
-                                   (DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT),
+                                   (self.xknx.multicast_group, self.xknx.multicast_port),
                                    multicast=True,
                                    bind_to_multicast_addr=bind_to_multicast_addr)
 

--- a/xknx/knxip/search_request.py
+++ b/xknx/knxip/search_request.py
@@ -18,7 +18,7 @@ class SearchRequest(KNXIPBody):
     def __init__(self, xknx):
         """Initialize SearchRequest object."""
         super().__init__(xknx)
-        self.discovery_endpoint = HPAI(ip_addr="224.0.23.12", port=3671)
+        self.discovery_endpoint = HPAI(ip_addr=xknx.multicast_group, port=xknx.multicast_port)
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -6,7 +6,7 @@ from sys import platform
 
 from xknx.core import Config, TelegramQueue
 from xknx.devices import Devices
-from xknx.io import ConnectionConfig, KNXIPInterface
+from xknx.io import ConnectionConfig, KNXIPInterface, DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from xknx.telegram import GroupAddressType, PhysicalAddress
 
 from .__version__ import __version__ as VERSION
@@ -27,7 +27,9 @@ class XKNX:
                  address_format=GroupAddressType.LONG,
                  telegram_received_cb=None,
                  device_updated_cb=None,
-                 rate_limit=DEFAULT_RATE_LIMIT):
+                 rate_limit=DEFAULT_RATE_LIMIT,
+                 multicast_group=DEFAULT_MCAST_GRP,
+                 multicast_port=DEFAULT_MCAST_PORT):
         """Initialize XKNX class."""
         # pylint: disable=too-many-arguments
         self.devices = Devices()
@@ -41,6 +43,8 @@ class XKNX:
         self.address_format = address_format
         self.own_address = own_address
         self.rate_limit = rate_limit
+        self.multicast_group = multicast_group
+        self.multicast_port = multicast_port
         self.logger = logging.getLogger('xknx.log')
         self.knx_logger = logging.getLogger('xknx.knx')
         self.telegram_logger = logging.getLogger('xknx.telegram')


### PR DESCRIPTION
This adds support for configuring the previously hard-coded multicast address.

Tested with knxd 0.14.39.