### PR TITLE
Adds the devices to the device list automatically after instantiation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@
 ### Internals
 
 - GatewayScanner: Passing None or an integer <= 0 to the `stop_on_found` parameter now causes the scanner to only stop once the timeout is reached (@jochembroekhoff #311)
+- Devices are now added automatically to the xknx.devices list after initialization
+
+### Bugfixes
+
+- Device: Fixes a bug (#339) introduced in 0.12.0 so that it is again possible to have multiple devices with the same name in the HA integration
 
 ## 0.12.0 New StateUpdater, improvements to the HA integrations and bug fixes 2020-08-14
 

--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -27,7 +27,6 @@ binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', devi
 
 ```python
 outlet = Switch(xknx, 'TestOutlet', group_address='1/2/3')
-xknx.devices.devices.append(outlet)
 
 binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='2/3/4')
 action_on = Action(
@@ -42,7 +41,6 @@ action_off = Action(
     target='TestOutlet',
     method='off')
 binarysensor.actions.append(action_off)
-xknx.devices.add(binarysensor)
 ```
 
 ## [](#header-2)Configuration via **xknx.yaml**

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -20,8 +20,6 @@ cover = Cover(xknx,
               travel_time_down=50,
               travel_time_up=60)
 
-xknx.devices.add(cover)
-
 # Accessing cover
 await xknx.devices['TestShutter'].set_up()
 ```

--- a/docs/light.md
+++ b/docs/light.md
@@ -23,7 +23,6 @@ light = Light(xknx,
               name='TestLight',
               group_address_switch='1/2/3',
               group_address_brightness='1/2/5')
-xknx.devices.add(light)
 
 # Accessing light
 await xknx.devices['TestLight'].set_on()

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -12,7 +12,6 @@ Switches are simple representations of binary actors. They mainly support switch
 
 ```python
 switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
-xknx.devices.add(switch)
 
 # Accessing switch
 await xknx.devices['TestOutlet'].set_on()

--- a/docs/time.md
+++ b/docs/time.md
@@ -17,7 +17,6 @@ time_device = DateTime(
     broadcast_type='TIME',
     localtime=True
 )
-xknx.devices.add(time_device)
 
 # Sending time to knx bus
 await xknx.devices['TimeTest'].sync()
@@ -52,7 +51,6 @@ from xknx.devices import DateTime
 async def main():
     xknx = XKNX()
     time = DateTime(xknx, 'TimeTest', group_address='1/2/3')
-    xknx.devices.add(time)
     print("Sending time to KNX bus every hour")
     await xknx.start(daemon_mode=True, state_updater=True)
     await xknx.stop()

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -75,7 +75,6 @@ Example:
 switch = Switch(xknx,
                 name='TestSwitch',
                 group_address='1/1/11')
-xknx.devices.add(switch)
 
 await xknx.devices['TestSwitch'].set_on()
 await xknx.devices['TestSwitch'].set_off()
@@ -121,7 +120,6 @@ async def main():
     switch = Switch(xknx,
                     name='TestSwitch',
                     group_address='1/1/11')
-    xknx.devices.add(switch)
 
     await xknx.start(daemon_mode=True)
 

--- a/examples/example_daemon.py
+++ b/examples/example_daemon.py
@@ -13,10 +13,9 @@ async def device_updated_cb(device):
 async def main():
     """Connect to KNX/IP device and listen if a switch was updated via KNX bus."""
     xknx = XKNX(device_updated_cb=device_updated_cb)
-    switch = Switch(xknx,
-                    name='TestOutlet',
-                    group_address='1/1/11')
-    xknx.devices.add(switch)
+    Switch(xknx,
+           name='TestOutlet',
+           group_address='1/1/11')
 
     # Wait until Ctrl-C was pressed
     await xknx.start(daemon_mode=True)

--- a/examples/example_datetime.py
+++ b/examples/example_datetime.py
@@ -8,8 +8,7 @@ from xknx.devices import DateTime
 async def main():
     """Connect to KNX/IP device and broadcast time."""
     xknx = XKNX()
-    datetime = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type="time")
-    xknx.devices.add(datetime)
+    DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type="time")
     print("Sending time to KNX bus every hour")
     await xknx.start(daemon_mode=True)
     await xknx.stop()

--- a/examples/example_devices.py
+++ b/examples/example_devices.py
@@ -9,15 +9,15 @@ async def main():
     """Add test Switch to devices storage and access it by name."""
     xknx = XKNX()
     await xknx.start()
-    switch = Switch(xknx,
-                    name='TestOutlet',
-                    group_address='1/1/11')
-    xknx.devices.add(switch)
+    Switch(xknx,
+           name='TestOutlet',
+           group_address='1/1/11')
 
     await xknx.devices["TestOutlet"].set_on()
     await asyncio.sleep(2)
     await xknx.devices["TestOutlet"].set_off()
     await xknx.stop()
+
 
 # pylint: disable=invalid-name
 loop = asyncio.get_event_loop()

--- a/examples/example_powermeter_mqtt.py
+++ b/examples/example_powermeter_mqtt.py
@@ -131,56 +131,45 @@ async def main():
     #  file that is loaded in on start.
 
     # Generic Types not specifically supported by XKNX
