### PR TITLE
Add wait_for_result back to sync() in devices (#348)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,8 @@
 
 - GatewayScanner: Passing None or an integer <= 0 to the `stop_on_found` parameter now causes the scanner to only stop once the timeout is reached (@jochembroekhoff #311)
 - Devices are now added automatically to the xknx.devices list after initialization
+- Device.sync() method now again has a `wait_for_result` parameter that allows the user to wait for the telegrams
+- The default timeout of the `ValueReader` has been extended from 1 second to 2 seconds
 
 ### Bugfixes
 

--- a/examples/example_weather.py
+++ b/examples/example_weather.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Weather
 from xknx.io import ConnectionConfig, ConnectionType
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.WARN)
 
 
 async def main():
@@ -27,10 +27,9 @@ async def main():
         group_address_rain_alarm='7/0/0'
     )
 
-    await weather.sync()
-    await asyncio.sleep(10)
+    await weather.sync(wait_for_result=True)
     print(weather.max_brightness)
-    print(weather.ha_current_state)
+    print(weather.ha_current_state())
     print(weather)
 
     await xknx.stop()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: System :: Hardware :: Hardware Drivers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -1,10 +1,10 @@
 """Unit test for Switch objects."""
 import asyncio
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from xknx import XKNX
-from xknx.devices import Device
+from xknx.devices import Device, Sensor
 from xknx.dpt import DPTArray
 from xknx.telegram import GroupAddress, Telegram, TelegramType
 
@@ -30,6 +30,7 @@ class TestDevice(unittest.TestCase):
         async def async_after_update_callback(device1):
             """Async callback"""
             after_update_callback(device1)
+
         device = Device(xknx, 'TestDevice', device_updated_cb=async_after_update_callback)
 
         self.loop.run_until_complete(asyncio.Task(device.after_update()))
@@ -126,6 +127,19 @@ class TestDevice(unittest.TestCase):
                 telegramtype=TelegramType.GROUP_RESPONSE)
             self.loop.run_until_complete(asyncio.Task(device.process(telegram)))
             mock_group_response.assert_called_with(telegram)
+
+    def test_sync_with_wait(self):
+        """Test sync with wait_for_result=True."""
+        xknx = XKNX(loop=self.loop)
+        sensor = Sensor(xknx, 'Sensor', group_address_state="1/2/3", value_type="wind_speed_ms")
+
+        with patch('xknx.remote_value.RemoteValue.read_state', new_callable=MagicMock) as read_state_mock:
+            fut = asyncio.Future()
+            fut.set_result(None)
+            read_state_mock.return_value = fut
+            self.loop.run_until_complete(asyncio.Task(sensor.sync(wait_for_result=True)))
+
+            read_state_mock.assert_called_with(wait_for_result=True)
 
     def test_process_group_write(self):
         """Test if process_group_write. Nothing really to test here."""

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -18,7 +18,7 @@ class ValueReader:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, xknx, group_address, timeout_in_seconds=1):
+    def __init__(self, xknx, group_address, timeout_in_seconds=2):
         """Initialize ValueReader class."""
         self.xknx = xknx
         self.group_address = group_address

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -282,11 +282,11 @@ class Climate(Device):
         if self.mode is not None:
             await self.mode.process_group_write(telegram)
 
-    async def sync(self):
+    async def sync(self, wait_for_result=False):
         """Read states of device from KNX bus."""
-        await super().sync()
+        await super().sync(wait_for_result=wait_for_result)
         if self.mode is not None:
-            await self.mode.sync()
+            await self.mode.sync(wait_for_result=wait_for_result)
 
     def __str__(self):
         """Return object as readable string."""

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -228,11 +228,11 @@ class ClimateMode(Device):
             # if no operation mode has been set and all binary operation modes are False
             await self._set_internal_operation_mode(HVACOperationMode.STANDBY)
 
-    async def sync(self):
+    async def sync(self, wait_for_result=False):
         """Read states of device from KNX bus."""
         if self.supports_operation_mode:
             for rv in self._iter_remote_values():
-                await rv.read_state()
+                await rv.read_state(wait_for_result=wait_for_result)
 
     def __str__(self):
         """Return object as readable string."""

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -255,10 +255,10 @@ class Cover(Device):
         else:
             self.xknx.logger.warning("Could not understand action %s for device %s", action, self.get_name())
 
-    async def sync(self):
+    async def sync(self, wait_for_result=False):
         """Read states of device from KNX bus."""
-        await self.position.read_state()
-        await self.angle.read_state()
+        await self.position.read_state(wait_for_result=wait_for_result)
+        await self.angle.read_state(wait_for_result=wait_for_result)
 
     async def process_group_write(self, telegram):
         """Process incoming GROUP WRITE telegram."""

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -63,7 +63,7 @@ class DateTime(Device):
         else:
             await self._remote_value.send(response=True)
 
-    async def sync(self):
+    async def sync(self, wait_for_result=False):
         """Read state of device from KNX bus. Used here to broadcast time to KNX bus."""
         if self.localtime:
             await self.broadcast_localtime(response=False)

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -40,10 +40,10 @@ class Device:
             # pylint: disable=not-callable
             await device_updated_cb(self)
 
-    async def sync(self):
+    async def sync(self, wait_for_result=False):
         """Read states of device from KNX bus."""
         for remote_value in self._iter_remote_values():
-            await remote_value.read_state()
+            await remote_value.read_state(wait_for_result=wait_for_result)
 
     async def process(self, telegram):
         """Process incoming telegram."""


### PR DESCRIPTION
* Add wait_for_result back to sync() in devices

* Review

Co-authored-by: Matthias Alphart <farmio@alphart.net>

* Fix tests and linting

* Increased value reader timeout to 2 seconds

* Changelog

Co-authored-by: Matthias Alphart <farmio@alphart.net>