### PR TITLE
Climate stepsize

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 
+- Climate: `setpoint_shift_step` renamed for `temperatur_step`. This attribute can be applied to all temperature modes. Default is `0.1`
 - Removed significant_bit attribute in BinarySensor
 - DateTime devices are initialized with sting for broadcast_type: "time", "date" or "datetime" instead of an Enum value
 - Removed `bind_to_multicast` option in ConnectionConfig and UDPClient

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Climate: `setpoint_shift_step` renamed for `temperatur_step`. This attribute can be applied to all temperature modes. Default is `0.1`
+- Climate: `setpoint_shift_step` renamed for `temperature_step`. This attribute can be applied to all temperature modes. Default is `0.1`
 - Removed significant_bit attribute in BinarySensor
 - DateTime devices are initialized with sting for broadcast_type: "time", "date" or "datetime" instead of an Enum value
 - Removed `bind_to_multicast` option in ConnectionConfig and UDPClient

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -63,9 +63,9 @@ groups:
 - **group_address_target_temperature_state** KNX address for reading the target temperature from the KNX bus. Used in for setpoint_shift calculations as base temperature.
 - **group_address_setpoint_shift** KNX address to set setpoint_shift (base temperature deviation).
 - **group_address_setpoint_shift_state** KNX address to read current setpoint_shift.
-- **setpoint_shift_step** Set the multiplier for setpoint_shift (DPT 6) calculations.
 - **setpoint_shift_max** Maximum value for setpoint_shift.
 - **setpoint_shift_min** Minimum value for setpoint_shift.
+- **temperature_step** Set the multiplier for setpoint_shift (DPT 6) calculations and the step size for HA UI-elements.
 - **group_address_on_off** KNX address for turning climate device on or off.
 - **group_address_on_off_state** KNX address for reading the on/off state.
 - **on_off_invert** Invert on/off.