-    el_meter_reading_active_energy = Sensor(
+    Sensor(
         xknx, 'EL-T-O_MeterReading_ActiveEnergy', group_address_state='5/6/11', value_type="DPT-13")
-    xknx.devices.add(el_meter_reading_active_energy)
-    el_meter_reading_reactive_energy = Sensor(
+    Sensor(
         xknx, 'EL-T-O_MeterReading_ReactiveEnergy', group_address_state='5/6/16', value_type="DPT-13")
-    xknx.devices.add(el_meter_reading_reactive_energy)
 
     # Active Power
-    el_total_active_power = Sensor(
+    Sensor(
         xknx, 'EL-T-O_TotalActivePower', group_address_state='5/6/24', value_type="power")
-    xknx.devices.add(el_total_active_power)
-    el_active_power_l1 = Sensor(
+    Sensor(
         xknx, 'EL-T-O_ActivePower_L1', group_address_state='5/6/25', value_type="power")
-    xknx.devices.add(el_active_power_l1)
     # ...
 
     # Reactive Power
-    el_total_reactive_power = Sensor(
+    Sensor(
         xknx, 'EL-T-O_TotalReactivePower', group_address_state='5/6/28', value_type="power")
-    xknx.devices.add(el_total_reactive_power)
-    el_reactive_power_l1 = Sensor(
+    Sensor(
         xknx, 'EL-T-O_ReactivePower_L1', group_address_state='5/6/29', value_type="power")
-    xknx.devices.add(el_reactive_power_l1)
     # ...
 
     # Apparent Power
-    el_total_apparent_power = Sensor(
+    Sensor(
         xknx, 'EL-T-O_TotalReactivePower', group_address_state='5/6/32', value_type="power")
-    xknx.devices.add(el_total_apparent_power)
-    el_apparent_power_l1 = Sensor(
+    Sensor(
         xknx, 'EL-T-O_ApparentPower_L1', group_address_state='5/6/33', value_type="power")
-    xknx.devices.add(el_apparent_power_l1)
     # ...
 
     # Current
-    el_current_l1 = Sensor(
+    Sensor(
         xknx, 'EL-T-O_Current_L1', group_address_state='5/6/45', value_type="electric_current")
-    xknx.devices.add(el_current_l1)
     # ...
 
     # Voltage
-    el_voltage_l1 = Sensor(
+    Sensor(
         xknx, 'EL-T-O_Voltage_L1-N', group_address_state='5/6/48', value_type="electric_potential")
-    xknx.devices.add(el_voltage_l1)
     # ...
 
     # Frequency
-    el_frequency = Sensor(
+    Sensor(
         xknx, 'EL-T-O_Frequency', group_address_state='5/6/53', value_type="frequency")
-    xknx.devices.add(el_frequency)
 
     mqttc.connect(BROKER_ADDRESS, 8883, 60)
     mqttc.loop_start()

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .const import DATA_XKNX, DOMAIN, DeviceTypes
+from .const import DATA_XKNX, DOMAIN, SupportedPlatforms
 from .factory import create_knx_device
 from .schema import (
     BinarySensorSchema,
@@ -51,21 +51,10 @@ CONF_XKNX_STATE_UPDATER = "state_updater"
 CONF_XKNX_RATE_LIMIT = "rate_limit"
 CONF_XKNX_EXPOSE = "expose"
 
-CONF_XKNX_LIGHT = "light"
-CONF_XKNX_COVER = "cover"
-CONF_XKNX_BINARY_SENSOR = "binary_sensor"
-CONF_XKNX_SCENE = "scene"
-CONF_XKNX_SENSOR = "sensor"
-CONF_XKNX_SWITCH = "switch"
-CONF_XKNX_NOTIFY = "notify"
-CONF_XKNX_CLIMATE = "climate"
-
 SERVICE_XKNX_SEND = "send"
 SERVICE_XKNX_ATTR_ADDRESS = "address"
 SERVICE_XKNX_ATTR_PAYLOAD = "payload"
 SERVICE_XKNX_ATTR_TYPE = "type"
-
-ATTR_DISCOVER_DEVICES = "devices"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -89,28 +78,28 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Optional(CONF_XKNX_EXPOSE): vol.All(
                     cv.ensure_list, [ExposeSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_COVER): vol.All(
+                vol.Optional(SupportedPlatforms.cover.value): vol.All(
                     cv.ensure_list, [CoverSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_BINARY_SENSOR): vol.All(
+                vol.Optional(SupportedPlatforms.binary_sensor.value): vol.All(
                     cv.ensure_list, [BinarySensorSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_LIGHT): vol.All(
+                vol.Optional(SupportedPlatforms.light.value): vol.All(
                     cv.ensure_list, [LightSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_CLIMATE): vol.All(
+                vol.Optional(SupportedPlatforms.climate.value): vol.All(
                     cv.ensure_list, [ClimateSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_NOTIFY): vol.All(
+                vol.Optional(SupportedPlatforms.notify.value): vol.All(
                     cv.ensure_list, [NotifySchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_SWITCH): vol.All(
+                vol.Optional(SupportedPlatforms.switch.value): vol.All(
                     cv.ensure_list, [SwitchSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_SENSOR): vol.All(
+                vol.Optional(SupportedPlatforms.sensor.value): vol.All(
                     cv.ensure_list, [SensorSchema.SCHEMA]
                 ),
-                vol.Optional(CONF_XKNX_SCENE): vol.All(
+                vol.Optional(SupportedPlatforms.scene.value): vol.All(
                     cv.ensure_list, [SceneSchema.SCHEMA]
                 ),
             }
@@ -129,16 +118,16 @@ SERVICE_XKNX_SEND_SCHEMA = vol.Schema(
     }
 )
 
-KNX_CONFIG_PLATFORM_MAPPING = {
-    CONF_XKNX_COVER: DeviceTypes.cover,
-    CONF_XKNX_SWITCH: DeviceTypes.switch,
-    CONF_XKNX_LIGHT: DeviceTypes.light,
-    CONF_XKNX_SENSOR: DeviceTypes.sensor,
-    CONF_XKNX_NOTIFY: DeviceTypes.notify,
-    CONF_XKNX_SCENE: DeviceTypes.scene,
-    CONF_XKNX_BINARY_SENSOR: DeviceTypes.binary_sensor,
-    CONF_XKNX_CLIMATE: DeviceTypes.climate,
-}
+SUPPORTED_PLATFORMS = [
+    SupportedPlatforms.cover,
+    SupportedPlatforms.switch,
+    SupportedPlatforms.light,
+    SupportedPlatforms.sensor,
+    SupportedPlatforms.notify,
+    SupportedPlatforms.scene,
+    SupportedPlatforms.binary_sensor,
+    SupportedPlatforms.climate,
+]
 
 
 async def async_setup(hass, config):
@@ -153,31 +142,17 @@ async def async_setup(hass, config):
             f"Can't connect to KNX interface: <br><b>{ex}</b>", title="KNX"
         )
 
-    for platform_config, device_type in KNX_CONFIG_PLATFORM_MAPPING.items():
-        if platform_config in config[DOMAIN]:
-            for device_config in config[DOMAIN][platform_config]:
-                hass.data[DATA_XKNX].xknx.devices.add(
-                    create_knx_device(
-                        hass, device_type, hass.data[DATA_XKNX].xknx, device_config
-                    )
+    for platform in SUPPORTED_PLATFORMS:
+        if platform.value in config[DOMAIN]:
+            for device_config in config[DOMAIN][platform.value]:
+                create_knx_device(
+                    hass, platform, hass.data[DATA_XKNX].xknx, device_config
                 )
-
-    for component, discovery_type in (
-        ("switch", "Switch"),
-        ("climate", "Climate"),
-        ("cover", "Cover"),
-        ("light", "Light"),
-        ("sensor", "Sensor"),
-        ("binary_sensor", "BinarySensor"),
-        ("scene", "Scene"),
-        ("notify", "Notification"),
-    ):
-        found_devices = _get_devices(hass, discovery_type)
-        hass.async_create_task(
-            discovery.async_load_platform(
-                hass, component, DOMAIN, {ATTR_DISCOVER_DEVICES: found_devices}, config
+            hass.async_create_task(
+                discovery.async_load_platform(
+                    hass, platform.value, DOMAIN, {}, config
+                )
             )
-        )
 
     hass.services.async_register(
         DOMAIN,
@@ -187,19 +162,6 @@ async def async_setup(hass, config):
     )
 
     return True
-
-
-def _get_devices(hass, discovery_type):
-    """Get the KNX devices."""
-    return list(
-        map(
-            lambda device: device.name,
-            filter(
-                lambda device: type(device).__name__ == discovery_type,
-                hass.data[DATA_XKNX].xknx.devices,
-            ),
-        )
-    )
 
 
 class KNXModule:
@@ -375,7 +337,6 @@ class KNXExposeTime:
         self.device = DateTime(
             self.xknx, "Time", broadcast_type=broadcast_type, group_address=self.address
         )
-        self.xknx.devices.add(self.device)
 
 
 class KNXExposeSensor:
@@ -402,7 +363,6 @@ class KNXExposeSensor:
         self.device = ExposeSensor(
             self.xknx, name=_name, group_address=self.address, value_type=self.type,
         )
-        self.xknx.devices.add(self.device)
         async_track_state_change_event(
             self.hass, [self.entity_id], self._async_entity_changed
         )

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -4,22 +4,15 @@ from xknx.devices import BinarySensor as XknxBinarySensor
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.core import callback
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up binary sensor(s) for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up binary sensors for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXBinarySensor(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxBinarySensor):
+            entities.append(KNXBinarySensor(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -13,9 +13,8 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
-from homeassistant.core import callback
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 from .const import OPERATION_MODES, PRESET_MODES
 
 OPERATION_MODES_INV = dict(reversed(item) for item in OPERATION_MODES.items())
@@ -24,17 +23,10 @@ PRESET_MODES_INV = dict(reversed(item) for item in PRESET_MODES.items())
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up climate(s) for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up climates for KNX platform configured within platform."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXClimate(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxClimate):
+            entities.append(KNXClimate(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/const.py
+++ b/home-assistant-plugin/custom_components/xknx/const.py
@@ -28,8 +28,8 @@ class ColorTempModes(Enum):
     relative = "DPT-5.001"
 
 
-class DeviceTypes(Enum):
-    """KNX device types."""
+class SupportedPlatforms(Enum):
+    """Supported platforms."""
 
     cover = "cover"
     light = "light"

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -15,22 +15,15 @@ from homeassistant.components.cover import (
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_utc_time_change
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up cover(s) for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up covers for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXCover(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxCover):
+            entities.append(KNXCover(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -19,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.script import Script
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DATA_XKNX, DOMAIN, ColorTempModes, DeviceTypes
+from .const import DOMAIN, ColorTempModes, SupportedPlatforms
 from .schema import (
     BinarySensorSchema,
     ClimateSchema,
@@ -32,31 +32,31 @@ from .schema import (
 
 
 def create_knx_device(
-    hass: HomeAssistant, device_type: DeviceTypes, knx_module: XKNX, config: ConfigType
+    hass: HomeAssistant, platform: SupportedPlatforms, knx_module: XKNX, config: ConfigType
 ) -> XknxDevice:
     """Return the requested XKNX device."""
-    if device_type is DeviceTypes.light:
+    if platform is SupportedPlatforms.light:
         return _create_light(knx_module, config)
 
-    if device_type is DeviceTypes.cover:
+    if platform is SupportedPlatforms.cover:
         return _create_cover(knx_module, config)
 
-    if device_type is DeviceTypes.climate:
+    if platform is SupportedPlatforms.climate:
         return _create_climate(hass, knx_module, config)
 
-    if device_type is DeviceTypes.switch:
+    if platform is SupportedPlatforms.switch:
         return _create_switch(knx_module, config)
 
-    if device_type is DeviceTypes.sensor:
+    if platform is SupportedPlatforms.sensor:
         return _create_sensor(knx_module, config)
 
-    if device_type is DeviceTypes.notify:
+    if platform is SupportedPlatforms.notify:
         return _create_notify(knx_module, config)
 
-    if device_type is DeviceTypes.scene:
+    if platform is SupportedPlatforms.scene:
         return _create_scene(knx_module, config)
 
-    if device_type is DeviceTypes.binary_sensor:
+    if platform is SupportedPlatforms.binary_sensor:
         return _create_binary_sensor(hass, knx_module, config)
 
 
@@ -163,7 +163,6 @@ def _create_climate(
         ),
         operation_modes=config.get(ClimateSchema.CONF_OPERATION_MODES),
     )
-    hass.data[DATA_XKNX].xknx.devices.add(climate_mode)
 
     return XknxClimate(
         knx_module,

--- a/home-assistant-plugin/custom_components/xknx/light.py
+++ b/home-assistant-plugin/custom_components/xknx/light.py
@@ -15,7 +15,7 @@ from homeassistant.components.light import (
 from homeassistant.core import callback
 import homeassistant.util.color as color_util
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 DEFAULT_COLOR = (0.0, 0.0)
 DEFAULT_BRIGHTNESS = 255
@@ -24,17 +24,10 @@ DEFAULT_WHITE_VALUE = 255
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up lights for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up lights for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXLight(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxLight):
+            entities.append(KNXLight(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/notify.py
+++ b/home-assistant-plugin/custom_components/xknx/notify.py
@@ -1,25 +1,19 @@
 """Support for KNX/IP notification services."""
+from typing import List
+
 from xknx.devices import Notification as XknxNotification
 
 from homeassistant.components.notify import BaseNotificationService
-from homeassistant.core import callback
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_get_service(hass, config, discovery_info=None):
     """Get the KNX notification service."""
-    if discovery_info is not None:
-        async_get_service_discovery(hass, discovery_info)
-
-
-@callback
-def async_get_service_discovery(hass, discovery_info):
-    """Set up notifications for KNX platform configured via xknx.yaml."""
     notification_devices = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        notification_devices.append(device)
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxNotification):
+            notification_devices.append(device)
     return (
         KNXNotificationService(notification_devices) if notification_devices else None
     )
@@ -28,7 +22,7 @@ def async_get_service_discovery(hass, discovery_info):
 class KNXNotificationService(BaseNotificationService):
     """Implement demo notification service."""
 
-    def __init__(self, devices: XknxNotification):
+    def __init__(self, devices: List[XknxNotification]):
         """Initialize the service."""
         self.devices = devices
 

--- a/home-assistant-plugin/custom_components/xknx/scene.py
+++ b/home-assistant-plugin/custom_components/xknx/scene.py
@@ -4,24 +4,16 @@ from typing import Any
 from xknx.devices import Scene as XknxScene
 
 from homeassistant.components.scene import Scene
-from homeassistant.core import callback
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the scenes for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up scenes for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXScene(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxScene):
+            entities.append(KNXScene(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -4,22 +4,15 @@ from xknx.devices import Sensor as XknxSensor
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up sensor(s) for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up sensors for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXSensor(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxSensor):
+            entities.append(KNXSensor(device))
     async_add_entities(entities)
 
 

--- a/home-assistant-plugin/custom_components/xknx/switch.py
+++ b/home-assistant-plugin/custom_components/xknx/switch.py
@@ -4,22 +4,15 @@ from xknx.devices import Switch as XknxSwitch
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import callback
 
-from . import ATTR_DISCOVER_DEVICES, DATA_XKNX
+from . import DATA_XKNX
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up switch(es) for KNX platform."""
-    if discovery_info is not None:
-        async_add_entities_discovery(hass, discovery_info, async_add_entities)
-
-
-@callback
-def async_add_entities_discovery(hass, discovery_info, async_add_entities):
-    """Set up switches for KNX platform configured via xknx.yaml."""
     entities = []
-    for device_name in discovery_info[ATTR_DISCOVER_DEVICES]:
-        device = hass.data[DATA_XKNX].xknx.devices[device_name]
-        entities.append(KNXSwitch(device))
+    for device in hass.data[DATA_XKNX].xknx.devices:
+        if isinstance(device, XknxSwitch):
+            entities.append(KNXSwitch(device))
     async_add_entities(entities)
 
 

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -124,8 +124,7 @@ class TestConfig(unittest.TestCase):
                   'Living-Room.Light_1',
                   group_address_switch='1/6/9',
                   min_kelvin=2700,
-                  max_kelvin=6000,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  max_kelvin=6000))
 
     def test_config_light_state(self):
         """Test reading Light with dimming address from config file."""
@@ -138,8 +137,7 @@ class TestConfig(unittest.TestCase):
                   group_address_brightness='1/7/6',
                   group_address_brightness_state='1/7/7',
                   min_kelvin=2700,
-                  max_kelvin=6000,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  max_kelvin=6000))
 
     def test_config_light_color(self):
         """Test reading Light with with dimming and color address."""
@@ -152,8 +150,7 @@ class TestConfig(unittest.TestCase):
                   group_address_color='1/6/7',
                   group_address_color_state='1/6/8',
                   min_kelvin=2700,
-                  max_kelvin=6000,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  max_kelvin=6000))
 
     def test_config_color_temperature(self):
         """Test reading Light with with dimming and color temperature address."""
@@ -168,8 +165,7 @@ class TestConfig(unittest.TestCase):
                   group_address_color_temperature='1/6/14',
                   group_address_color_temperature_state='1/6/15',
                   min_kelvin=2700,
-                  max_kelvin=6000,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  max_kelvin=6000))
 
     def test_config_tunable_white(self):
         """Test reading Light with with dimming and tunable white address."""
@@ -184,8 +180,7 @@ class TestConfig(unittest.TestCase):
                   group_address_tunable_white='1/6/24',
                   group_address_tunable_white_state='1/6/25',
                   min_kelvin=2700,
-                  max_kelvin=6000,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  max_kelvin=6000))
 
     def test_config_switch(self):
         """Test reading Switch from config file."""
@@ -193,8 +188,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Livingroom.Outlet_2'],
             Switch(TestConfig.xknx,
                    'Livingroom.Outlet_2',
-                   group_address='1/3/2',
-                   device_updated_cb=TestConfig.xknx.devices.device_updated))
+                   group_address='1/3/2'))
 
     def test_config_fan(self):
         """Test reading Fan from config file."""
@@ -203,8 +197,7 @@ class TestConfig(unittest.TestCase):
             Fan(TestConfig.xknx,
                 'Kitchen.Fan_1',
                 group_address_speed='1/3/21',
-                group_address_speed_state='1/3/22',
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                group_address_speed_state='1/3/22'))
 
     def test_config_cover(self):
         """Test reading Cover from config file."""
@@ -217,8 +210,7 @@ class TestConfig(unittest.TestCase):
                   group_address_position_state='1/4/7',
                   group_address_position='1/4/8',
                   travel_time_down=50,
-                  travel_time_up=60,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  travel_time_up=60))
 
     def test_config_cover_venetian(self):
         """Test reading Cover with angle from config file."""
@@ -231,8 +223,7 @@ class TestConfig(unittest.TestCase):
                   group_address_position_state='1/4/17',
                   group_address_position='1/4/16',
                   group_address_angle='1/4/18',
-                  group_address_angle_state='1/4/19',
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  group_address_angle_state='1/4/19'))
 
     def test_config_cover_venetian_with_inverted_position(self):
         """Test reading Cover with angle from config file with inverted position/angle."""
@@ -247,8 +238,7 @@ class TestConfig(unittest.TestCase):
                   group_address_angle='1/4/18',
                   group_address_angle_state='1/4/19',
                   invert_position=True,
-                  invert_angle=True,
-                  device_updated_cb=TestConfig.xknx.devices.device_updated))
+                  invert_angle=True))
 
     def test_config_climate_temperature(self):
         """Test reading Climate object from config file."""
@@ -256,8 +246,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Kitchen.Climate'],
             Climate(TestConfig.xknx,
                     'Kitchen.Climate',
-                    group_address_temperature='1/7/1',
-                    device_updated_cb=TestConfig.xknx.devices.device_updated))
+                    group_address_temperature='1/7/1'))
 
     def test_config_climate_target_temperature_and_setpoint_shift(self):
         """Test reading Climate object with target_temperature_address and setpoint shift from config file."""
@@ -271,8 +260,7 @@ class TestConfig(unittest.TestCase):
                     group_address_setpoint_shift_state='1/7/14',
                     temperature_step=0.5,
                     setpoint_shift_min=-10,
-                    setpoint_shift_max=10,
-                    device_updated_cb=TestConfig.xknx.devices.device_updated))
+                    setpoint_shift_max=10))
 
     def test_config_climate_operation_mode(self):
         """Test reading Climate object with operation mode in one group address from config file."""
@@ -280,8 +268,7 @@ class TestConfig(unittest.TestCase):
             TestConfig.xknx.devices['Office.Climate'].mode,
             ClimateMode(TestConfig.xknx,
                         name=None,
-                        group_address_operation_mode='1/7/6',
-                        device_updated_cb=TestConfig.xknx.devices.device_updated))
+                        group_address_operation_mode='1/7/6'))
 
     def test_config_climate_operation_mode2(self):
         """Test reading Climate object with operation mode in different group addresses  from config file."""
@@ -291,8 +278,7 @@ class TestConfig(unittest.TestCase):
                         name=None,
                         group_address_operation_mode_protection='1/7/8',
                         group_address_operation_mode_night='1/7/9',
-                        group_address_operation_mode_comfort='1/7/10',
-                        device_updated_cb=TestConfig.xknx.devices.device_updated))
+                        group_address_operation_mode_comfort='1/7/10'))
 
     def test_config_climate_operation_mode_state(self):
         """Test reading Climate object with status address for operation mode."""
@@ -301,8 +287,7 @@ class TestConfig(unittest.TestCase):
             ClimateMode(TestConfig.xknx,
                         name=None,
                         group_address_operation_mode='1/7/6',
-                        group_address_operation_mode_state='1/7/7',
-                        device_updated_cb=TestConfig.xknx.devices.device_updated))
+                        group_address_operation_mode_state='1/7/7'))
 
     def test_config_climate_controller_status_state(self):
         """Test reading Climate object with addresses for controller status."""
@@ -311,8 +296,7 @@ class TestConfig(unittest.TestCase):
             ClimateMode(TestConfig.xknx,
                         name=None,
                         group_address_controller_status='1/7/12',
-                        group_address_controller_status_state='1/7/13',
-                        device_updated_cb=TestConfig.xknx.devices.device_updated))
+                        group_address_controller_status_state='1/7/13'))
 
     def test_config_datetime(self):
         """Test reading DateTime objects from config file."""
@@ -322,24 +306,21 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'General.Time',
                 group_address='2/1/1',
-                broadcast_type="TIME",
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                broadcast_type="TIME"))
         self.assertEqual(
             TestConfig.xknx.devices['General.DateTime'],
             DateTime(
                 TestConfig.xknx,
                 'General.DateTime',
                 group_address='2/1/2',
-                broadcast_type="DATETIME",
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                broadcast_type="DATETIME"))
         self.assertEqual(
             TestConfig.xknx.devices['General.Date'],
             DateTime(
                 TestConfig.xknx,
                 'General.Date',
                 group_address='2/1/3',
-                broadcast_type="DATE",
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                broadcast_type="DATE"))
 
     def test_config_notification(self):
         """Test reading DateTime object from config file."""
@@ -349,8 +330,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'AlarmWindow',
                 group_address='2/7/1',
-                group_address_state='2/7/2',
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                group_address_state='2/7/2'))
 
     def test_config_binary_sensor(self):
         """Test reading BinarySensor from config file."""
@@ -366,8 +346,7 @@ class TestConfig(unittest.TestCase):
                              Action(TestConfig.xknx,
                                     target="Livingroom.Outlet_2",
                                     counter=2,
-                                    method="on")],
-                         device_updated_cb=TestConfig.xknx.devices.device_updated))
+                                    method="on")]))
 
     def test_config_sensor_percent(self):
         """Test reading percent Sensor from config file."""
@@ -377,8 +356,7 @@ class TestConfig(unittest.TestCase):
                    'Heating.Valve1',
                    group_address_state='2/0/0',
                    value_type='percent',
-                   sync_state=True,
-                   device_updated_cb=TestConfig.xknx.devices.device_updated))
+                   sync_state=True))
 
     def test_config_sensor_percent_passive(self):
         """Test passive percent Sensor from config file."""
@@ -388,8 +366,7 @@ class TestConfig(unittest.TestCase):
                    'Heating.Valve2',
                    group_address_state='2/0/1',
                    value_type='percent',
-                   sync_state=False,
-                   device_updated_cb=TestConfig.xknx.devices.device_updated))
+                   sync_state=False))
 
     def test_config_sensor_temperature_type(self):
         """Test reading temperature Sensor from config file."""
@@ -398,8 +375,7 @@ class TestConfig(unittest.TestCase):
             Sensor(TestConfig.xknx,
                    'Kitchen.Temperature',
                    group_address_state='2/0/2',
-                   value_type='temperature',
-                   device_updated_cb=TestConfig.xknx.devices.device_updated))
+                   value_type='temperature'))
 
     def test_config_expose_sensor(self):
         """Test reading ExposeSensor from config file."""
@@ -409,8 +385,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 'Outside.Temperature',
                 group_address='2/0/3',
-                value_type='temperature',
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                value_type='temperature'))
 
     def test_config_sensor_binary_device_class(self):
         """Test reading Sensor with device_class from config file."""
@@ -419,8 +394,7 @@ class TestConfig(unittest.TestCase):
             BinarySensor(TestConfig.xknx,
                          'Kitchen.Motion.Sensor',
                          group_address_state='3/0/0',
-                         device_class='motion',
-                         device_updated_cb=TestConfig.xknx.devices.device_updated))
+                         device_class='motion'))
 
     def test_config_sensor_binary_passive(self):
         """Test reading Sensor with sync_state False from config file."""
@@ -430,8 +404,7 @@ class TestConfig(unittest.TestCase):
                          'DiningRoom.Motion.Sensor',
                          group_address_state='3/0/1',
                          sync_state=False,
-                         device_class='motion',
-                         device_updated_cb=TestConfig.xknx.devices.device_updated))
+                         device_class='motion'))
 
     def test_config_scene(self):
         """Test reading Scene from config file."""
@@ -441,8 +414,7 @@ class TestConfig(unittest.TestCase):
                 TestConfig.xknx,
                 "Romantic",
                 group_address='7/0/1',
-                scene_number=23,
-                device_updated_cb=TestConfig.xknx.devices.device_updated))
+                scene_number=23))
 
     def test_config_file_not_found(self):
         """Test error message when reading a non exisiting config file."""

--- a/test/devices_tests/action_test.py
+++ b/test/devices_tests/action_test.py
@@ -83,8 +83,7 @@ class TestAction(unittest.TestCase):
             xknx,
             'Light1',
             group_address_switch='1/6/4')
-        xknx.devices.add(light)
-        action = Action(xknx, target='Light1', method='on')
+        action = Action(xknx, target=light.name, method='on')
         with patch('xknx.devices.Light.do') as mock_do:
             fut = asyncio.Future()
             fut.set_result(None)

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -52,14 +52,13 @@ class TestBinarySensor(unittest.TestCase):
         telegram_on.payload = DPTBinary(1)
 
         self.loop.run_until_complete(asyncio.Task(binaryinput.process(telegram_on)))
-        self.loop.run_until_complete(asyncio.sleep(reset_after_ms*2/1000))
+        self.loop.run_until_complete(asyncio.sleep(reset_after_ms * 2 / 1000))
         self.assertEqual(binaryinput.state, False)
 
     def test_process_action(self):
         """Test process / reading telegrams from telegram queue. Test if action is executed."""
         xknx = XKNX(loop=self.loop)
-        switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
-        xknx.devices.add(switch)
+        Switch(xknx, 'TestOutlet', group_address='1/2/3')
 
         binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3')
         action_on = Action(
@@ -74,7 +73,6 @@ class TestBinarySensor(unittest.TestCase):
             target='TestOutlet',
             method='off')
         binary_sensor.actions.append(action_off)
-        xknx.devices.add(binary_sensor)
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
@@ -109,7 +107,6 @@ class TestBinarySensor(unittest.TestCase):
         """Test process / reading telegrams from telegram queue. Test if action is executed."""
         xknx = XKNX(loop=self.loop)
         switch = Switch(xknx, 'TestOutlet', group_address='5/5/5')
-        xknx.devices.add(switch)
 
         binary_sensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', ignore_internal_state=True)
         action_on = Action(
@@ -118,7 +115,6 @@ class TestBinarySensor(unittest.TestCase):
             target='TestOutlet',
             method='on')
         binary_sensor.actions.append(action_on)
-        xknx.devices.add(binary_sensor)
 
         self.assertEqual(
             xknx.devices['TestInput'].state,
@@ -202,6 +198,7 @@ class TestBinarySensor(unittest.TestCase):
         async def async_after_update_callback(device):
             """Async callback."""
             after_update_callback(device)
+
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(group_address=GroupAddress('1/2/3'))

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -21,6 +21,27 @@ class TestDevice(unittest.TestCase):
         """Tear down test class."""
         self.loop.close()
 
+    def test_device_updated_cb(self):
+        """Test device updated cb is added to the device."""
+        xknx = XKNX(loop=self.loop)
+
+        after_update_callback = Mock()
+
+        async def async_after_update_callback(device1):
+            """Async callback"""
+            after_update_callback(device1)
+        device = Device(xknx, 'TestDevice', device_updated_cb=async_after_update_callback)
+
+        self.loop.run_until_complete(asyncio.Task(device.after_update()))
+        after_update_callback.assert_called_with(device)
+
+    def test_iter_remote_value_raises_exception(self):
+        """Test _iter_remote_value raises NotImplementedError."""
+        xknx = XKNX(loop=self.loop)
+        device = Device(xknx, 'TestDevice')
+
+        self.assertRaises(NotImplementedError, device._iter_remote_values)
+
     def test_process_callback(self):
         """Test process / reading telegrams from telegram queue. Test if callback was called."""
         xknx = XKNX(loop=self.loop)

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -27,43 +27,38 @@ class TestDevices(unittest.TestCase):
     def test_get_item(self):
         """Test get item by name or by index."""
         xknx = XKNX(loop=self.loop)
-        devices = Devices()
 
         light1 = Light(xknx,
                        'Living-Room.Light_1',
                        group_address_switch='1/6/7')
-        devices.add(light1)
 
         switch1 = Switch(xknx,
                          "TestOutlet_1",
                          group_address='1/2/3')
-        devices.add(switch1)
 
         light2 = Light(xknx,
                        'Living-Room.Light_2',
                        group_address_switch='1/6/8')
-        devices.add(light2)
 
         switch2 = Switch(xknx,
                          "TestOutlet_2",
                          group_address='1/2/4')
-        devices.add(switch2)
 
-        self.assertEqual(devices["Living-Room.Light_1"], light1)
-        self.assertEqual(devices["TestOutlet_1"], switch1)
-        self.assertEqual(devices["Living-Room.Light_2"], light2)
-        self.assertEqual(devices["TestOutlet_2"], switch2)
+        self.assertEqual(xknx.devices["Living-Room.Light_1"], light1)
+        self.assertEqual(xknx.devices["TestOutlet_1"], switch1)
+        self.assertEqual(xknx.devices["Living-Room.Light_2"], light2)
+        self.assertEqual(xknx.devices["TestOutlet_2"], switch2)
         with self.assertRaises(KeyError):
             # pylint: disable=pointless-statement
-            devices["TestOutlet_X"]
+            xknx.devices["TestOutlet_2sdds"]
 
-        self.assertEqual(devices[0], light1)
-        self.assertEqual(devices[1], switch1)
-        self.assertEqual(devices[2], light2)
-        self.assertEqual(devices[3], switch2)
+        self.assertEqual(xknx.devices[0], light1)
+        self.assertEqual(xknx.devices[1], switch1)
+        self.assertEqual(xknx.devices[2], light2)
+        self.assertEqual(xknx.devices[3], switch2)
         with self.assertRaises(IndexError):
             # pylint: disable=pointless-statement
-            devices[4]
+            xknx.devices[4]
 
     def test_device_by_group_address(self):
         """Test get devices by group address."""
@@ -133,65 +128,57 @@ class TestDevices(unittest.TestCase):
     def test_len(self):
         """Test len() function."""
         xknx = XKNX(loop=self.loop)
-        devices = Devices()
-        self.assertEqual(len(devices), 0)
+        self.assertEqual(len(xknx.devices), 0)
 
-        light1 = Light(xknx,
-                       'Living-Room.Light_1',
-                       group_address_switch='1/6/7')
-        devices.add(light1)
-        self.assertEqual(len(devices), 1)
+        Light(xknx,
+              'Living-Room.Light_1',
+              group_address_switch='1/6/7')
+        self.assertEqual(len(xknx.devices), 1)
 
-        sensor1 = BinarySensor(xknx,
-                               'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1')
-        devices.add(sensor1)
-        self.assertEqual(len(devices), 2)
+        BinarySensor(xknx,
+                     'DiningRoom.Motion.Sensor',
+                     group_address_state='3/0/1')
+        self.assertEqual(len(xknx.devices), 2)
 
-        sensor2 = BinarySensor(xknx,
-                               'DiningRoom.Motion.Sensor',
-                               group_address_state='3/0/1')
-        devices.add(sensor2)
-        self.assertEqual(len(devices), 3)
+        BinarySensor(xknx,
+                     'DiningRoom.Motion.Sensor',
+                     group_address_state='3/0/1')
+        self.assertEqual(len(xknx.devices), 3)
 
-        light2 = Light(xknx,
-                       'Living-Room.Light_2',
-                       group_address_switch='1/6/8')
-        devices.add(light2)
-        self.assertEqual(len(devices), 4)
+        Light(xknx,
+              'Living-Room.Light_2',
+              group_address_switch='1/6/8')
+        self.assertEqual(len(xknx.devices), 4)
 
     def test_contains(self):
         """Test __contains__() function."""
         xknx = XKNX(loop=self.loop)
-        devices = Devices()
 
-        light1 = Light(xknx,
-                       'Living-Room.Light_1',
-                       group_address_switch='1/6/7')
-        devices.add(light1)
-        light2 = Light(xknx,
-                       'Living-Room.Light_2',
-                       group_address_switch='1/6/8')
-        devices.add(light2)
-        self.assertTrue('Living-Room.Light_1' in devices)
-        self.assertTrue('Living-Room.Light_2' in devices)
-        self.assertFalse('Living-Room.Light_3' in devices)
+        Light(xknx,
+              'Living-Room.Light_1',
+              group_address_switch='1/6/7')
+
+        Light(xknx,
+              'Living-Room.Light_2',
+              group_address_switch='1/6/8')
+
+        self.assertTrue('Living-Room.Light_1' in xknx.devices)
+        self.assertTrue('Living-Room.Light_2' in xknx.devices)
+        self.assertFalse('Living-Room.Light_3' in xknx.devices)
 
     def test_modification_of_device(self):
         """Test if devices object does store references and not copies of objects."""
         xknx = XKNX(loop=self.loop)
-        devices = Devices()
         light1 = Light(xknx,
                        'Living-Room.Light_1',
                        group_address_switch='1/6/7')
-        devices.add(light1)
-        for device in devices:
+        for device in xknx.devices:
             self.loop.run_until_complete(asyncio.Task(device.set_on()))
         self.assertTrue(light1.state)
-        device2 = devices["Living-Room.Light_1"]
+        device2 = xknx.devices["Living-Room.Light_1"]
         self.loop.run_until_complete(asyncio.Task(device2.set_off()))
         self.assertFalse(light1.state)
-        for device in devices.devices_by_group_address(GroupAddress('1/6/7')):
+        for device in xknx.devices.devices_by_group_address(GroupAddress('1/6/7')):
             self.loop.run_until_complete(asyncio.Task(device.set_on()))
         self.assertTrue(light1.state)
 
@@ -207,10 +194,8 @@ class TestDevices(unittest.TestCase):
     def test_sync(self):
         """Test sync function."""
         xknx = XKNX(loop=self.loop)
-        device1 = Device(xknx, 'TestDevice1')
-        device2 = Device(xknx, 'TestDevice2')
-        xknx.devices.add(device1)
-        xknx.devices.add(device2)
+        Device(xknx, 'TestDevice1')
+        Device(xknx, 'TestDevice2')
         with patch('xknx.devices.Device.sync') as mock_sync:
             fut = asyncio.Future()
             fut.set_result(None)
@@ -226,8 +211,6 @@ class TestDevices(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         device1 = Device(xknx, 'TestDevice1')
         device2 = Device(xknx, 'TestDevice2')
-        xknx.devices.add(device1)
-        xknx.devices.add(device2)
 
         after_update_callback1 = Mock()
         after_update_callback2 = Mock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38, flake8, pylint, pydocstyle
+envlist = py36, py37, py38, flake8, pylint, pydocstyle
 skip_missing_interpreters = True
 
 [testenv]

--- a/xknx/core/config.py
+++ b/xknx/core/config.py
@@ -120,100 +120,87 @@ class Config:
     def parse_group_binary_sensor(self, entries):
         """Parse a binary_sensor section of xknx.yaml."""
         for entry in entries:
-            binary_sensor = BinarySensor.from_config(
+            BinarySensor.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(binary_sensor)
 
     def parse_group_climate(self, entries):
         """Parse a climate section of xknx.yaml."""
         for entry in entries:
-            climate = Climate.from_config(
+            Climate.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(climate)
-            if climate.mode is not None:
-                self.xknx.devices.add(climate.mode)
 
     def parse_group_cover(self, entries):
         """Parse a cover section of xknx.yaml."""
         for entry in entries:
-            cover = Cover.from_config(
+            Cover.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(cover)
 
     def parse_group_datetime(self, entries):
         """Parse a datetime section of xknx.yaml."""
         for entry in entries:
-            datetime = DateTime.from_config(
+            DateTime.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(datetime)
 
     def parse_group_expose_sensor(self, entries):
         """Parse a exposed sensor section of xknx.yaml."""
         for entry in entries:
-            expose_sensor = ExposeSensor.from_config(
+            ExposeSensor.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(expose_sensor)
 
     def parse_group_fan(self, entries):
         """Parse a fan section of xknx.yaml."""
         for entry in entries:
-            fan = Fan.from_config(
+            Fan.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(fan)
 
     def parse_group_light(self, entries):
         """Parse a light section of xknx.yaml."""
         for entry in entries:
-            light = Light.from_config(
+            Light.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(light)
 
     def parse_group_notification(self, entries):
         """Parse a sensor section of xknx.yaml."""
         for entry in entries:
-            notification = Notification.from_config(
+            Notification.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(notification)
 
     def parse_group_scene(self, entries):
         """Parse a scene section of xknx.yaml."""
         for entry in entries:
-            scene = Scene.from_config(
+            Scene.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(scene)
 
     def parse_group_sensor(self, entries):
         """Parse a sensor section of xknx.yaml."""
         for entry in entries:
-            sensor = Sensor.from_config(
+            Sensor.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(sensor)
 
     def parse_group_switch(self, entries):
         """Parse a switch section of xknx.yaml."""
         for entry in entries:
-            switch = Switch.from_config(
+            Switch.from_config(
                 self.xknx,
                 entry,
                 entries[entry])
-            self.xknx.devices.add(switch)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -162,7 +162,3 @@ class BinarySensor(Device):
         """Return object as readable string."""
         return '<BinarySensor name="{0}" remote_value="{1}" state="{2}"/>' \
             .format(self.name, self.remote_value.group_addr_str(), self.state)
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -308,7 +308,3 @@ class Climate(Device):
                 self.setpoint_shift_max,
                 self.setpoint_shift_min,
                 self.on.group_addr_str())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -246,7 +246,3 @@ class ClimateMode(Device):
                 self.remote_value_operation_mode.group_addr_str(),
                 self.remote_value_controller_mode.group_addr_str(),
                 self.remote_value_controller_status.group_addr_str(),)
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -334,7 +334,3 @@ class Cover(Device):
     def supports_angle(self):
         """Return if cover supports tilt angle."""
         return self.angle.initialized
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -74,7 +74,3 @@ class DateTime(Device):
             .format(self.name,
                     self._remote_value.group_addr_str(),
                     self._broadcast_type)
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -9,13 +9,15 @@ from xknx.telegram import TelegramType
 class Device:
     """Base class for devices."""
 
-    def __init__(self, xknx, name, device_updated_cb=None):
+    def __init__(self, xknx, name: str, device_updated_cb=None):
         """Initialize Device class."""
         self.xknx = xknx
         self.name = name
         self.device_updated_cbs = []
         if device_updated_cb is not None:
             self.register_device_updated_cb(device_updated_cb)
+
+        self.xknx.devices.add(self)
 
     def _iter_remote_values(self):
         """Iterate the devices RemoteValue classes."""
@@ -80,3 +82,7 @@ class Device:
         """Execute 'do' commands."""
         # pylint: disable=invalid-name
         self.xknx.logger.info("Do not implemented action '%s' for %s", action, self.__class__.__name__)
+
+    def __eq__(self, other):
+        """Compare for quality."""
+        return self.__dict__ == other.__dict__

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -87,7 +87,3 @@ class ExposeSensor(Device):
                     self.sensor_value.group_addr_str(),
                     self.resolve_state(),
                     self.unit_of_measurement())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -82,7 +82,3 @@ class Fan(Device):
     def current_speed(self):
         """Return current speed of fan."""
         return self.speed.value
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -318,7 +318,3 @@ class Light(Device):
         """Process incoming GROUP WRITE telegram."""
         for remote_value in self._iter_remote_values():
             await remote_value.process(telegram)
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -67,7 +67,3 @@ class Notification(Device):
         return '<Notification name="{0}" message="{1}" />' \
             .format(self.name,
                     self._message.group_addr_str())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -62,7 +62,3 @@ class Scene(Device):
             await self.run()
         else:
             self.xknx.logger.warning("Could not understand action %s for device %s", action, self.get_name())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -74,7 +74,3 @@ class Sensor(Device):
                     self.sensor_value.group_addr_str(),
                     self.resolve_state(),
                     self.unit_of_measurement())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -80,7 +80,3 @@ class Switch(Device):
         return '<Switch name="{0}" switch="{1}" />' \
             .format(self.name,
                     self.switch.group_addr_str())
-
-    def __eq__(self, other):
-        """Equal operator."""
-        return self.__dict__ == other.__dict__


### PR DESCRIPTION
Before this change all devices had to be manually added to the xknx.devices List.
This was cumbersome and not needed, thats why it was removed.

Additionally, the device class now has a unique_id property that is used within the HA
integration in order to avoid errors where multiple devices share the same name within
different platforms.

Fixes #339, fixes #337