### PR TITLE
HA knx.send: add `type` attribute

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 
 ### New Features
 
+- HA integration: `knx.send` service takes `type` attribute to allow sending DPT encoded values like `sensor`
+- HA integration: `sensor` and `expose` accept int and float values for `type` (parsed as DPT numbers)
 - new StateUpdater: Devices `sync_state` can be set to `init` to just initialize state on startup, `expire [minutes]` to read the state from the KNX bus when it was not updated for [minutes] or `every [minutes]` to update it regularly every [minutes]
 - Sensor and ExposeSensor now also accepts `value_type` of int (generic DPT) or float (specific DPT) if implemented.
 - Added config option ignore_internal_state in binary sensors (@andreasnanko #267)

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 from xknx import XKNX
 from xknx.devices import ActionCallback, DateTime, ExposeSensor
-from xknx.dpt import DPTArray, DPTBinary
+from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.exceptions import XKNXException
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
 from xknx.telegram import AddressFilter, GroupAddress, Telegram
@@ -47,6 +47,7 @@ CONF_XKNX_EXPOSE_ADDRESS = "address"
 SERVICE_XKNX_SEND = "send"
 SERVICE_XKNX_ATTR_ADDRESS = "address"
 SERVICE_XKNX_ATTR_PAYLOAD = "payload"
+SERVICE_XKNX_ATTR_TYPE = "type"
 
 ATTR_DISCOVER_DEVICES = "devices"
 
@@ -62,7 +63,9 @@ ROUTING_SCHEMA = vol.Schema({vol.Optional(CONF_XKNX_LOCAL_IP): cv.string})
 
 EXPOSE_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_XKNX_EXPOSE_TYPE): cv.string,
+        vol.Required(CONF_XKNX_EXPOSE_TYPE): vol.Any(
+            int, float, str
+        ),
         vol.Optional(CONF_ENTITY_ID): cv.entity_id,
         vol.Optional(CONF_XKNX_EXPOSE_ATTRIBUTE): cv.string,
         vol.Optional(CONF_XKNX_EXPOSE_DEFAULT): cv.match_all,
@@ -97,6 +100,9 @@ SERVICE_XKNX_SEND_SCHEMA = vol.Schema(
         vol.Required(SERVICE_XKNX_ATTR_ADDRESS): cv.string,
         vol.Required(SERVICE_XKNX_ATTR_PAYLOAD): vol.Any(
             cv.positive_int, [cv.positive_int]
+        ),
+        vol.Optional(SERVICE_XKNX_ATTR_TYPE): vol.Any(
+            int, float, str
         ),
     }
 )
@@ -286,9 +292,17 @@ class KNXModule:
         """Service for sending an arbitrary KNX message to the KNX bus."""
         attr_payload = call.data.get(SERVICE_XKNX_ATTR_PAYLOAD)
         attr_address = call.data.get(SERVICE_XKNX_ATTR_ADDRESS)
+        attr_type = call.data.get(SERVICE_XKNX_ATTR_TYPE)
 
         def calculate_payload(attr_payload):
             """Calculate payload depending on type of attribute."""
+            if attr_type:
+                try:
+                    transcoder = DPTBase.parse_transcoder(attr_type)
+                    return DPTArray(transcoder.to_knx(attr_payload))
+                except AttributeError as ex:
+                    _LOGGER.error("Invalid type for knx.send service: %s", attr_type)
+                    raise ex
             if isinstance(attr_payload, int):
                 return DPTBinary(attr_payload)
             return DPTArray(attr_payload)

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -20,7 +20,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_SYNC_STATE, default=True):
             vol.Any(vol.All(vol.Coerce(int), vol.Range(min=2, max=1440)), cv.boolean, cv.string),
         vol.Required(CONF_STATE_ADDRESS): cv.string,
-        vol.Required(CONF_TYPE): cv.string,
+        vol.Required(CONF_TYPE): vol.Any(
+            int, float, str
+        ),
     }
 )
 

--- a/home-assistant-plugin/custom_components/xknx/services.yaml
+++ b/home-assistant-plugin/custom_components/xknx/services.yaml
@@ -7,3 +7,6 @@ send:
     payload:
       description: "Payload to send to the bus. Integers are treated as DPT 1/2/3 payloads. For DPTs > 6 bits send a list. Each value represents 1 octet (0-255). Pad with 0 to DPT byte length."
       example: "[0, 4]"
+    type:
+      description: "Optional. If set, the payload will not be sent as raw bytes, but encoded as given DPT. Knx sensor types are valid values (see https://www.home-assistant.io/integrations/sensor.knx)."
+      example: "temperature"


### PR DESCRIPTION
Updates the HA service knx.send to take an additional attribute `type`. It'll use DPTBase.parse_transcoder() to select a DPT and encode the payload accordingly (like RemoteValueSensor). So we don't have to use tuples with raw payloads anymore.