### PR TITLE
rename DPTBase to DPTTranscoder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,7 @@
 
 ### Internals
 
-- Use new DPTTranscoder class as base for DPT implementations - use DPTBase as base class for DPTArray and DPTBinary
+- Use new DPTTranscoder class as base for DPT implementations - use _DPTPayload as base class for DPTArray and DPTBinary (for future type checking)
 - DPT classes can now be searched via value_type string or dpt number from any parent class (DPTTranscoder for all) to be used in Sensor
 - Use RemoteValue class in BinarySensor, DateTime and ClimateMode device
 - use time.struct_time for internal time and date representation

--- a/changelog.md
+++ b/changelog.md
@@ -27,7 +27,8 @@
 
 ### Internals
 
-- DPT classes can now be searched via value_type string or dpt number from any parent class (DPTBase for all) to be used in Sensor
+- Use new DPTTranscoder class as base for DPT implementations - use DPTBase as base class for DPTArray and DPTBinary
+- DPT classes can now be searched via value_type string or dpt number from any parent class (DPTTranscoder for all) to be used in Sensor
 - Use RemoteValue class in BinarySensor, DateTime and ClimateMode device
 - use time.struct_time for internal time and date representation
 - use a regular Bool type for BinarySensor state representation

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -4,7 +4,7 @@ import logging
 import voluptuous as vol
 from xknx import XKNX
 from xknx.devices import ActionCallback, DateTime, ExposeSensor
-from xknx.dpt import DPTArray, DPTBase, DPTBinary
+from xknx.dpt import DPTArray, DPTBinary, DPTTranscoder
 from xknx.exceptions import XKNXException
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
 from xknx.telegram import AddressFilter, GroupAddress, Telegram
@@ -298,7 +298,7 @@ class KNXModule:
             """Calculate payload depending on type of attribute."""
             if attr_type:
                 try:
-                    transcoder = DPTBase.parse_transcoder(attr_type)
+                    transcoder = DPTTranscoder.parse_type(attr_type)
                     return DPTArray(transcoder.to_knx(attr_payload))
                 except AttributeError as ex:
                     _LOGGER.error("Invalid type for knx.send service: %s", attr_type)

--- a/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
+++ b/home-assistant-plugin/home-assistant.io/sensor_table_generator.py
@@ -1,6 +1,6 @@
 """Generate a markdown table that can be copied to home-assistant.io sensor.knx documentation."""
 try:
-    from xknx.dpt import DPTBase
+    from xknx.dpt import DPTTranscoder
 except ModuleNotFoundError:
     exit("Add the `xknx` directory to pythons path via `export PYTHONPATH=$HOME/directory/to/xknx`")
 
@@ -62,7 +62,7 @@ class Row():
 class DPTRow(Row):
     """A row holding information for a DPT."""
 
-    def __init__(self, dpt_class: DPTBase):
+    def __init__(self, dpt_class: DPTTranscoder):
         dpt_range = ""
         if hasattr(dpt_class, "value_min") and hasattr(dpt_class, "value_max"):
             dpt_range = "%s ... %s" % (dpt_class.value_min, dpt_class.value_max)
@@ -73,7 +73,7 @@ class DPTRow(Row):
                          dpt_size=str(dpt_class.payload_length),
                          dpt_range=dpt_range)
 
-    def _get_dpt_number_from_docstring(self, dpt_class: DPTBase):
+    def _get_dpt_number_from_docstring(self, dpt_class: DPTTranscoder):
         """Extract dpt number from class docstring."""
         docstring = dpt_class.__doc__
         try:
@@ -123,8 +123,8 @@ def table_delimiter():
 def print_table():
     """Read the values and print the table to stdout."""
     rows = []
-    for dpt in DPTBase.__recursive_subclasses__():
-        if dpt.has_distinct_value_type():
+    for dpt in DPTTranscoder.__recursive_subclasses__():
+        if dpt._has_distinct_value_type():
             rows.append(DPTRow(dpt_class=dpt))
 
     rows.sort(key=lambda row: row.dpt_number_int())