@@ -113,7 +113,7 @@ climate = Climate(
         group_address_target_temperature_state='',
         group_address_setpoint_shift='',
         group_address_setpoint_shift_state='',
-        setpoint_shift_step=0.1,
+        temperature_step=0.1,
         setpoint_shift_max=6,
         setpoint_shift_min=-6,
         group_address_on_off='',

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -319,7 +319,7 @@ class KNXClimate(ClimateEntity):
             _operations.append(HVAC_MODE_HEAT)
             _operations.append(HVAC_MODE_OFF)
 
-        _modes = list(filter(None, _operations))
+        _modes = list(set(filter(None, _operations)))
         # default to ["heat"]
         return _modes if _modes else [HVAC_MODE_HEAT]
 

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -88,7 +88,6 @@ PLATFORM_SCHEMA = vol.All(
     cv.deprecated("setpoint_shift_step", replacement_key=CONF_TEMPERATURE_STEP),
     PLATFORM_SCHEMA.extend(
         {
-            # cv.deprecated("setpoint_shift_step", replacement_key=CONF_TEMPERATURE_STEP): cv.match_all,
             vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
             vol.Optional(CONF_SETPOINT_SHIFT_MODE, default=DEFAULT_SETPOINT_SHIFT_MODE): cv.enum(
                 SetpointShiftMode

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -30,10 +30,10 @@ from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
 CONF_SETPOINT_SHIFT_ADDRESS = "setpoint_shift_address"
 CONF_SETPOINT_SHIFT_STATE_ADDRESS = "setpoint_shift_state_address"
 CONF_SETPOINT_SHIFT_MODE = "setpoint_shift_mode"
-CONF_SETPOINT_SHIFT_STEP = "setpoint_shift_step"
 CONF_SETPOINT_SHIFT_MAX = "setpoint_shift_max"
 CONF_SETPOINT_SHIFT_MIN = "setpoint_shift_min"
 CONF_TEMPERATURE_ADDRESS = "temperature_address"
+CONF_TEMPERATURE_STEP = "temperature_step"
 CONF_TARGET_TEMPERATURE_ADDRESS = "target_temperature_address"
 CONF_TARGET_TEMPERATURE_STATE_ADDRESS = "target_temperature_state_address"
 CONF_OPERATION_MODE_ADDRESS = "operation_mode_address"
@@ -57,9 +57,9 @@ CONF_MAX_TEMP = "max_temp"
 
 DEFAULT_NAME = "KNX Climate"
 DEFAULT_SETPOINT_SHIFT_MODE = "DPT6010"
-DEFAULT_SETPOINT_SHIFT_STEP = 0.5
 DEFAULT_SETPOINT_SHIFT_MAX = 6
 DEFAULT_SETPOINT_SHIFT_MIN = -6
+DEFAULT_TEMPERATURE_STEP = 0.1
 DEFAULT_ON_OFF_INVERT = False
 # Map KNX operation modes to HA modes. This list might not be complete.
 OPERATION_MODES = {
@@ -91,14 +91,14 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             SetpointShiftMode
         ),
         vol.Optional(
-            CONF_SETPOINT_SHIFT_STEP, default=DEFAULT_SETPOINT_SHIFT_STEP
-        ): vol.All(float, vol.Range(min=0, max=2)),
-        vol.Optional(
             CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
         ): vol.All(int, vol.Range(min=0, max=32)),
         vol.Optional(
             CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN
         ): vol.All(int, vol.Range(min=-32, max=0)),
+        vol.Optional(
+            CONF_TEMPERATURE_STEP, default=DEFAULT_TEMPERATURE_STEP
+        ): vol.All(float, vol.Range(min=0, max=2)),
         vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
         vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
         vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
@@ -199,9 +199,9 @@ def async_add_entities_config(hass, config, async_add_entities):
             CONF_SETPOINT_SHIFT_STATE_ADDRESS
         ),
         setpoint_shift_mode=config[CONF_SETPOINT_SHIFT_MODE],
-        setpoint_shift_step=config[CONF_SETPOINT_SHIFT_STEP],
         setpoint_shift_max=config[CONF_SETPOINT_SHIFT_MAX],
         setpoint_shift_min=config[CONF_SETPOINT_SHIFT_MIN],
+        temperature_step=config[CONF_TEMPERATURE_STEP],
         group_address_on_off=config.get(CONF_ON_OFF_ADDRESS),
         group_address_on_off_state=config.get(CONF_ON_OFF_STATE_ADDRESS),
         min_temp=config.get(CONF_MIN_TEMP),

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -84,47 +84,51 @@ PRESET_MODES = {
 
 PRESET_MODES_INV = dict(reversed(item) for item in PRESET_MODES.items())
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_SETPOINT_SHIFT_MODE, default=DEFAULT_SETPOINT_SHIFT_MODE): cv.enum(
-            SetpointShiftMode
-        ),
-        vol.Optional(
-            CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
-        ): vol.All(int, vol.Range(min=0, max=32)),
-        vol.Optional(
-            CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN
-        ): vol.All(int, vol.Range(min=-32, max=0)),
-        vol.Optional(
-            CONF_TEMPERATURE_STEP, default=DEFAULT_TEMPERATURE_STEP
-        ): vol.All(float, vol.Range(min=0, max=2)),
-        vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
-        vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
-        vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
-        vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_STATUS_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_MODE_ADDRESS): cv.string,
-        vol.Optional(CONF_CONTROLLER_MODE_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_HEAT_COOL_ADDRESS): cv.string,
-        vol.Optional(CONF_HEAT_COOL_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_NIGHT_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
-        vol.Optional(CONF_OPERATION_MODE_STANDBY_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
-        vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
-        vol.Optional(CONF_OPERATION_MODES): vol.All(
-            cv.ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
-        ),
-        vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
-    }
+PLATFORM_SCHEMA = vol.All(
+    cv.deprecated("setpoint_shift_step", replacement_key=CONF_TEMPERATURE_STEP),
+    PLATFORM_SCHEMA.extend(
+        {
+            # cv.deprecated("setpoint_shift_step", replacement_key=CONF_TEMPERATURE_STEP): cv.match_all,
+            vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+            vol.Optional(CONF_SETPOINT_SHIFT_MODE, default=DEFAULT_SETPOINT_SHIFT_MODE): cv.enum(
+                SetpointShiftMode
+            ),
+            vol.Optional(
+                CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
+            ): vol.All(int, vol.Range(min=0, max=32)),
+            vol.Optional(
+                CONF_SETPOINT_SHIFT_MIN, default=DEFAULT_SETPOINT_SHIFT_MIN
+            ): vol.All(int, vol.Range(min=-32, max=0)),
+            vol.Optional(
+                CONF_TEMPERATURE_STEP, default=DEFAULT_TEMPERATURE_STEP
+            ): vol.All(float, vol.Range(min=0, max=2)),
+            vol.Required(CONF_TEMPERATURE_ADDRESS): cv.string,
+            vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): cv.string,
+            vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): cv.string,
+            vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_STATUS_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_MODE_ADDRESS): cv.string,
+            vol.Optional(CONF_CONTROLLER_MODE_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_HEAT_COOL_ADDRESS): cv.string,
+            vol.Optional(CONF_HEAT_COOL_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_FROST_PROTECTION_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_NIGHT_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_COMFORT_ADDRESS): cv.string,
+            vol.Optional(CONF_OPERATION_MODE_STANDBY_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_STATE_ADDRESS): cv.string,
+            vol.Optional(CONF_ON_OFF_INVERT, default=DEFAULT_ON_OFF_INVERT): cv.boolean,
+            vol.Optional(CONF_OPERATION_MODES): vol.All(
+                cv.ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
+            ),
+            vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
+            vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
+        }
+    )
 )
 
 

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -267,7 +267,7 @@ class TestConfig(unittest.TestCase):
                     group_address_target_temperature='1/7/4',
                     group_address_setpoint_shift='1/7/3',
                     group_address_setpoint_shift_state='1/7/14',
-                    setpoint_shift_step=0.1,
+                    temperature_step=0.1,
                     setpoint_shift_min=-10,
                     setpoint_shift_max=10,
                     device_updated_cb=TestConfig.xknx.devices.device_updated))

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -267,7 +267,7 @@ class TestConfig(unittest.TestCase):
                     group_address_target_temperature='1/7/4',
                     group_address_setpoint_shift='1/7/3',
                     group_address_setpoint_shift_state='1/7/14',
