### PR TITLE
process outgoing telegrams in devices

### DIFF
--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -163,13 +163,13 @@ class TestClimate(unittest.TestCase):
 
         climate.register_device_updated_cb(async_after_update_callback)
 
-        self.loop.run_until_complete(
-            asyncio.Task(climate.target_temperature.set(23.00))
-        )
+        self.loop.run_until_complete(climate.target_temperature.set(23.00))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
         self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(-2)))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
@@ -419,7 +419,8 @@ class TestClimate(unittest.TestCase):
 
         climate2 = Climate(xknx, "TestClimate", group_address_setpoint_shift="1/2/3")
         self.assertFalse(climate2.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(asyncio.Task(climate2.set_setpoint_shift(4)))
+        self.loop.run_until_complete(climate2.set_setpoint_shift(4))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(climate2.initialized_for_setpoint_shift_calculations)
 
         climate3 = Climate(
@@ -428,11 +429,12 @@ class TestClimate(unittest.TestCase):
             group_address_target_temperature="1/2/2",
             group_address_setpoint_shift="1/2/3",
         )
-        self.loop.run_until_complete(asyncio.Task(climate3.set_setpoint_shift(4)))
+        self.loop.run_until_complete(climate3.set_setpoint_shift(4))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(climate3.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(
-            asyncio.Task(climate3.target_temperature.set(23.00))
-        )
+
+        self.loop.run_until_complete(climate3.target_temperature.set(23.00))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertTrue(climate3.initialized_for_setpoint_shift_calculations)
 
     #
@@ -469,13 +471,13 @@ class TestClimate(unittest.TestCase):
             max_temp="42",
             min_temp="3",
         )
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(4)))
+        self.loop.run_until_complete(climate.set_setpoint_shift(4))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(climate.initialized_for_setpoint_shift_calculations)
-        self.loop.run_until_complete(
-            asyncio.Task(climate.target_temperature.set(23.00))
-        )
-        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
 
+        self.loop.run_until_complete(climate.target_temperature.set(23.00))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
+        self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.target_temperature_min, "3")
         self.assertEqual(climate.target_temperature_max, "42")
 
@@ -495,39 +497,43 @@ class TestClimate(unittest.TestCase):
 
         self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(3)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(30)),
         )
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
 
-        self.loop.run_until_complete(
-            asyncio.Task(climate.target_temperature.set(23.00))
-        )
+        self.loop.run_until_complete(climate.target_temperature.set(23.00))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))
             ),
         )
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate.base_temperature, 20)
 
         # First change
-        self.loop.run_until_complete(
-            asyncio.Task(climate.set_target_temperature(24.00))
-        )
+        self.loop.run_until_complete(climate.set_target_temperature(24.00))
         self.assertEqual(xknx.telegrams.qsize(), 2)
+        _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(40)),
         )
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
+        _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))
             ),
         )
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate.target_temperature.value, 24.00)
 
         # Second change
@@ -535,16 +541,20 @@ class TestClimate(unittest.TestCase):
             asyncio.Task(climate.set_target_temperature(23.50))
         )
         self.assertEqual(xknx.telegrams.qsize(), 2)
+        _telegram = xknx.telegrams.get_nowait()
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(35)),
         )
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(23.50))
             ),
         )
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate.target_temperature.value, 23.50)
 
         # Test max target temperature
@@ -650,33 +660,37 @@ class TestClimate(unittest.TestCase):
 
         self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(3)))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             # temperature_step is 0.5 -> payload = setpoint_shift * 2
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(6)),
         )
 
-        self.loop.run_until_complete(
-            asyncio.Task(climate.target_temperature.set(23.00))
-        )
+        self.loop.run_until_complete(climate.target_temperature.set(23.00))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(23.00))
             ),
         )
         self.assertEqual(climate.base_temperature, 20.00)
-        self.loop.run_until_complete(
-            asyncio.Task(climate.set_target_temperature(24.00))
-        )
+        self.loop.run_until_complete(climate.set_target_temperature(24.00))
         self.assertEqual(xknx.telegrams.qsize(), 2)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(8)),
         )
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(24.00))
             ),