--- a/test/dpt_tests/dpt_test.py
+++ b/test/dpt_tests/dpt_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX binary/integer objects."""
 import unittest
 
-from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTComparator
+from xknx.dpt import DPTArray, DPTBinary, DPTComparator, DPTTranscoder
 from xknx.exceptions import ConversionError
 
 
@@ -80,12 +80,12 @@ class TestDPT(unittest.TestCase):
             DPTComparator.compare("bla", DPTBinary(0))
 
 
-class TestDPTBase(unittest.TestCase):
+class TestDPTTranscoder(unittest.TestCase):
     """Test class for transcoder base object."""
 
     def test_dpt_subclasses_definition_types(self):
-        """Test value_type and dpt_*_number values for correct type in subclasses of DPTBase."""
-        for dpt in DPTBase.__recursive_subclasses__():
+        """Test value_type and dpt_*_number values for correct type in subclasses of DPTTranscoder."""
+        for dpt in DPTTranscoder.__recursive_subclasses__():
             if hasattr(dpt, 'value_type'):
                 self.assertTrue(isinstance(dpt.value_type, str),
                                 msg="Wrong type for value_type in %s - str expected" % dpt)
@@ -97,25 +97,25 @@ class TestDPTBase(unittest.TestCase):
                                 msg="Wrong type for dpt_sub_number in %s - int or `None` expected" % dpt)
 
     def test_dpt_subclasses_no_duplicate_value_types(self):
-        """Test for duplicate value_type values in subclasses of DPTBase."""
+        """Test for duplicate value_type values in subclasses of DPTTranscoder."""
         value_types = []
-        for dpt in DPTBase.__recursive_subclasses__():
+        for dpt in DPTTranscoder.__recursive_subclasses__():
             if hasattr(dpt, 'value_type'):
                 value_types.append(dpt.value_type)
         self.assertCountEqual(value_types,
                               set(value_types))
 
     def test_dpt_subclasses_have_both_dpt_number_attributes(self):
-        """Test DPTBase subclasses for having both dpt number attributes set."""
-        for dpt in DPTBase.__recursive_subclasses__():
+        """Test DPTTranscoder subclasses for having both dpt number attributes set."""
+        for dpt in DPTTranscoder.__recursive_subclasses__():
             if hasattr(dpt, 'dpt_main_number'):
                 self.assertTrue(hasattr(dpt, 'dpt_sub_number'),
                                 "No dpt_sub_number in %s" % dpt)
 
     def test_dpt_subclasses_no_duplicate_dpt_number(self):
-        """Test for duplicate value_type values in subclasses of DPTBase."""
+        """Test for duplicate value_type values in subclasses of DPTTranscoder."""
         dpt_tuples = []
-        for dpt in DPTBase.__recursive_subclasses__():
+        for dpt in DPTTranscoder.__recursive_subclasses__():
             if hasattr(dpt, 'dpt_main_number') and hasattr(dpt, 'dpt_sub_number'):
                 dpt_tuples.append((dpt.dpt_main_number, dpt.dpt_sub_number))
         self.assertCountEqual(dpt_tuples,
@@ -123,13 +123,13 @@ class TestDPTBase(unittest.TestCase):
 
     def test_dpt_alternative_notations(self):
         """Test the parser for accepting alternateive notations for the same DPT class."""
-        dpt1 = DPTBase.parse_transcoder("2byte_unsigned")
-        dpt2 = DPTBase.parse_transcoder(7)
-        dpt3 = DPTBase.parse_transcoder("DPT-7")
+        dpt1 = DPTTranscoder.parse_type("2byte_unsigned")
+        dpt2 = DPTTranscoder.parse_type(7)
+        dpt3 = DPTTranscoder.parse_type("DPT-7")
         self.assertEqual(dpt1, dpt2)
         self.assertEqual(dpt2, dpt3)
-        dpt4 = DPTBase.parse_transcoder("temperature")
-        dpt5 = DPTBase.parse_transcoder(9.001)
-        dpt6 = DPTBase.parse_transcoder("9.001")
+        dpt4 = DPTTranscoder.parse_type("temperature")
+        dpt5 = DPTTranscoder.parse_type(9.001)
+        dpt6 = DPTTranscoder.parse_type("9.001")
         self.assertEqual(dpt4, dpt5)
         self.assertEqual(dpt5, dpt6)

--- a/test/dpt_tests/dpt_test.py
+++ b/test/dpt_tests/dpt_test.py
@@ -128,8 +128,16 @@ class TestDPTTranscoder(unittest.TestCase):
         dpt3 = DPTTranscoder.parse_type("DPT-7")
         self.assertEqual(dpt1, dpt2)
         self.assertEqual(dpt2, dpt3)
+
         dpt4 = DPTTranscoder.parse_type("temperature")
         dpt5 = DPTTranscoder.parse_type(9.001)
         dpt6 = DPTTranscoder.parse_type("9.001")
         self.assertEqual(dpt4, dpt5)
         self.assertEqual(dpt5, dpt6)
+
+    def test_dpt_not_implemented(self):
+        """Test the parser for processing wrong dpt values."""
+        self.assertIsNone(DPTTranscoder.parse_type("unknown"))
+        self.assertIsNone(DPTTranscoder.parse_type(0))
+        self.assertIsNone(DPTTranscoder.parse_type(5.99999))
+        self.assertIsNone(DPTTranscoder.parse_type(["list"]))

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -3,7 +3,7 @@ import asyncio
 import unittest
 
 from xknx import XKNX
-from xknx.dpt import DPTBase
+from xknx.dpt import DPTTranscoder
 from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueSensor
 
@@ -28,5 +28,5 @@ class TestRemoteValueSensor(unittest.TestCase):
 
     def test_payload_length_defined(self):
         """Test if all members of DPTMAP implement payload_length."""
-        for dpt_class in DPTBase.__recursive_subclasses__():
+        for dpt_class in DPTTranscoder.__recursive_subclasses__():
             self.assertTrue(isinstance(dpt_class.payload_length, int))

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -5,11 +5,12 @@ Module for encoding and decoding KNX datatypes.
 * Derived KNX Values like Scaling, Temperature
 """
 # flake8: noqa