-                    temperature_step=0.1,
+                    temperature_step=0.5,
                     setpoint_shift_min=-10,
                     setpoint_shift_max=10,
                     device_updated_cb=TestConfig.xknx.devices.device_updated))

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -468,8 +468,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
+            # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(30)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -483,7 +483,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(8)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(40)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
@@ -494,7 +494,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(7)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(35)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(23.50))))
@@ -523,8 +523,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(2)))
+            # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(10)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -538,7 +538,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFD)))  # -3
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xF1)))  # -15
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(20.50))))
@@ -549,7 +549,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xFA)))  # -6
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(0xE2)))  # -30
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(19.00))))
@@ -573,7 +573,7 @@ class TestClimate(unittest.TestCase):
             'TestClimate',
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
-            setpoint_shift_step=0.1,
+            temperature_step=0.5,
             setpoint_shift_max=10,
             setpoint_shift_min=-10)
 
@@ -581,8 +581,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            # setpoint_shift_step is 0.1 -> payload = setpoint_shift * 10
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(30)))
+            # temperature_step is 0.5 -> payload = setpoint_shift * 2
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(6)))
 
         self.loop.run_until_complete(asyncio.Task(climate.target_temperature.set(23.00)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -594,7 +594,7 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(40)))
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(8)))
         self.assertEqual(
             xknx.telegrams.get_nowait(),
             Telegram(GroupAddress('1/2/2'), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))))
@@ -631,8 +631,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(2)))
+            # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(10)))
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.base_temperature, 20.00)
 
