### PR TITLE
use the IA provided by a tunnelling server only for the current connection

### DIFF
--- a/examples/example_tunnel.py
+++ b/examples/example_tunnel.py
@@ -18,7 +18,8 @@ async def main():
         return
 
     gateway = gateways[0]
-    src_address = PhysicalAddress("15.15.249")
+    # an individual address will most likely be assigned by the tunnelling server
+    xknx.own_address = PhysicalAddress("15.15.249")
 
     print(
         "Connecting to {}:{} from {}".format(
@@ -28,7 +29,6 @@ async def main():
 
     tunnel = Tunnel(
         xknx,
-        src_address,
         local_ip=gateway.local_ip,
         gateway_ip=gateway.ip_addr,
         gateway_port=gateway.port,

--- a/xknx/io/connect.py
+++ b/xknx/io/connect.py
@@ -37,5 +37,3 @@ class Connect(RequestResponse):
         """Set communication channel and identifier after having received a valid answer."""
         self.communication_channel = knxipframe.body.communication_channel
         self.identifier = knxipframe.body.identifier
-        # Use the address they gave us
-        self.xknx.own_address.raw = self.identifier

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -140,7 +140,6 @@ class KNXIPInterface:
         )
         self.interface = Tunnel(
             self.xknx,
-            self.xknx.own_address,
             local_ip=local_ip,
             gateway_ip=gateway_ip,
             gateway_port=gateway_port,

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -7,7 +7,7 @@ import asyncio
 
 from xknx.exceptions import XKNXException
 from xknx.knxip import CEMIMessageCode, KNXIPFrame, KNXIPServiceType, TunnellingRequest
-from xknx.telegram import TelegramDirection
+from xknx.telegram import PhysicalAddress, TelegramDirection
 
 from .connect import Connect
 from .connectionstate import ConnectionState
@@ -124,6 +124,8 @@ class Tunnel:
         )
         self._reconnect_task = None
         self.communication_channel = connect.communication_channel
+        # Use the individual address provided by the tunnelling server
+        self.src_address = PhysicalAddress(connect.identifier)
         self.sequence_number = 0
         await self.start_heartbeat()
 

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -24,7 +24,6 @@ class Tunnel:
     def __init__(
         self,
         xknx,
-        src_address,
         local_ip,
         gateway_ip,
         gateway_port,
@@ -35,7 +34,6 @@ class Tunnel:
         """Initialize Tunnel class."""
         # pylint: disable=too-many-arguments
         self.xknx = xknx
-        self.src_address = src_address
         self.local_ip = local_ip
         self.gateway_ip = gateway_ip
         self.gateway_port = gateway_port
@@ -44,6 +42,7 @@ class Tunnel:
         self.udp_client = None
         self.init_udp_client()
 
+        self._src_address = xknx.own_address
         self.sequence_number = 0
         self.communication_channel = None
         self.number_heartbeat_failed = 0
@@ -125,7 +124,7 @@ class Tunnel:
         self._reconnect_task = None
         self.communication_channel = connect.communication_channel
         # Use the individual address provided by the tunnelling server
-        self.src_address = PhysicalAddress(connect.identifier)
+        self._src_address = PhysicalAddress(connect.identifier)
         self.sequence_number = 0
         await self.start_heartbeat()
 
@@ -166,7 +165,7 @@ class Tunnel:
             self.xknx,
             self.udp_client,
             telegram,
-            self.src_address,
+            self._src_address,
             self.sequence_number,
             self.communication_channel,
         )


### PR DESCRIPTION
Don't replace `xknx.own_address` with the address assigned by a tunnelling server - just use it for the tunnel.
If the tunnel is closed and a routing connection is opened with the same XKNX object, the configured address shall be used.