### PR TITLE
add support for binary heating cooling mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - Added config option ignore_internal_state in binary sensors (@andreasnanko #267)
 - Add support for 2byte float type (DPT 9.002) to climate shiftpoint
 - ClimateMode: add `group_address_operation_mode_standby` as binary operation mode
+- ClimateMode: add `group_address_heat_cool` and `group_address_heat_cool_state for switching heating mode / cooling mode with DPT1
 
 ### Bugfixes
 

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -73,16 +73,18 @@ groups:
 - **min_temp** Minimum value for target temperature.
 - **mode** ClimateMode instance for this climate device
 
-* **group_address_operation_mode** KNX address for operation mode.
-* **group_address_operation_mode_state** KNX address for operation mode status.
-* **group_address_operation_mode_protection** KNX address for switching on/off frost/heat protection mode.
-* **group_address_operation_mode_night** KNX address for switching on/off night nmode.
-* **group_address_operation_mode_comfort** KNX address for switching on/off comfort mode.
-* **group_address_operation_mode_standby** KNX address for switching on/off standby mode.
+* **group_address_operation_mode** KNX address for operation mode. DPT 20.102
+* **group_address_operation_mode_state** KNX address for operation mode status. DPT 20.102
+* **group_address_operation_mode_protection** KNX address for switching on/off frost/heat protection mode. DPT 1
+* **group_address_operation_mode_night** KNX address for switching on/off night nmode. DPT 1
+* **group_address_operation_mode_comfort** KNX address for switching on/off comfort mode. DPT 1
+* **group_address_operation_mode_standby** KNX address for switching on/off standby mode. DPT 1
 * **group_address_controller_status** KNX address for controller status.
 * **group_address_controller_status_state** KNX address for controller status state.
-* **group_address_controller_mode** KNX address for controller mode.
-* **group_address_controller_mode_state** KNX address for controller mode status.
+* **group_address_controller_mode** KNX address for controller mode. DPT 20.105
+* **group_address_controller_mode_state** KNX address for controller mode status. DPT 20.105
+* **group_address_heat_cool** KNX address for switching heating / cooling mode. DPT 1
+* **group_address_heat_cool_state** KNX address for reading heating / cooling mode. DPT 1
 * **operation_modes** Overrides the supported operation modes.
 
 **Note:** `group_address_operation_mode_protection` / `group_address_operation_mode_night` / `group_address_operation_mode_comfort` / `group_address_operation_mode_standby` are not necessary if `group_address_operation_mode` was specified. When one of these is set `True`, the others will be set `False`. When one of these is set "Standby", "Comfort", "Frost_Protection" and "Night" will be set as supported. If `group_address_operation_mode_standby` is omitted, "Standby" is set when the other 3 are set to `False`.

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -42,6 +42,8 @@ CONF_CONTROLLER_STATUS_ADDRESS = "controller_status_address"
 CONF_CONTROLLER_STATUS_STATE_ADDRESS = "controller_status_state_address"
 CONF_CONTROLLER_MODE_ADDRESS = "controller_mode_address"
 CONF_CONTROLLER_MODE_STATE_ADDRESS = "controller_mode_state_address"
+CONF_HEAT_COOL_ADDRESS = "heat_cool_address"
+CONF_HEAT_COOL_STATE_ADDRESS = "heat_cool_state_address"
 CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS = "operation_mode_frost_protection_address"
 CONF_OPERATION_MODE_NIGHT_ADDRESS = "operation_mode_night_address"
 CONF_OPERATION_MODE_COMFORT_ADDRESS = "operation_mode_comfort_address"
@@ -108,6 +110,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_CONTROLLER_STATUS_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_CONTROLLER_MODE_ADDRESS): cv.string,
         vol.Optional(CONF_CONTROLLER_MODE_STATE_ADDRESS): cv.string,
+        vol.Optional(CONF_HEAT_COOL_ADDRESS): cv.string,
+        vol.Optional(CONF_HEAT_COOL_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS): cv.string,
         vol.Optional(CONF_OPERATION_MODE_NIGHT_ADDRESS): cv.string,
         vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
@@ -171,6 +175,12 @@ def async_add_entities_config(hass, config, async_add_entities):
         ),
         group_address_operation_mode_standby=config.get(
             CONF_OPERATION_MODE_STANDBY_ADDRESS
+        ),
+        group_address_heat_cool=config.get(
+            CONF_HEAT_COOL_ADDRESS
+        ),
+        group_address_heat_cool_state=config.get(
+            CONF_HEAT_COOL_STATE_ADDRESS
         ),
         operation_modes=config.get(CONF_OPERATION_MODES),
     )

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -1,0 +1,208 @@
+"""Unit test for RemoteValueClimateMode objects."""
+import asyncio
+import unittest
+
+from xknx import XKNX
+from xknx.dpt import DPTArray, DPTBinary, HVACOperationMode
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.remote_value import (
+    RemoteValueBinaryHeatCool, RemoteValueBinaryOperationMode,
+    RemoteValueClimateMode)
+from xknx.telegram import GroupAddress, Telegram
+
+
+class TestRemoteValueDptValue1Ucount(unittest.TestCase):
+    """Test class for RemoteValueDptValue1Ucount objects."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self.loop)
+
+    def tearDown(self):
+        """Tear down test class."""
+        self.loop.close()
+
+    def test_to_knx_operation_mode(self):
+        """Test to_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        self.assertEqual(remote_value.to_knx(HVACOperationMode.COMFORT), DPTArray((0x01, )))
+
+    def test_to_knx_binary(self):
+        """Test to_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            operation_mode=HVACOperationMode.COMFORT)
+        self.assertEqual(remote_value.to_knx(HVACOperationMode.COMFORT), DPTBinary(True))
+        self.assertEqual(remote_value.to_knx(HVACOperationMode.NIGHT), DPTBinary(False))
+
+    def test_to_knx_heat_cool(self):
+        """Test to_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryHeatCool(
+            xknx,
+            operation_mode=HVACOperationMode.HEAT)
+        self.assertEqual(remote_value.to_knx(HVACOperationMode.HEAT), DPTBinary(True))
+        self.assertEqual(remote_value.to_knx(HVACOperationMode.COOL), DPTBinary(False))
+
+    def test_from_knx_operation_mode(self):
+        """Test from_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        self.assertEqual(remote_value.from_knx(DPTArray((0x02, ))), HVACOperationMode.STANDBY)
+
+    def test_from_knx_binary(self):
+        """Test from_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            operation_mode=HVACOperationMode.COMFORT)
+        self.assertEqual(remote_value.from_knx(DPTBinary(True)), HVACOperationMode.COMFORT)
+        self.assertEqual(remote_value.from_knx(DPTBinary(False)), None)
+
+    def test_from_knx_heat_cool(self):
+        """Test from_knx function with normal operation."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryHeatCool(
+            xknx,
+            operation_mode=HVACOperationMode.HEAT)
+        self.assertEqual(remote_value.from_knx(DPTBinary(True)), HVACOperationMode.HEAT)
+        self.assertEqual(remote_value.from_knx(DPTBinary(False)), HVACOperationMode.COOL)
+
+    def test_to_knx_error_operation_mode(self):
+        """Test to_knx function with wrong parameter."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx(256)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx("256")
+
+    def test_to_knx_error_binary(self):
+        """Test to_knx function with wrong parameter."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            operation_mode=HVACOperationMode.NIGHT)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx(256)
+        with self.assertRaises(ConversionError):
+            remote_value.to_knx(True)
+
+    def test_set_operation_mode(self):
+        """Test setting value."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(HVACOperationMode.NIGHT)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTArray((0x03, ))))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(HVACOperationMode.FROST_PROTECTION)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTArray((0x04, ))))
+
+    def test_set_binary(self):
+        """Test setting value."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            operation_mode=HVACOperationMode.STANDBY)
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(HVACOperationMode.STANDBY)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTBinary(True)))
+        self.loop.run_until_complete(asyncio.Task(remote_value.set(HVACOperationMode.FROST_PROTECTION)))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                GroupAddress('1/2/3'),
+                payload=DPTBinary(False)))
+
+    def test_process_operation_mode(self):
+        """Test process telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        telegram = Telegram(
+            group_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x00, )))
+        self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        self.assertEqual(remote_value.value, HVACOperationMode.AUTO)
+
+    def test_process_binary(self):
+        """Test process telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            operation_mode=HVACOperationMode.FROST_PROTECTION)
+        telegram = Telegram(
+            group_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(True))
+        self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        self.assertEqual(remote_value.value, HVACOperationMode.FROST_PROTECTION)
+
+    def test_to_process_error_operation_mode(self):
+        """Test process errornous telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueClimateMode(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE)
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x64, 0x65, )))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+
+    def test_to_process_error_heat_cool(self):
+        """Test process errornous telegram."""
+        xknx = XKNX(loop=self.loop)
+        remote_value = RemoteValueBinaryHeatCool(
+            xknx,
+            group_address=GroupAddress("1/2/3"),
+            operation_mode=HVACOperationMode.COOL)
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x01, )))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))
+        with self.assertRaises(CouldNotParseTelegram):
+            telegram = Telegram(
+                group_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x64, 0x65, )))
+            self.loop.run_until_complete(asyncio.Task(remote_value.process(telegram)))

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -6,7 +6,8 @@ Climate modes can be 'auto', 'comfort', 'standby', 'economy' or 'protection'.
 from xknx.dpt import HVACOperationMode
 from xknx.exceptions import DeviceIllegalValue
 from xknx.remote_value import (
-    RemoteValueClimateBinaryMode, RemoteValueClimateMode)
+    RemoteValueBinaryHeatCool, RemoteValueBinaryOperationMode,
+    RemoteValueClimateMode)
 
 from .device import Device
 
@@ -29,6 +30,8 @@ class ClimateMode(Device):
                  group_address_controller_status_state=None,
                  group_address_controller_mode=None,
                  group_address_controller_mode_state=None,
+                 group_address_heat_cool=None,
+                 group_address_heat_cool_state=None,
                  operation_modes=None,
                  device_updated_cb=None):
         """Initialize ClimateMode class."""
@@ -63,7 +66,7 @@ class ClimateMode(Device):
             climate_mode_type=RemoteValueClimateMode.ClimateModeType.CONTROLLER_STATUS,
             after_update_cb=None)
 
-        self.remote_value_operation_mode_comfort = RemoteValueClimateBinaryMode(
+        self.remote_value_operation_mode_comfort = RemoteValueBinaryOperationMode(
             xknx,
             group_address=group_address_operation_mode_comfort,
             group_address_state=group_address_operation_mode_comfort,
@@ -72,7 +75,7 @@ class ClimateMode(Device):
             feature_name="Operation mode Comfort",
             operation_mode=HVACOperationMode.COMFORT,
             after_update_cb=None)
-        self.remote_value_operation_mode_standby = RemoteValueClimateBinaryMode(
+        self.remote_value_operation_mode_standby = RemoteValueBinaryOperationMode(
             xknx,
             group_address=group_address_operation_mode_standby,
             group_address_state=group_address_operation_mode_standby,
@@ -81,7 +84,7 @@ class ClimateMode(Device):
             feature_name="Operation mode Standby",
             operation_mode=HVACOperationMode.STANDBY,
             after_update_cb=None)
-        self.remote_value_operation_mode_night = RemoteValueClimateBinaryMode(
+        self.remote_value_operation_mode_night = RemoteValueBinaryOperationMode(
             xknx,
             group_address=group_address_operation_mode_night,
             group_address_state=group_address_operation_mode_night,
@@ -90,7 +93,7 @@ class ClimateMode(Device):
             feature_name="Operation mode Night",
             operation_mode=HVACOperationMode.NIGHT,
             after_update_cb=None)
-        self.remote_value_operation_mode_protection = RemoteValueClimateBinaryMode(
+        self.remote_value_operation_mode_protection = RemoteValueBinaryOperationMode(
             xknx,
             group_address=group_address_operation_mode_protection,
             group_address_state=group_address_operation_mode_protection,
@@ -98,6 +101,15 @@ class ClimateMode(Device):
             device_name=name,
             feature_name="Operation mode Protection",
             operation_mode=HVACOperationMode.FROST_PROTECTION,
+            after_update_cb=None)
+        self.remote_value_heat_cool = RemoteValueBinaryHeatCool(
+            xknx,
+            group_address=group_address_heat_cool,
+            group_address_state=group_address_heat_cool_state,
+            sync_state=True,
+            device_name=name,
+            feature_name="Heat/Cool",
+            operation_mode=HVACOperationMode.HEAT,
             after_update_cb=None)
 
         self.operation_mode = HVACOperationMode.STANDBY
@@ -122,7 +134,9 @@ class ClimateMode(Device):
             group_address_controller_status is not None or \
             group_address_controller_status_state is not None or \
             group_address_controller_mode is not None or \
-            group_address_controller_mode_state is not None
+            group_address_controller_mode_state is not None or \
+            group_address_heat_cool is not None or \
+            group_address_heat_cool_state is not None
 
     @classmethod
     def from_config(cls, xknx, name, config):
@@ -138,6 +152,8 @@ class ClimateMode(Device):
         group_address_controller_status_state = config.get('group_address_controller_status_state')
         group_address_controller_mode = config.get('group_address_controller_mode')
         group_address_controller_mode_state = config.get('group_address_controller_mode_state')
+        group_address_heat_cool = config.get('group_address_heat_cool')
+        group_address_heat_cool_state = config.get('group_address_heat_cool_state')
 
         return cls(xknx,
                    name,
@@ -150,7 +166,9 @@ class ClimateMode(Device):
                    group_address_controller_status=group_address_controller_status,
                    group_address_controller_status_state=group_address_controller_status_state,
                    group_address_controller_mode=group_address_controller_mode,
-                   group_address_controller_mode_state=group_address_controller_mode_state)
+                   group_address_controller_mode_state=group_address_controller_mode_state,
+                   group_address_heat_cool=group_address_heat_cool,
+                   group_address_heat_cool_state=group_address_heat_cool_state)
 
     def _iter_remote_values(self):
         """Iterate climate mode RemoteValue classes."""
@@ -160,7 +178,8 @@ class ClimateMode(Device):
                     self.remote_value_operation_mode_comfort,
                     self.remote_value_operation_mode_night,
                     self.remote_value_operation_mode_protection,
-                    self.remote_value_operation_mode_standby)
+                    self.remote_value_operation_mode_standby,
+                    self.remote_value_heat_cool)
 
     async def _set_internal_operation_mode(self, operation_mode):
         """Set internal value of operation mode. Call hooks if operation mode was changed."""

--- a/xknx/remote_value/__init__.py
+++ b/xknx/remote_value/__init__.py
@@ -2,7 +2,7 @@
 # flake8: noqa
 from .remote_value import RemoteValue
 from .remote_value_1count import RemoteValue1Count
-from .remote_value_climate_mode import RemoteValueClimateBinaryMode, RemoteValueClimateMode
+from .remote_value_climate_mode import RemoteValueBinaryHeatCool, RemoteValueBinaryOperationMode, RemoteValueClimateMode
 from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_color_rgbw import RemoteValueColorRGBW
 from .remote_value_datetime import RemoteValueDateTime


### PR DESCRIPTION
This adds support for binary heating cooling mode

Heating mode defaults to DPT1 value 1
Cooling mode defaults to DPT1 value 0
as used by Gira, Jung and MDT actuators.

closes #307 