@@ -642,8 +642,8 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(xknx.telegrams.qsize(), 2)
         self.assertEqual(
             xknx.telegrams.get_nowait(),
-            # DEFAULT_SETPOINT_SHIFT_STEP is 0.5 -> payload = setpoint_shift * 2
-            Telegram(GroupAddress('1/2/3'), payload=DPTArray(4)))
+            # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
+            Telegram(GroupAddress('1/2/3'), payload=DPTArray(20)))
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.base_temperature, 20.00)
         self.assertEqual(climate.target_temperature.value, 22)
@@ -672,7 +672,7 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3')
         # default temperature_step for setpoint_shift
-        self.assertEqual(climate.temperature_step, 0.5)
+        self.assertEqual(climate.temperature_step, 0.1)
 
         climate = Climate(
             xknx,
@@ -680,7 +680,7 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature_state='1/2/1',
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
-            setpoint_shift_step=0.3)
+            temperature_step=0.3)
         self.assertEqual(climate.temperature_step, 0.3)
 
     #

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -75,7 +75,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_target_temperature='1/2/2',
             group_address_setpoint_shift='1/2/3',
             group_address_setpoint_shift_state='1/2/4',
-            setpoint_shift_step=0.1,
+            temperature_step=0.1,
             setpoint_shift_max=20,
             setpoint_shift_min=-20,
             group_address_on_off='1/2/14',
@@ -83,9 +83,9 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(climate),
             '<Climate name="Wohnzimmer" temperature="None/GroupAddress("1/2/1")/None/None" '
-            'target_temperature="GroupAddress("1/2/2")/None/None/None" '
+            'target_temperature="GroupAddress("1/2/2")/None/None/None" temperature_step="0.1" '
             'setpoint_shift="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" '
-            'setpoint_shift_step="0.1" setpoint_shift_max="20" setpoint_shift_min="-20" '
+            'setpoint_shift_max="20" setpoint_shift_min="-20" '
             'group_address_on_off="GroupAddress("1/2/14")/GroupAddress("1/2/15")/None/None" />')
 
     def test_climate_mode(self):

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -182,7 +182,7 @@ groups:
                 group_address_target_temperature: "1/7/4",
                 group_address_setpoint_shift: "1/7/3",
                 group_address_setpoint_shift_state: "1/7/14",
-                setpoint_shift_step: 0.1,
+                temperature_step: 0.5,
                 setpoint_shift_min: -10,
                 setpoint_shift_max: 10,
             }

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -23,7 +23,6 @@ class SetpointShiftMode(Enum):
 
 DEFAULT_SETPOINT_SHIFT_MAX = 6
 DEFAULT_SETPOINT_SHIFT_MIN = -6
-DEFAULT_SETPOINT_SHIFT_STEP = 0.5
 DEFAULT_TEMPERATURE_STEP = 0.1
 DEFAULT_SETPOINT_SHIFT_MODE = SetpointShiftMode.DPT6010
 
@@ -41,9 +40,9 @@ class Climate(Device):
                  group_address_setpoint_shift=None,
                  group_address_setpoint_shift_state=None,
                  setpoint_shift_mode=DEFAULT_SETPOINT_SHIFT_MODE,
-                 setpoint_shift_step=DEFAULT_SETPOINT_SHIFT_STEP,
                  setpoint_shift_max=DEFAULT_SETPOINT_SHIFT_MAX,
                  setpoint_shift_min=DEFAULT_SETPOINT_SHIFT_MIN,
+                 temperature_step=DEFAULT_TEMPERATURE_STEP,
                  group_address_on_off=None,
                  group_address_on_off_state=None,
                  on_off_invert=False,
@@ -64,9 +63,9 @@ class Climate(Device):
 
         self.min_temp = min_temp
         self.max_temp = max_temp
-        self.setpoint_shift_step = setpoint_shift_step
         self.setpoint_shift_min = setpoint_shift_min
         self.setpoint_shift_max = setpoint_shift_max
