### PR TITLE
Datetime: fix hourly broadcasting localtime

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -337,7 +337,7 @@ class KNXExposeTime:
             name=self.expose_type.capitalize(),
             broadcast_type=self.expose_type.upper(),
             localtime=True,
-            group_address=self.address
+            group_address=self.address,
         )
 
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -267,7 +267,7 @@ class KNXModule:
             attribute = to_expose.get(ExposeSchema.CONF_XKNX_EXPOSE_ATTRIBUTE)
             default = to_expose.get(ExposeSchema.CONF_XKNX_EXPOSE_DEFAULT)
             address = to_expose.get(ExposeSchema.CONF_XKNX_EXPOSE_ADDRESS)
-            if expose_type in ["time", "date", "datetime"]:
+            if expose_type.lower() in ["time", "date", "datetime"]:
                 exposure = KNXExposeTime(self.xknx, expose_type, address)
                 exposure.async_register()
                 self.exposures.append(exposure)
@@ -322,20 +322,22 @@ class KNXModule:
 class KNXExposeTime:
     """Object to Expose Time/Date object to KNX bus."""
 
-    def __init__(self, xknx, expose_type, address):
+    def __init__(self, xknx: XKNX, expose_type: str, address: str):
         """Initialize of Expose class."""
         self.xknx = xknx
-        self.type = expose_type
+        self.expose_type = expose_type
         self.address = address
         self.device = None
 
     @callback
     def async_register(self):
         """Register listener."""
-        broadcast_type_string = self.type.upper()
-        broadcast_type = broadcast_type_string
         self.device = DateTime(
-            self.xknx, "Time", broadcast_type=broadcast_type, group_address=self.address
+            self.xknx,
+            name=self.expose_type.capitalize(),
+            broadcast_type=self.expose_type.upper(),
+            localtime=True,
+            group_address=self.address
         )
 
 

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -35,11 +35,18 @@ class TestConfig(unittest.TestCase):
         """Set up test class."""
         cls.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(cls.loop)
+        # patch creation of asyncio.Task in DateTime devices (would leave open tasks every time xknx.yaml is read)
+        cls.datetime_patcher = patch(
+            "xknx.devices.DateTime._start_broadcast_loop", return_value=None
+        )
+        cls.datetime_patcher.start()
+
         cls.xknx = XKNX(config="xknx.yaml", loop=cls.loop)
 
     @classmethod
     def tearDownClass(cls):
         """Tear down test class."""
+        cls.datetime_patcher.stop()
         cls.loop.close()
 
     #

--- a/test/core_tests/config_test.py
+++ b/test/core_tests/config_test.py
@@ -37,7 +37,7 @@ class TestConfig(unittest.TestCase):
         asyncio.set_event_loop(cls.loop)
         # patch creation of asyncio.Task in DateTime devices (would leave open tasks every time xknx.yaml is read)
         cls.datetime_patcher = patch(
-            "xknx.devices.DateTime._start_broadcast_loop", return_value=None
+            "xknx.devices.DateTime._create_broadcast_task", return_value=None
         )
         cls.datetime_patcher.start()
 

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -36,6 +36,10 @@ class TestDateTime(unittest.TestCase):
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.sync()))
 
+        # initial Telegram from broadcasting on init
+        self.assertEqual(xknx.telegrams.qsize(), 2)
+        _throwaway_initial = xknx.telegrams.get_nowait()
+
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
@@ -54,11 +58,15 @@ class TestDateTime(unittest.TestCase):
         datetime = DateTime(
             xknx, "TestDateTime", group_address="1/2/3", broadcast_type="DATE"
         )
+
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.sync()))
 
-        self.assertEqual(xknx.telegrams.qsize(), 1)
+        # initial Telegram from broadcasting on init
+        self.assertEqual(xknx.telegrams.qsize(), 2)
+        _throwaway_initial = xknx.telegrams.get_nowait()
+
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
@@ -74,11 +82,15 @@ class TestDateTime(unittest.TestCase):
         datetime = DateTime(
             xknx, "TestDateTime", group_address="1/2/3", broadcast_type="TIME"
         )
+
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.sync()))
 