@@ -703,12 +717,12 @@ class TestClimate(unittest.TestCase):
             group_address_setpoint_shift="1/2/3",
         )
 
-        self.loop.run_until_complete(
-            asyncio.Task(climate.set_target_temperature(21.00))
-        )
+        self.loop.run_until_complete(climate.set_target_temperature(21.00))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(
                 GroupAddress("1/2/2"), payload=DPTArray(DPT2ByteFloat().to_knx(21.00))
             ),
@@ -717,10 +731,12 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(climate.base_temperature, None)
 
         # setpoint_shift initialized after target_temperature (no temperature change)
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(1)))
+        self.loop.run_until_complete(climate.set_setpoint_shift(1))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(10)),
         )
@@ -728,14 +744,18 @@ class TestClimate(unittest.TestCase):
         self.assertEqual(climate.base_temperature, 20.00)
 
         # setpoint_shift changed after initialisation
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(2)))
+        self.loop.run_until_complete(climate.set_setpoint_shift(2))
         # setpoint_shift and target_temperature are sent to the bus
         self.assertEqual(xknx.telegrams.qsize(), 2)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             # DEFAULT_TEMPERATURE_STEP is 0.1 -> payload = setpoint_shift * 10
             Telegram(GroupAddress("1/2/3"), payload=DPTArray(20)),
         )
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.base_temperature, 20.00)
         self.assertEqual(climate.target_temperature.value, 22)
@@ -756,50 +776,49 @@ class TestClimate(unittest.TestCase):
 
         # base temperature is 20 °C
         self.loop.run_until_complete(
-            asyncio.Task(
-                climate.target_temperature.process(
-                    Telegram(
-                        GroupAddress("1/2/2"),
-                        payload=DPTArray(DPT2ByteFloat().to_knx(20.00)),
-                    )
+            climate.target_temperature.process(
+                Telegram(
+                    GroupAddress("1/2/2"),
+                    payload=DPTArray(DPT2ByteFloat().to_knx(20.00)),
                 )
             )
         )
-        self.loop.run_until_complete(asyncio.Task(climate.set_setpoint_shift(0)))
+
+        self.loop.run_until_complete(climate.set_setpoint_shift(0))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertTrue(climate.initialized_for_setpoint_shift_calculations)
         self.assertEqual(climate.base_temperature, 20.00)
-        self.assertEqual(xknx.telegrams.qsize(), 1)
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray((0x00, 0x00))),
         )  # 0
         # - 0.6 °C = 19.4
-        self.loop.run_until_complete(
-            asyncio.Task(climate.set_target_temperature(19.40))
-        )
+        self.loop.run_until_complete(climate.set_target_temperature(19.40))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray((0x87, 0xC4))),
         )  # -0.6
         # simulate incoming new target temperature for next calculation
         self.loop.run_until_complete(
-            asyncio.Task(
-                climate.target_temperature.process(
-                    Telegram(
-                        GroupAddress("1/2/2"),
-                        payload=DPTArray(DPT2ByteFloat().to_knx(19.40)),
-                    )
+            climate.target_temperature.process(
+                Telegram(
+                    GroupAddress("1/2/2"),
+                    payload=DPTArray(DPT2ByteFloat().to_knx(19.40)),
                 )
             )
         )
         # + 3.5 °C = 23.5
-        self.loop.run_until_complete(
-            asyncio.Task(climate.set_target_temperature(23.50))
-        )
+        self.loop.run_until_complete(climate.set_target_temperature(23.50))
         self.assertEqual(xknx.telegrams.qsize(), 1)
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/3"), payload=DPTArray((0x01, 0x5E))),
         )  # +3.5
 
@@ -882,7 +901,7 @@ class TestClimate(unittest.TestCase):
             group_address_operation_mode="1/2/23",
             group_address_controller_status_state="1/2/24",
         )