-from .dpt import DPTArray, DPTBase, DPTBinary, DPTComparator
+from .dpt import DPTArray, DPTBinary, DPTComparator, DPTTranscoder
 from .dpt_1byte_signed import (
     DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count)
 from .dpt_1byte_uint import (
-    DPTPercentU8, DPTDecimalFactor, DPTSceneNumber, DPTTariff, DPTValue1ByteUnsigned, DPTValue1Ucount)
+    DPTDecimalFactor, DPTPercentU8, DPTSceneNumber, DPTTariff,
+    DPTValue1ByteUnsigned, DPTValue1Ucount)
 from .dpt_2byte_float import (
     DPT2ByteFloat, DPTCurrent, DPTEnthalpy, DPTHumidity, DPTKelvinPerPercent,
     DPTLux, DPTPartsPerMillion, DPTPower2Byte, DPTPowerDensity,
@@ -53,7 +54,8 @@ from .dpt_4byte_int import (
     DPTValue4Count)
 from .dpt_date import DPTDate
 from .dpt_datetime import DPTDateTime
-from .dpt_hvac_mode import DPTHVACContrMode, DPTControllerStatus, DPTHVACMode, HVACOperationMode
+from .dpt_hvac_mode import (
+    DPTControllerStatus, DPTHVACContrMode, DPTHVACMode, HVACOperationMode)
 from .dpt_scaling import DPTAngle, DPTScaling
 from .dpt_string import DPTString
 from .dpt_time import DPTTime

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -119,8 +119,8 @@ class DPTTranscoder:
 
 class _DPTPayload():
     """Base class for telegram payloads."""
-    # pylint: disable=too-few-public-methods
 
+    # pylint: disable=too-few-public-methods
     def __eq__(self, other):
         """Equal operator."""
         return DPTComparator.compare(self, other)

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -117,7 +117,16 @@ class DPTTranscoder:
         return None
 
 
-class DPTBinary():
+class _DPTPayload():
+    """Base class for telegram payloads."""
+    # pylint: disable=too-few-public-methods
+
+    def __eq__(self, other):
+        """Equal operator."""
+        return DPTComparator.compare(self, other)
+
+
+class DPTBinary(_DPTPayload):
     """The DPTBinary is a base class for all datatypes encoded directly into the last 6 bit of the APCI (mostly integer)."""
 
     # pylint: disable=too-few-public-methods
@@ -135,16 +144,12 @@ class DPTBinary():
 
         self.value = value
 
-    def __eq__(self, other):
-        """Equal operator."""
-        return DPTComparator.compare(self, other)
-
     def __str__(self):
         """Return object as readable string."""
         return '<DPTBinary value="{0}" />'.format(self.value)
 
 
-class DPTArray():
+class DPTArray(_DPTPayload):
     """The DPTArray is a base class for all datatypes appended to the KNX telegram."""
 
     # pylint: disable=too-few-public-methods
@@ -158,10 +163,6 @@ class DPTArray():
             self.value = value
         else:
             raise TypeError()
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return DPTComparator.compare(self, other)
 
     def __str__(self):
         """Return object as readable string."""

--- a/xknx/dpt/dpt_1byte_signed.py
+++ b/xknx/dpt/dpt_1byte_signed.py
@@ -2,10 +2,10 @@
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTSignedRelativeValue(DPTBase):
+class DPTSignedRelativeValue(DPTTranscoder):
     """
     Abstraction for KNX 1 Byte "1-octet Signed Relative Value".
 

--- a/xknx/dpt/dpt_1byte_uint.py
+++ b/xknx/dpt/dpt_1byte_uint.py
@@ -1,10 +1,10 @@
 """Implementation of Basic KNX DPT_1_Ucount Values."""
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTValue1ByteUnsigned(DPTBase):
+class DPTValue1ByteUnsigned(DPTTranscoder):
     """
     Abstraction for KNX 1 Octet.
 

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -6,10 +6,10 @@ They correspond to the the following KDN DPT 9 class.
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPT2ByteFloat(DPTBase):
+class DPT2ByteFloat(DPTTranscoder):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -9,10 +9,10 @@ import struct
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPT2ByteSigned(DPTBase):
+class DPT2ByteSigned(DPTTranscoder):
     """
     Abstraction for KNX 2 Byte signed values.
 

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -2,10 +2,10 @@
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPT2ByteUnsigned(DPTBase):
+class DPT2ByteUnsigned(DPTTranscoder):
     """
     Abstraction for KNX 2 Byte "2-octet unsigned value".
 

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -8,10 +8,10 @@ import struct
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPT4ByteFloat(DPTBase):
+class DPT4ByteFloat(DPTTranscoder):
     """
     Abstraction for KNX 4 Octet Floating Point Numbers, with a maximum usable range as specified in IEEE 754.
 

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -10,10 +10,10 @@ import struct
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPT4ByteUnsigned(DPTBase):
+class DPT4ByteUnsigned(DPTTranscoder):
     """
     Abstraction for KNX 4 Byte "32-bit unsigned".
 

--- a/xknx/dpt/dpt_date.py
+++ b/xknx/dpt/dpt_date.py
@@ -4,10 +4,10 @@ import time
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTDate(DPTBase):
+class DPTDate(DPTTranscoder):
     """Abstraction for KNX 3 octet date (DPT 11.001)."""
 
     payload_length = 3

--- a/xknx/dpt/dpt_datetime.py
+++ b/xknx/dpt/dpt_datetime.py
@@ -4,10 +4,10 @@ import time
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTDateTime(DPTBase):
+class DPTDateTime(DPTTranscoder):
     """Abstraction for KNX 8 octet datetime (DPT 19.001)."""
 
     payload_length = 8

--- a/xknx/dpt/dpt_hvac_mode.py
+++ b/xknx/dpt/dpt_hvac_mode.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from xknx.exceptions import ConversionError, CouldNotParseKNXIP
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
 class HVACOperationMode(Enum):
@@ -30,7 +30,7 @@ class HVACOperationMode(Enum):
     NODEM = "NoDem"
 
 
-class _DPTClimateMode(DPTBase):
+class _DPTClimateMode(DPTTranscoder):
     """Base class for KNX Climate modes."""
 
     SUPPORTED_MODES = {}

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -1,10 +1,10 @@
 """Implementation of scaled KNX DPT_1_Ucount Values."""
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTScaling(DPTBase):
+class DPTScaling(DPTTranscoder):
     """
     Abstraction for KNX 1 Octet Percent.
 

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -1,10 +1,10 @@
 """Implementation of 3.17 Datapoint Types String."""
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTString(DPTBase):
+class DPTString(DPTTranscoder):
     """
     Abstraction for KNX 14 Octet ASCII String.
 

--- a/xknx/dpt/dpt_time.py
+++ b/xknx/dpt/dpt_time.py
@@ -4,10 +4,10 @@ import time
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTTranscoder
 
 
-class DPTTime(DPTBase):
+class DPTTime(DPTTranscoder):
     """
     Abstraction for KNX 3 Octet Time.
 

--- a/xknx/remote_value/__init__.py
+++ b/xknx/remote_value/__init__.py
@@ -2,7 +2,9 @@
 # flake8: noqa
 from .remote_value import RemoteValue
 from .remote_value_1count import RemoteValue1Count
-from .remote_value_climate_mode import RemoteValueBinaryHeatCool, RemoteValueBinaryOperationMode, RemoteValueClimateMode
+from .remote_value_climate_mode import (
+    RemoteValueBinaryHeatCool, RemoteValueBinaryOperationMode,
+    RemoteValueClimateMode)
 from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_color_rgbw import RemoteValueColorRGBW
 from .remote_value_datetime import RemoteValueDateTime

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -4,7 +4,7 @@ Module for managing a remote value typically used within a sensor.
 The module maps a given value_type to a DPT class and uses this class
 for serialization and deserialization of the KNX value.
 """
-from xknx.dpt import DPTArray, DPTBase
+from xknx.dpt import DPTArray, DPTTranscoder
 from xknx.exceptions import ConversionError
 
 from .remote_value import RemoteValue
@@ -24,7 +24,7 @@ class RemoteValueSensor(RemoteValue):
                  after_update_cb=None):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
-        _dpt_class = DPTBase.parse_transcoder(value_type)
+        _dpt_class = DPTTranscoder.parse_type(value_type)
         if _dpt_class is None:
             raise ConversionError("invalid value type", value_type=value_type, device_name=device_name)
         self.dpt_class = _dpt_class


### PR DESCRIPTION
- rename DPTBase to DPTTranscoder
- introduce _DPTPayload as base class for DPTBinary and DPTArray. For future type checking.

I think DPTTranscoder is more self-explanatory than DPTBase.

----------

I was also thinking of changing the DPTTranscoder.to_knx() return values to instances of _DPTPayload. 
Eg. DPTTemperature.to_knx(value) now returns a tuple of `(exponent, significand)`. This is packed into a DPTArray in the RemoteValue using it. I think it would be more straight forward to return a DPTArray from this function. I'm not sure how to do this with RemoteValues that use DPTBinary - maybe just add a .to_knx() and .from_knx() function to it.

What do you think??