### PR TITLE
Don't process incoming L_Data.con confirmation frames

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 
 ### Bugfixes
 
+- Tunneling: don't process incoming L_Data.con confirmation frames. This avoids processing every outgoing telegram twice.
 - enable multicast on macOS and fix a bug where unknown cemi frames raise a TypeError on routing connections
 - BinarySensor: reset_after is now implemented as asyncio.Task to prevent blocking the loop
 - ClimateMode: binary climate modes should be fully functional now (sending, receiving and syncing)

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -6,7 +6,8 @@ Tunnels connect to KNX/IP devices directly via UDP and build a static UDP connec
 import asyncio
 
 from xknx.exceptions import XKNXException
-from xknx.knxip import KNXIPFrame, KNXIPServiceType, TunnellingRequest
+from xknx.knxip import (
+    CEMIMessageCode, KNXIPFrame, KNXIPServiceType, TunnellingRequest)
 from xknx.telegram import TelegramDirection
 
 from .connect import Connect
@@ -63,7 +64,10 @@ class Tunnel():
             self.xknx.logger.warning("Service not implemented: %s", knxipframe)
         else:
             self.send_ack(knxipframe.body.communication_channel_id, knxipframe.body.sequence_counter)
-            if knxipframe.body.cemi is not None:
+            # Don't handle invalid cemi frames (None) and only handle incoming L_DATA_IND frames.
+            # Ignore L_DATA_CON confirmation frames. L_DATA_REQ frames should only be outgoing.
+            if knxipframe.body.cemi is not None and \
+                    knxipframe.body.cemi.code is CEMIMessageCode.L_DATA_IND:
                 telegram = knxipframe.body.cemi.telegram
                 telegram.direction = TelegramDirection.INCOMING
                 if self.telegram_received_callback is not None:


### PR DESCRIPTION
Incoming L_Data.con frames get an ACK, but are not processed (and not checked in any way).

Quickfix for #323 