### PR TITLE
Implement brightness_north attribute to weather device.

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/weather.py
+++ b/home-assistant-plugin/custom_components/xknx/weather.py
@@ -1,4 +1,6 @@
 """Support for KNX/IP weather station."""
+from typing import Any, Dict, Optional
+
 from xknx.devices import Weather as XknxWeather
 
 from homeassistant.components.weather import WeatherEntity
@@ -22,6 +24,11 @@ class KNXWeather(WeatherEntity):
     def __init__(self, device: XknxWeather):
         """Initialize of a KNX sensor."""
         self.device = device
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self.device.name
 
     @property
     def temperature(self):
@@ -60,3 +67,8 @@ class KNXWeather(WeatherEntity):
         return (
             self.device.wind_speed * 3.6 if self.device.wind_speed is not None else None
         )
+
+    @property
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return the device specific state attributes."""
+        return self.device.ha_state_attributes

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -297,6 +297,27 @@ class TestWeather(unittest.TestCase):
 
         self.assertEqual(weather.ha_current_state(), WeatherCondition.exceptional)
 
+    def test_weather_state_attributes(self):
+        """Test state attributes of weather device."""
+        xknx = XKNX(loop=self.loop)
+        weather: Weather = Weather(
+            name="weather",
+            xknx=xknx,
+            group_address_brightness_east="1/3/5",
+            group_address_brightness_south="1/3/6",
+            group_address_brightness_west="1/3/7",
+        )
+
+        weather._brightness_south.payload = DPTArray(
+            (
+                0x46,
+                0x45,
+            )
+        )
+
+        self.assertEqual(len(weather.ha_state_attributes), 7)
+        self.assertEqual(weather.ha_state_attributes["brightness_south"], 4108.8)
+
     #
     # Expose Sensor tests
     #

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -338,8 +338,9 @@ class TestStringRepresentations(unittest.TestCase):
         )
         self.assertEqual(
             str(weather),
-            '<Weather name="Home" temperature="None/GroupAddress("7/0/1")/None/None" brightness_south="None/'
-            'GroupAddress("7/0/5")/None/None" brightness_west="None/GroupAddress("7/0/3")/None/None" '
+            '<Weather name="Home" temperature="None/GroupAddress("7/0/1")/None/None" '
+            'brightness_south="None/GroupAddress("7/0/5")/None/None" brightness_north="None/None/None/None"'
+            ' brightness_west="None/GroupAddress("7/0/3")/None/None" '
             'brightness_east="None/GroupAddress("7/0/4")/None/None" wind_speed="None/GroupAddress("7/0/2")/None/None"'
             ' rain_alarm="None/GroupAddress("7/0/0")/None/None" wind_alarm="None/GroupAddress("7/0/10")/None/None" '
             'frost_alarm="None/GroupAddress("7/0/8")/None/None" day_night="None/GroupAddress("7/0/7")/None/None" '
@@ -358,10 +359,10 @@ class TestStringRepresentations(unittest.TestCase):
         self.assertEqual(
             str(weather),
             '<Weather name="Home" temperature="None/GroupAddress("7/0/1")/None/None" '
-            'brightness_south="None/GroupAddress("7/0/5")/None/None" '
+            'brightness_south="None/GroupAddress("7/0/5")/None/None" brightness_north="None/None/None/None" '
             'brightness_west="None/GroupAddress("7/0/3")/None/None" '
-            'brightness_east="None/GroupAddress("7/0/4")/None/None" wind_speed="None/GroupAddress("7/0/2")/None/None"'
-            ' rain_alarm="None/GroupAddress("7/0/0")/None/None" '
+            'brightness_east="None/GroupAddress("7/0/4")/None/None" wind_speed="None/GroupAddress("7/0/2")/None/None" '
+            'rain_alarm="None/GroupAddress("7/0/0")/None/None" '
             'wind_alarm="None/GroupAddress("7/0/10")/<DPTBinary value="1" />/True" '
             'frost_alarm="None/GroupAddress("7/0/8")/None/None" day_night="None/GroupAddress("7/0/7")/None/None" '
             'air_pressure="None/GroupAddress("7/0/9")/None/None" humidity="None/GroupAddress("7/0/9")/None/None" />',

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -13,7 +13,7 @@ It provides functionality for
 """
 from datetime import date, datetime
 from enum import Enum
-from typing import Callable, Generator, Optional
+from typing import Any, Callable, Dict, Generator, Optional
 
 from xknx.remote_value import RemoteValue, RemoteValueSensor, RemoteValueSwitch
 
@@ -75,6 +75,7 @@ class Weather(Device):
         name: str,
         group_address_temperature: str = None,
         group_address_brightness_south: Optional[str] = None,