+        self.temperature_step = temperature_step
 
         self.temperature = RemoteValueTemp(
             xknx,
@@ -97,7 +96,7 @@ class Climate(Device):
                 group_address_setpoint_shift_state,
                 device_name=self.name,
                 after_update_cb=self.after_update,
-                setpoint_shift_step=setpoint_shift_step)
+                setpoint_shift_step=self.temperature_step)
 
         self.supports_on_off = \
             group_address_on_off is not None or \
@@ -136,12 +135,12 @@ class Climate(Device):
             config.get('group_address_setpoint_shift_state')
         setpoint_shift_mode = \
             config.get('setpoint_shift_mode', DEFAULT_SETPOINT_SHIFT_MODE)
-        setpoint_shift_step = \
-            config.get('setpoint_shift_step', DEFAULT_SETPOINT_SHIFT_STEP)
         setpoint_shift_max = \
             config.get('setpoint_shift_max', DEFAULT_SETPOINT_SHIFT_MAX)
         setpoint_shift_min = \
             config.get('setpoint_shift_min', DEFAULT_SETPOINT_SHIFT_MIN)
+        temperature_step = \
+            config.get('temperature_step', DEFAULT_TEMPERATURE_STEP)
         group_address_on_off = \
             config.get('group_address_on_off')
         group_address_on_off_state = \
@@ -166,9 +165,9 @@ class Climate(Device):
                    group_address_setpoint_shift=group_address_setpoint_shift,
                    group_address_setpoint_shift_state=group_address_setpoint_shift_state,
                    setpoint_shift_mode=setpoint_shift_mode,
-                   setpoint_shift_step=setpoint_shift_step,
                    setpoint_shift_max=setpoint_shift_max,
                    setpoint_shift_min=setpoint_shift_min,
+                   temperature_step=temperature_step,
                    group_address_on_off=group_address_on_off,
                    group_address_on_off_state=group_address_on_off_state,
                    on_off_invert=on_off_invert,
@@ -208,13 +207,6 @@ class Climate(Device):
         if self.target_temperature.value is None:
             return False
         return True
-
-    @property
-    def temperature_step(self):
-        """Return smallest possible temperature step."""
-        if self._setpoint_shift.initialized:
-            return self.setpoint_shift_step
-        return DEFAULT_TEMPERATURE_STEP
 
     async def set_target_temperature(self, target_temperature):
         """Send new target temperature or setpoint_shift to KNX bus."""
@@ -301,8 +293,8 @@ class Climate(Device):
         return '<Climate name="{0}" ' \
             'temperature="{1}" ' \
             'target_temperature="{2}" ' \
-            'setpoint_shift="{3}" ' \
-            'setpoint_shift_step="{4}" ' \
+            'temperature_step="{3}" ' \
+            'setpoint_shift="{4}" ' \
             'setpoint_shift_max="{5}" ' \
             'setpoint_shift_min="{6}" ' \
             'group_address_on_off="{7}" ' \
@@ -311,8 +303,8 @@ class Climate(Device):
                 self.name,
                 self.temperature.group_addr_str(),
                 self.target_temperature.group_addr_str(),
+                self.temperature_step,
                 self._setpoint_shift.group_addr_str(),
-                self._setpoint_shift.setpoint_shift_step,
                 self.setpoint_shift_max,
                 self.setpoint_shift_min,
                 self.on.group_addr_str())

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -15,7 +15,7 @@ class RemoteValueSetpointShift(RemoteValue1Count):
                  group_address_state=None,
                  device_name=None,
                  after_update_cb=None,
-                 setpoint_shift_step=0.5):
+                 setpoint_shift_step=0.1):
         """Initialize RemoteValueSetpointShift class."""
         # pylint: disable=too-many-arguments
         super().__init__(xknx,


### PR DESCRIPTION
- `setpoint_shift_step` renamed for `temperature_step`. This attribute can be applied to all temperature modes. Default is `0.1`
- HA integration: don't duplicate HEAT in operation modes when on_off is used

fixes https://github.com/home-assistant/core/issues/32180
fixes https://github.com/home-assistant/core/issues/30419