-        self.loop.run_until_complete(asyncio.Task(climate_mode.sync()))
+        self.loop.run_until_complete(climate_mode.sync())
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
@@ -898,7 +917,7 @@ class TestClimate(unittest.TestCase):
             group_address_controller_mode="1/2/13",
             group_address_controller_mode_state="1/2/14",
         )
-        self.loop.run_until_complete(asyncio.Task(climate_mode.sync()))
+        self.loop.run_until_complete(climate_mode.sync())
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram1 = xknx.telegrams.get_nowait()
         self.assertEqual(
@@ -1227,31 +1246,39 @@ class TestClimate(unittest.TestCase):
         """Test turn_on and turn_off functions."""
         xknx = XKNX(loop=self.loop)
         climate = Climate(xknx, "TestClimate", group_address_on_off="1/2/2")
-        self.loop.run_until_complete(asyncio.Task(climate.turn_on()))
+        self.loop.run_until_complete(climate.turn_on())
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate.is_on, True)
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/2"), payload=DPTBinary(True)),
         )
-        self.loop.run_until_complete(asyncio.Task(climate.turn_off()))
+        self.loop.run_until_complete(climate.turn_off())
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate.is_on, False)
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/2"), payload=DPTBinary(False)),
         )
 
         climate_inv = Climate(
             xknx, "TestClimate", group_address_on_off="1/2/2", on_off_invert=True
         )
-        self.loop.run_until_complete(asyncio.Task(climate_inv.turn_on()))
+        self.loop.run_until_complete(climate_inv.turn_on())
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate_inv.is_on, True)
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/2"), payload=DPTBinary(False)),
         )
-        self.loop.run_until_complete(asyncio.Task(climate_inv.turn_off()))
+        self.loop.run_until_complete(climate_inv.turn_off())
+        _telegram = xknx.telegrams.get_nowait()
+        self.loop.run_until_complete(xknx.devices.process(_telegram))
         self.assertEqual(climate_inv.is_on, False)
         self.assertEqual(
-            xknx.telegrams.get_nowait(),
+            _telegram,
             Telegram(GroupAddress("1/2/2"), payload=DPTBinary(True)),
         )

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -143,12 +143,19 @@ class TestDevices(unittest.TestCase):
         light1 = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
         for device in xknx.devices:
             self.loop.run_until_complete(asyncio.Task(device.set_on()))
+            self.loop.run_until_complete(
+                xknx.devices.process(xknx.telegrams.get_nowait())
+            )
         self.assertTrue(light1.state)
         device2 = xknx.devices["Living-Room.Light_1"]
         self.loop.run_until_complete(asyncio.Task(device2.set_off()))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(light1.state)
         for device in xknx.devices.devices_by_group_address(GroupAddress("1/6/7")):
             self.loop.run_until_complete(asyncio.Task(device.set_on()))
+            self.loop.run_until_complete(
+                xknx.devices.process(xknx.telegrams.get_nowait())
+            )
         self.assertTrue(light1.state)
 
     def test_add_wrong_type(self):