-        self.assertEqual(xknx.telegrams.qsize(), 1)
+        # initial Telegram from broadcasting on init
+        self.assertEqual(xknx.telegrams.qsize(), 2)
+        _throwaway_initial = xknx.telegrams.get_nowait()
+
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
@@ -104,7 +116,11 @@ class TestDateTime(unittest.TestCase):
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
             self.loop.run_until_complete(asyncio.Task(datetime.process(telegram_read)))
-        self.assertEqual(xknx.telegrams.qsize(), 1)
+
+        # initial Telegram from broadcasting on init
+        self.assertEqual(xknx.telegrams.qsize(), 2)
+        _throwaway_initial = xknx.telegrams.get_nowait()
+
         telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
             telegram,

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -137,6 +137,8 @@ class TestDateTime(unittest.TestCase):
     def test_has_group_address(self):
         """Test if has_group_address function works."""
         xknx = XKNX(loop=self.loop)
-        datetime = DateTime(xknx, "TestDateTime", group_address="1/2/3")
+        datetime = DateTime(
+            xknx, "TestDateTime", group_address="1/2/3", localtime=False
+        )
         self.assertTrue(datetime.has_group_address(GroupAddress("1/2/3")))
         self.assertFalse(datetime.has_group_address(GroupAddress("1/2/4")))

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -370,7 +370,7 @@ class TestStringRepresentations(unittest.TestCase):
     def test_datetime(self):
         """Test string representation of datetime object."""
         xknx = XKNX(loop=self.loop)
-        dateTime = DateTime(xknx, name="Zeit", group_address="1/2/3")
+        dateTime = DateTime(xknx, name="Zeit", group_address="1/2/3", localtime=False)
         self.assertEqual(
             str(dateTime),
             '<DateTime name="Zeit" group_address="GroupAddress("1/2/3")/None/None/None" broadcast_type="TIME" />',

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -5,6 +5,7 @@ DateTime is a virtual/pseudo device, using the infrastructure for
 beeing configured via xknx.yaml and synchronized periodically
 by StateUpdate.
 """
+import asyncio
 import time
 
 from xknx.remote_value import RemoteValueDateTime
@@ -19,9 +20,9 @@ class DateTime(Device):
     def __init__(
         self,
         xknx,
-        name,
-        broadcast_type="TIME",
-        localtime=True,
+        name: str,
+        broadcast_type: str = "TIME",
+        localtime: bool = True,
         group_address=None,
         device_updated_cb=None,
     ):
@@ -37,6 +38,13 @@ class DateTime(Device):
             device_name=name,
             after_update_cb=self.after_update,
         )
+        self._broadcast_task = None
+        if self.localtime:
+            self._broadcast_task = self.xknx.loop.create_task(self._broadcast_loop(minutes=60))
+
+    def __del__(self):
+        if self._broadcast_task:
+            self._broadcast_task.cancel()
 
     def _iter_remote_values(self):
         """Iterate the devices RemoteValue classes."""
@@ -50,6 +58,11 @@ class DateTime(Device):
         return cls(
             xknx, name, broadcast_type=broadcast_type, group_address=group_address
         )
+
+    async def _broadcast_loop(self, minutes: int = 60):
+        while True:
+            await self.broadcast_localtime()
+            await asyncio.sleep(minutes * 60)
 
     async def broadcast_localtime(self, response=False):
         """Broadcast the local time to KNX bus."""

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -40,9 +40,12 @@ class DateTime(Device):
         )
         self._broadcast_task = None
         if self.localtime:
-            self._broadcast_task = self.xknx.loop.create_task(self._broadcast_loop(minutes=60))
+            self._broadcast_task = self.xknx.loop.create_task(
+                self._broadcast_loop(minutes=60)
+            )
 
     def __del__(self):
+        """Destructor. Cleaning up if this was not done before."""
         if self._broadcast_task:
             self._broadcast_task.cancel()
 
@@ -60,6 +63,7 @@ class DateTime(Device):
         )
 
     async def _broadcast_loop(self, minutes: int = 60):
+        """Endless loop for broadcasting local time."""
         while True:
             await self.broadcast_localtime()
             await asyncio.sleep(minutes * 60)


### PR DESCRIPTION
This was previously done by the state_updater calling DateTime.sync() once every hour. New state_updater (0.12) doesn't do that.
A Task is introduced to handle hourly broadcasting of localtime in the Device itself.