### PR TITLE
HA: configurable IA, Multicast group and port

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -241,12 +241,10 @@ class KNXModule:
     def connection_config_tunneling(self):
         """Return the connection_config if tunneling is configured."""
         gateway_ip = self.config[DOMAIN][CONF_XKNX_TUNNELING][CONF_HOST]
-        gateway_port = self.config[DOMAIN][CONF_XKNX_TUNNELING].get(CONF_PORT)
+        gateway_port = self.config[DOMAIN][CONF_XKNX_TUNNELING][CONF_PORT]
         local_ip = self.config[DOMAIN][CONF_XKNX_TUNNELING].get(
             ConnectionSchema.CONF_XKNX_LOCAL_IP
         )
-        if gateway_port is None:
-            gateway_port = DEFAULT_MCAST_PORT
         return ConnectionConfig(
             connection_type=ConnectionType.TUNNELING,
             gateway_ip=gateway_ip,

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -1,6 +1,7 @@
 """Voluptuous schemas for the KNX integration."""
 import voluptuous as vol
 from xknx.devices.climate import SetpointShiftMode
+from xknx.io import DEFAULT_MCAST_PORT
 
 from homeassistant.const import (
     CONF_ADDRESS,
@@ -29,9 +30,9 @@ class ConnectionSchema:
 
     TUNNELING_SCHEMA = vol.Schema(
         {
+            vol.Optional(CONF_PORT, default=DEFAULT_MCAST_PORT): cv.port,
             vol.Required(CONF_HOST): cv.string,
             vol.Optional(CONF_XKNX_LOCAL_IP): cv.string,
-            vol.Optional(CONF_PORT): cv.port,
         }
     )
 


### PR DESCRIPTION
I'm still not happy with having to set `local_ip` manually for routing connections, but I haven't found a way to configure it so that
```yaml
knx:
  routing:
  expose:
    ....
```
or similar would be possible. 

Should we change the configuration to something like that:
```yaml
knx:
  connection_type: routing # or "tunneling"
  local_ip: 123 # optional - would fit for routing and tunnelling
# or
knx:
  connection_type: tunneling
  tunneling:
    host: 10.1.1.1
    port: 1234
# or
knx:
  connection_type: tunneling
  tunneling_host: 10.1.1.1
  tunneling_port: 1234
```
?