+        group_address_brightness_north: Optional[str] = None,
         group_address_brightness_west: Optional[str] = None,
         group_address_brightness_east: Optional[str] = None,
         group_address_wind_speed: Optional[str] = None,
@@ -109,6 +110,16 @@ class Weather(Device):
             value_type="illuminance",
             device_name=self.name,
             feature_name="Brightness south",
+            after_update_cb=self.after_update,
+        )
+
+        self._brightness_north = RemoteValueSensor(
+            xknx,
+            group_address_state=group_address_brightness_north,
+            sync_state=sync_state,
+            value_type="illuminance",
+            device_name=self.name,
+            feature_name="Brightness north",
             after_update_cb=self.after_update,
         )
 
@@ -202,6 +213,7 @@ class Weather(Device):
         yield from [
             self._temperature,
             self._brightness_south,
+            self._brightness_north,
             self._brightness_east,
             self._brightness_west,
             self._wind_speed,
@@ -230,6 +242,15 @@ class Weather(Device):
             0.0
             if self._brightness_south.value is None
             else self._brightness_south.value
+        )
+
+    @property
+    def brightness_north(self) -> float:
+        """Return brightness north."""
+        return (
+            0.0
+            if self._brightness_north.value is None
+            else self._brightness_north.value
         )
 
     @property
@@ -284,7 +305,12 @@ class Weather(Device):
     @property
     def max_brightness(self) -> float:
         """Return highest illuminance from all sensors."""
-        return max(self.brightness_west, self.brightness_south, self.brightness_east)
+        return max(
+            self.brightness_west,
+            self.brightness_south,
+            self.brightness_north,
+            self.brightness_east,
+        )
 
     def expose_sensors(self):
         """Expose sensors to xknx."""
@@ -334,6 +360,13 @@ class Weather(Device):
                 None
                 if not self._brightness_south.initialized
                 else self._brightness_south.group_address_state.raw,
+                "illuminance",
+            ),
+            (
+                "_brightness_north",
+                None
+                if not self._brightness_north.initialized
+                else self._brightness_north.group_address_state.raw,
                 "illuminance",
             ),
             (
@@ -418,11 +451,25 @@ class Weather(Device):
 
         return WeatherCondition.exceptional
 
+    @property
+    def ha_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return device specific state attributes."""
+        return {
+            "brightness_south": self.brightness_south,
+            "brightness_north": self.brightness_north,
+            "brightness_east": self.brightness_east,
+            "brightness_west": self.brightness_west,
+            "wind_alarm": self.wind_alarm,
+            "frost_alarm": self.frost_alarm,
+            "rain_alarm": self.rain_alarm,
+        }
+
     @classmethod
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
         group_address_temperature = config.get("group_address_temperature")
         group_address_brightness_south = config.get("group_address_brightness_south")
+        group_address_brightness_north = config.get("group_address_brightness_north")
         group_address_brightness_west = config.get("group_address_brightness_west")
         group_address_brightness_east = config.get("group_address_brightness_east")
         group_address_wind_speed = config.get("group_address_wind_speed")
@@ -440,6 +487,7 @@ class Weather(Device):
             name,
             group_address_temperature=group_address_temperature,
             group_address_brightness_south=group_address_brightness_south,
+            group_address_brightness_north=group_address_brightness_north,
             group_address_brightness_west=group_address_brightness_west,
             group_address_brightness_east=group_address_brightness_east,
             group_address_wind_speed=group_address_wind_speed,
@@ -457,13 +505,14 @@ class Weather(Device):
         """Return object as readable string."""
         return (
             '<Weather name="{}" '
-            'temperature="{}" brightness_south="{}" brightness_west="{}" '
+            'temperature="{}" brightness_south="{}" brightness_north="{}" brightness_west="{}" '
             'brightness_east="{}" wind_speed="{}" rain_alarm="{}" '
             'wind_alarm="{}" frost_alarm="{}" day_night="{}" '
             'air_pressure="{}" humidity="{}" />'.format(
                 self.name,
                 self._temperature.group_addr_str(),
                 self._brightness_south.group_addr_str(),
+                self._brightness_north.group_addr_str(),
                 self._brightness_west.group_addr_str(),
                 self._brightness_east.group_addr_str(),
                 self._wind_speed.group_addr_str(),


### PR DESCRIPTION
Merges upstream changes in weather device. (name attribute)
Adds all non HA supported attributes as device specific state attributes.

State attributes are now available in HA: 
![image](https://user-images.githubusercontent.com/708887/92421480-fc54b200-f178-11ea-9a1e-21ed3b99181e.png)


Closes #376 