--- a/test/devices_tests/expose_sensor_test.py
+++ b/test/devices_tests/expose_sensor_test.py
@@ -214,4 +214,5 @@ class TestExposeSensor(unittest.TestCase):
         expose_sensor.register_device_updated_cb(async_after_update_callback)
 
         self.loop.run_until_complete(asyncio.Task(expose_sensor.set(21.0)))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         after_update_callback.assert_called_with(expose_sensor)

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -116,8 +116,10 @@ class TestFan(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3")
         self.loop.run_until_complete(asyncio.Task(fan.do("speed:50")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(fan.current_speed, 50)
         self.loop.run_until_complete(asyncio.Task(fan.do("speed:25")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(fan.current_speed, 25)
 
     def test_wrong_do(self):

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -295,6 +295,7 @@ class TestLight(unittest.TestCase):
         self.assertEqual(
             telegram, Telegram(GroupAddress("1/2/5"), payload=DPTArray((23, 24, 25)))
         )
+        self.loop.run_until_complete(xknx.devices.process(telegram))
         self.assertEqual(light.current_color, ((23, 24, 25), None))
 
     def test_set_color_not_possible(self):
@@ -329,6 +330,7 @@ class TestLight(unittest.TestCase):
             telegram,
             Telegram(GroupAddress("1/2/5"), payload=DPTArray((23, 24, 25, 26, 0, 15))),
         )
+        self.loop.run_until_complete(xknx.devices.process(telegram))
         self.assertEqual(light.current_color, ([23, 24, 25], 26))
 
     def test_set_color_rgbw_not_possible(self):
@@ -649,14 +651,19 @@ class TestLight(unittest.TestCase):
             group_address_color_temperature="1/2/11",
         )
         self.loop.run_until_complete(asyncio.Task(light.do("on")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertTrue(light.state)
         self.loop.run_until_complete(asyncio.Task(light.do("brightness:80")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(light.current_brightness, 80)
         self.loop.run_until_complete(asyncio.Task(light.do("tunable_white:80")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(light.current_tunable_white, 80)
         self.loop.run_until_complete(asyncio.Task(light.do("color_temperature:3750")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(light.current_color_temperature, 3750)
         self.loop.run_until_complete(asyncio.Task(light.do("off")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(light.state)
 
     def test_wrong_do(self):

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -133,6 +133,7 @@ class TestNotification(unittest.TestCase):
         self.loop.run_until_complete(
             asyncio.Task(notification.do("message:Ein Prosit!"))
         )
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertEqual(notification.message, "Ein Prosit!")
 
     def test_wrong_do(self):

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -132,8 +132,10 @@ class TestSwitch(unittest.TestCase):
         xknx = XKNX(loop=self.loop)
         switch = Switch(xknx, "TestOutlet", group_address="1/2/3")
         self.loop.run_until_complete(asyncio.Task(switch.do("on")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertTrue(switch.state)
         self.loop.run_until_complete(asyncio.Task(switch.do("off")))
+        self.loop.run_until_complete(xknx.devices.process(xknx.telegrams.get_nowait()))
         self.assertFalse(switch.state)
 
     def test_wrong_do(self):

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -250,6 +250,7 @@ class TestStringRepresentations(unittest.TestCase):
         self.loop.run_until_complete(
             asyncio.Task(notification.set("Einbrecher im Haus"))
         )
+        self.loop.run_until_complete(notification.process(xknx.telegrams.get_nowait()))
         self.assertEqual(
             str(notification),
             '<Notification name="Alarm" '
@@ -300,7 +301,8 @@ class TestStringRepresentations(unittest.TestCase):
             str(sensor),
             '<ExposeSensor name="MeinSensor" sensor="GroupAddress("1/2/3")/None/None/None" value="None" unit="%"/>',
         )
-        self.loop.run_until_complete(asyncio.Task(sensor.set(25)))
+        self.loop.run_until_complete(sensor.set(25))
+        self.loop.run_until_complete(sensor.process(xknx.telegrams.get_nowait()))
         self.assertEqual(
             str(sensor),
             '<ExposeSensor name="MeinSensor" sensor="GroupAddress("1/2/3")/None/<DPTArray value="[0x40]" />/25" value="25" unit="%"/>',

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -129,10 +129,7 @@ class TelegramQueue:
         if self.xknx.knxip_interface is not None:
             await self.xknx.knxip_interface.send_telegram(telegram)
             if telegram.telegramtype == TelegramType.GROUP_WRITE:
-                for device in self.xknx.devices.devices_by_group_address(
-                    telegram.group_address
-                ):
-                    await device.process(telegram)
+                await self.xknx.devices.process(telegram)
         else:
             self.xknx.logger.warning("No KNXIP interface defined")
 
@@ -147,7 +144,4 @@ class TelegramQueue:
                     processed = True
         # TODO: why don't we process every incoming telegram by device?
         if not processed:
-            for device in self.xknx.devices.devices_by_group_address(
-                telegram.group_address
-            ):
-                await device.process(telegram)
+            await self.xknx.devices.process(telegram)

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -9,7 +9,6 @@ You may register callbacks to be notified if a telegram was pushed to the queue.
 """
 import asyncio
 
-
 from xknx.exceptions import CommunicationError, XKNXException
 from xknx.telegram import TelegramDirection, TelegramType
 

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -10,7 +10,7 @@ You may register callbacks to be notified if a telegram was pushed to the queue.
 import asyncio
 
 from xknx.exceptions import XKNXException
-from xknx.telegram import TelegramDirection
+from xknx.telegram import TelegramDirection, TelegramType
 
 
 class TelegramQueue:
@@ -128,6 +128,11 @@ class TelegramQueue:
         self.xknx.telegram_logger.debug(telegram)
         if self.xknx.knxip_interface is not None:
             await self.xknx.knxip_interface.send_telegram(telegram)
+            if telegram.telegramtype == TelegramType.GROUP_WRITE:
+                for device in self.xknx.devices.devices_by_group_address(
+                    telegram.group_address
+                ):
+                    await device.process(telegram)
         else:
             self.xknx.logger.warning("No KNXIP interface defined")
 
@@ -140,7 +145,7 @@ class TelegramQueue:
                 ret = await telegram_received_cb.callback(telegram)
                 if ret:
                     processed = True
-
+        # TODO: why don't we process every incoming telegram by device?
         if not processed:
             for device in self.xknx.devices.devices_by_group_address(
                 telegram.group_address

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -168,7 +168,7 @@ class BinarySensor(Device):
         return 1
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         if await self.remote_value.process(telegram, always_callback=True):
 
             if self.reset_after is not None and self.state:

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -282,7 +282,7 @@ class Climate(Device):
         return None
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         for remote_value in self._iter_remote_values():
             await remote_value.process(telegram)
         if self.mode is not None:

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -261,7 +261,7 @@ class Climate(Device):
         await self._setpoint_shift.set(validated_offset)
         # broadcast new target temperature and set internally
         if self.target_temperature.writable and base_temperature is not None:
-            await self.target_temperature.set(base_temperature + self.setpoint_shift)
+            await self.target_temperature.set(base_temperature + validated_offset)
 
     @property
     def target_temperature_max(self):

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -249,7 +249,7 @@ class ClimateMode(Device):
         return list(set(operation_modes))
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         if self.supports_operation_mode:
             for rv in self._iter_remote_values():
                 if await rv.process(telegram):

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -264,7 +264,7 @@ class Cover(Device):
         await self.angle.read_state(wait_for_result=wait_for_result)
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         if await self.updown.process(telegram):
             if self.updown.value == RemoteValueUpDown.Direction.UP:
                 self.travelcalculator.start_travel_up()

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -84,7 +84,7 @@ class DateTime(Device):
         if self.localtime:
             await self.broadcast_localtime(True)
         else:
-            await self._remote_value.send(response=True)
+            await self._remote_value.respond()
 
     async def sync(self, wait_for_result=False):
         """Read state of device from KNX bus. Used here to broadcast time to KNX bus."""

--- a/xknx/devices/devices.py
+++ b/xknx/devices/devices.py
@@ -64,6 +64,11 @@ class Devices:
         for device_updated_cb in self.device_updated_cbs:
             await device_updated_cb(device)
 
+    async def process(self, telegram):
+        """Process telegram."""
+        for device in self.devices_by_group_address(telegram.group_address):
+            await device.process(telegram)
+
     async def sync(self):
         """Read state of devices from KNX bus."""
         for device in self.__devices:

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -58,7 +58,7 @@ class ExposeSensor(Device):
         return cls(xknx, name, group_address=group_address, value_type=value_type)
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         await self.sensor_value.process(telegram)
 
     async def process_group_read(self, telegram):

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -57,6 +57,10 @@ class ExposeSensor(Device):
 
         return cls(xknx, name, group_address=group_address, value_type=value_type)
 
+    async def process_group_write(self, telegram):
+        """Process incoming GROUP WRITE telegram."""
+        await self.sensor_value.process(telegram)
+
     async def process_group_read(self, telegram):
         """Process incoming GROUP READ telegram."""
         await self.sensor_value.respond()

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -59,7 +59,7 @@ class ExposeSensor(Device):
 
     async def process_group_read(self, telegram):
         """Process incoming GROUP READ telegram."""
-        await self.sensor_value.send(response=True)
+        await self.sensor_value.respond()
 
     async def set(self, value):
         """Set new value."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -77,7 +77,7 @@ class Fan(Device):
             )
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         await self.speed.process(telegram)
 
     @property

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -339,6 +339,6 @@ class Light(Device):
             )
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         for remote_value in self._iter_remote_values():
             await remote_value.process(telegram)

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -56,7 +56,7 @@ class Notification(Device):
         await self._message.set(cropped_message)
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         await self._message.process(telegram)
 
     async def do(self, action):

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -56,7 +56,7 @@ class Sensor(Device):
         )
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         await self.sensor_value.process(telegram)
 
     def unit_of_measurement(self):

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -77,7 +77,7 @@ class Switch(Device):
             )
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         await self.switch.process(telegram)
 
     def __str__(self):

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -214,7 +214,7 @@ class Weather(Device):
         ]
 
     async def process_group_write(self, telegram):
-        """Process incoming GROUP WRITE telegram."""
+        """Process incoming and outgoing GROUP WRITE telegram."""
         for remote_value in self._iter_remote_values():
             await remote_value.process(telegram)
 

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -118,14 +118,14 @@ class RemoteValue:
             return None
         return self.from_knx(self.payload)
 
-    async def send(self, response=False):
+    async def _send(self, payload, response=False):
         """Send payload as telegram to KNX bus."""
         telegram = Telegram(
             group_address=self.group_address,
             telegramtype=(
                 TelegramType.GROUP_RESPONSE if response else TelegramType.GROUP_WRITE
             ),
-            payload=self.payload,
+            payload=payload,
         )
         await self.xknx.telegrams.put(telegram)
 
@@ -149,13 +149,13 @@ class RemoteValue:
             return
 
         payload = self.to_knx(value)  # pylint: disable=assignment-from-no-return
-        updated = False
-        if self.payload is None or payload != self.payload:
-            self.payload = payload
-            updated = True
-        await self.send(response)
-        if updated and self.after_update_cb is not None:
-            await self.after_update_cb()
+        await self._send(payload, response)
+        # after_update_cb() is called when the outgoing telegram is processed.
+
+    async def respond(self):
+        """Send current payload as GroupValueResponse telegram to KNX bus."""
+        if self.payload is not None:
+            await self._send(self.payload, response=True)
 
     async def read_state(self, wait_for_result=False):
         """Send GroupValueRead telegram for state address to KNX bus."""

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -150,7 +150,7 @@ class RemoteValue:
 
         payload = self.to_knx(value)  # pylint: disable=assignment-from-no-return
         await self._send(payload, response)
-        # after_update_cb() is called when the outgoing telegram is processed.
+        # self.payload is set and after_update_cb() called when the outgoing telegram is processed.
 
     async def respond(self):
         """Send current payload as GroupValueResponse telegram to KNX bus."""
@@ -162,6 +162,8 @@ class RemoteValue:
         if self.readable:
             self.xknx.logger.debug("Sync %s - %s", self.device_name, self.feature_name)
             # pylint: disable=import-outside-toplevel
+            # TODO: send a ReadRequset and start a timeout from here instead of ValueReader
+            #       cancel timeout form process(); delete ValueReader
             from xknx.core import ValueReader
 
             value_reader = ValueReader(self.xknx, self.group_address_state)


### PR DESCRIPTION
process outgoing telegrams in all devices - regarding #393 
This enables xknx-devices that share a specific GA (without state_address) to be updated when a new value is sent form xknx.

I'm not sure if this would break anything - I guess it does. On my installation everything seems to work, but I don't use fancy binary_sensors with count and actions etc...

Updating the tests for this change will be non-trivial 😬