### PR TITLE
create outgoing KNXIPFrame and CEMIFrame directly

### DIFF
--- a/xknx/io/connect.py
+++ b/xknx/io/connect.py
@@ -1,10 +1,10 @@
 """Abstraction to send ConnectRequest and wait for ConnectResponse."""
 from xknx.knxip import (
     HPAI,
+    ConnectRequest,
     ConnectRequestType,
     ConnectResponse,
     KNXIPFrame,
-    KNXIPServiceType,
 )
 
 from .request_response import RequestResponse
@@ -21,17 +21,18 @@ class Connect(RequestResponse):
         self.communication_channel = 0
         self.identifier = 0
 
-    def create_knxipframe(self):
+    def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udp_client.getsockname()
-        knxipframe = KNXIPFrame(self.xknx)
-        knxipframe.init(KNXIPServiceType.CONNECT_REQUEST)
-        knxipframe.body.request_type = ConnectRequestType.TUNNEL_CONNECTION
-
         # set control_endpoint and data_endpoint to the same udp_connection
-        knxipframe.body.control_endpoint = HPAI(ip_addr=local_addr, port=local_port)
-        knxipframe.body.data_endpoint = HPAI(ip_addr=local_addr, port=local_port)
-        return knxipframe
+        endpoint = HPAI(ip_addr=local_addr, port=local_port)
+        connect_request = ConnectRequest(
+            self.xknx,
+            request_type=ConnectRequestType.TUNNEL_CONNECTION,
+            control_endpoint=endpoint,
+            data_endpoint=endpoint,
+        )
+        return KNXIPFrame.init_from_body(connect_request)
 
     def on_success_hook(self, knxipframe):
         """Set communication channel and identifier after having received a valid answer."""

--- a/xknx/io/connectionstate.py
+++ b/xknx/io/connectionstate.py
@@ -1,5 +1,5 @@
 """Abstraction to send ConnectonStateRequest and wait for ConnectionStateResponse."""
-from xknx.knxip import HPAI, ConnectionStateResponse, KNXIPFrame, KNXIPServiceType
+from xknx.knxip import HPAI, ConnectionStateRequest, ConnectionStateResponse, KNXIPFrame
 
 from .request_response import RequestResponse
 
@@ -13,12 +13,12 @@ class ConnectionState(RequestResponse):
         super().__init__(xknx, self.udp_client, ConnectionStateResponse)
         self.communication_channel_id = communication_channel_id
 
-    def create_knxipframe(self):
+    def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udpclient.getsockname()
-        knxipframe = KNXIPFrame(self.xknx)
-        knxipframe.init(KNXIPServiceType.CONNECTIONSTATE_REQUEST)
-        knxipframe.body.communication_channel_id = self.communication_channel_id
-        knxipframe.body.control_endpoint = HPAI(ip_addr=local_addr, port=local_port)
-
-        return knxipframe
+        connectionstate_request = ConnectionStateRequest(
+            self.xknx,
+            communication_channel_id=self.communication_channel_id,
+            control_endpoint=HPAI(ip_addr=local_addr, port=local_port),
+        )
+        return KNXIPFrame.init_from_body(connectionstate_request)

--- a/xknx/io/disconnect.py
+++ b/xknx/io/disconnect.py
@@ -14,7 +14,7 @@ class Disconnect(RequestResponse):
         super().__init__(xknx, self.udp_client, DisconnectResponse)
         self.communication_channel_id = communication_channel_id
 
-    def create_knxipframe(self):
+    def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udpclient.getsockname()
         disconnect_request = DisconnectRequest(

--- a/xknx/io/disconnect.py
+++ b/xknx/io/disconnect.py
@@ -1,5 +1,5 @@
 """Abstraction to send DisconnectRequest and wait for DisconnectResponse."""
-from xknx.knxip import HPAI, DisconnectResponse, KNXIPFrame, KNXIPServiceType
+from xknx.knxip import HPAI, DisconnectRequest, DisconnectResponse, KNXIPFrame
 
 from .request_response import RequestResponse
 
@@ -17,8 +17,9 @@ class Disconnect(RequestResponse):
     def create_knxipframe(self):
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udpclient.getsockname()
-        knxipframe = KNXIPFrame(self.xknx)
-        knxipframe.init(KNXIPServiceType.DISCONNECT_REQUEST)
-        knxipframe.body.communication_channel_id = self.communication_channel_id
-        knxipframe.body.control_endpoint = HPAI(ip_addr=local_addr, port=local_port)
-        return knxipframe
+        disconnect_request = DisconnectRequest(
+            self.xknx,
+            communication_channel_id=self.communication_channel_id,
+            control_endpoint=HPAI(ip_addr=local_addr, port=local_port),
+        )
+        return KNXIPFrame.init_from_body(disconnect_request)

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -16,6 +16,7 @@ from xknx.knxip import (
     DIBSuppSVCFamilies,
     KNXIPFrame,
     KNXIPServiceType,
+    SearchRequest,
     SearchResponse,
 )
 
@@ -162,11 +163,10 @@ class GatewayScanner:
         self._udp_clients.append(udp_client)
 
         (local_addr, local_port) = udp_client.getsockname()
-        knx_ip_frame = KNXIPFrame(self.xknx)
-        knx_ip_frame.init(KNXIPServiceType.SEARCH_REQUEST)
-        knx_ip_frame.body.discovery_endpoint = HPAI(ip_addr=local_addr, port=local_port)
-        knx_ip_frame.normalize()
-        udp_client.send(knx_ip_frame)
+        search_request = SearchRequest(
+            self.xknx, discovery_endpoint=HPAI(ip_addr=local_addr, port=local_port)
+        )
+        udp_client.send(KNXIPFrame.init_from_body(search_request))
 
     def _response_rec_callback(
         self, knx_ip_frame: KNXIPFrame, udp_client: UDPClient

--- a/xknx/io/request_response.py
+++ b/xknx/io/request_response.py
@@ -40,9 +40,7 @@ class RequestResponse:
 
     async def send_request(self):
         """Build knxipframe (within derived class) and send via UDP."""
-        knxipframe = self.create_knxipframe()
-        # knxipframe.normalize()
-        self.udpclient.send(knxipframe)
+        self.udpclient.send(self.create_knxipframe())
 
     def response_rec_callback(self, knxipframe, _):
         """Verify and handle knxipframe. Callback from internal udpclient."""

--- a/xknx/io/request_response.py
+++ b/xknx/io/request_response.py
@@ -5,7 +5,7 @@ Will report if the corresponding answer was not received.
 """
 import asyncio
 
-from xknx.knxip import ErrorCode
+from xknx.knxip import ErrorCode, KNXIPFrame
 
 
 class RequestResponse:
@@ -23,7 +23,7 @@ class RequestResponse:
         self.timeout_in_seconds = timeout_in_seconds
         self.timeout_handle = None
 
-    def create_knxipframe(self):
+    def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
         raise NotImplementedError("create_knxipframe has to be implemented")
 
@@ -41,7 +41,7 @@ class RequestResponse:
     async def send_request(self):
         """Build knxipframe (within derived class) and send via UDP."""
         knxipframe = self.create_knxipframe()
-        knxipframe.normalize()
+        # knxipframe.normalize()
         self.udpclient.send(knxipframe)
 
     def response_rec_callback(self, knxipframe, _):

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -6,6 +6,7 @@ Routing uses UDP Multicast to broadcast and receive KNX/IP messages.
 from xknx.knxip import (
     APCICommand,
     CEMIFrame,
+    CEMIMessageCode,
     KNXIPFrame,
     KNXIPServiceType,
     RoutingIndication,
@@ -59,9 +60,12 @@ class Routing:
 
     async def send_telegram(self, telegram):
         """Send Telegram to routing connected device."""
-        cemi = CEMIFrame(self.xknx)
-        cemi.src_addr = self.xknx.own_address
-        cemi.telegram = telegram
+        cemi = CEMIFrame.init_from_telegram(
+            self.xknx,
+            telegram=telegram,
+            code=CEMIMessageCode.L_DATA_IND,
+            src_addr=self.xknx.own_address,
+        )
         routing_indication = RoutingIndication(self.xknx, cemi=cemi)
         await self.send_knxipframe(KNXIPFrame.init_from_body(routing_indication))
 

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -3,7 +3,13 @@ Abstraction for handling KNX/IP routing.
 
 Routing uses UDP Multicast to broadcast and receive KNX/IP messages.
 """
-from xknx.knxip import APCICommand, KNXIPFrame, KNXIPServiceType
+from xknx.knxip import (
+    APCICommand,
+    CEMIFrame,
+    KNXIPFrame,
+    KNXIPServiceType,
+    RoutingIndication,
+)
 from xknx.telegram import TelegramDirection
 
 from .udp_client import UDPClient
@@ -53,13 +59,11 @@ class Routing:
 
     async def send_telegram(self, telegram):
         """Send Telegram to routing connected device."""
-        knxipframe = KNXIPFrame(self.xknx)
-        knxipframe.init(KNXIPServiceType.ROUTING_INDICATION)
-        knxipframe.body.cemi.src_addr = self.xknx.own_address
-        knxipframe.body.cemi.telegram = telegram
-        knxipframe.body.cemi.sender = self.xknx.own_address
-        knxipframe.normalize()
-        await self.send_knxipframe(knxipframe)
+        cemi = CEMIFrame(self.xknx)
+        cemi.src_addr = self.xknx.own_address
+        cemi.telegram = telegram
+        routing_indication = RoutingIndication(self.xknx, cemi=cemi)
+        await self.send_knxipframe(KNXIPFrame.init_from_body(routing_indication))
 
     async def send_knxipframe(self, knxipframe):
         """Send KNXIPFrame to connected routing device."""

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -6,7 +6,13 @@ Tunnels connect to KNX/IP devices directly via UDP and build a static UDP connec
 import asyncio
 
 from xknx.exceptions import CommunicationError, XKNXException
-from xknx.knxip import CEMIMessageCode, KNXIPFrame, KNXIPServiceType, TunnellingRequest
+from xknx.knxip import (
+    CEMIMessageCode,
+    KNXIPFrame,
+    KNXIPServiceType,
+    TunnellingAck,
+    TunnellingRequest,
+)
 from xknx.telegram import PhysicalAddress, TelegramDirection
 
 from .connect import Connect
@@ -88,12 +94,12 @@ class Tunnel:
 
     def send_ack(self, communication_channel_id, sequence_counter):
         """Send tunnelling ACK after tunnelling request received."""
-        ack_knxipframe = KNXIPFrame(self.xknx)
-        ack_knxipframe.init(KNXIPServiceType.TUNNELLING_ACK)
-        ack_knxipframe.body.communication_channel_id = communication_channel_id
-        ack_knxipframe.body.sequence_counter = sequence_counter
-        ack_knxipframe.normalize()
-        self.udp_client.send(ack_knxipframe)
+        ack = TunnellingAck(
+            self.xknx,
+            communication_channel_id=communication_channel_id,
+            sequence_counter=sequence_counter,
+        )
+        self.udp_client.send(KNXIPFrame.init_from_body(ack))
 
     async def start(self):
         """Start tunneling."""

--- a/xknx/io/tunnelling.py
+++ b/xknx/io/tunnelling.py
@@ -1,5 +1,5 @@
 """Abstraction to send a TunnelingRequest and wait for TunnelingResponse."""
-from xknx.knxip import KNXIPFrame, KNXIPServiceType, TunnellingAck
+from xknx.knxip import CEMIFrame, KNXIPFrame, TunnellingAck, TunnellingRequest
 
 from .request_response import RequestResponse
 
@@ -28,12 +28,15 @@ class Tunnelling(RequestResponse):
         self.sequence_counter = sequence_counter
         self.communication_channel_id = communication_channel_id
 
-    def create_knxipframe(self):
+    def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
-        knxipframe = KNXIPFrame(self.xknx)
-        knxipframe.init(KNXIPServiceType.TUNNELLING_REQUEST)
-        knxipframe.body.communication_channel_id = self.communication_channel_id
-        knxipframe.body.cemi.telegram = self.telegram
-        knxipframe.body.cemi.src_addr = self.src_address
-        knxipframe.body.sequence_counter = self.sequence_counter
-        return knxipframe
+        cemi = CEMIFrame(self.xknx)
+        cemi.telegram = self.telegram
+        cemi.src_addr = self.src_address
+        tunnelling_request = TunnellingRequest(
+            self.xknx,
+            communication_channel_id=self.communication_channel_id,
+            sequence_counter=self.sequence_counter,
+            cemi=cemi,
+        )
+        return KNXIPFrame.init_from_body(tunnelling_request)

--- a/xknx/io/tunnelling.py
+++ b/xknx/io/tunnelling.py
@@ -1,5 +1,11 @@
 """Abstraction to send a TunnelingRequest and wait for TunnelingResponse."""
-from xknx.knxip import CEMIFrame, KNXIPFrame, TunnellingAck, TunnellingRequest
+from xknx.knxip import (
+    CEMIFrame,
+    CEMIMessageCode,
+    KNXIPFrame,
+    TunnellingAck,
+    TunnellingRequest,
+)
 
 from .request_response import RequestResponse
 
@@ -30,9 +36,12 @@ class Tunnelling(RequestResponse):
 
     def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
-        cemi = CEMIFrame(self.xknx)
-        cemi.telegram = self.telegram
-        cemi.src_addr = self.src_address
+        cemi = CEMIFrame.init_from_telegram(
+            self.xknx,
+            telegram=self.telegram,
+            code=CEMIMessageCode.L_Data_REQ,
+            src_addr=self.src_address,
+        )
         tunnelling_request = TunnellingRequest(
             self.xknx,
             communication_channel_id=self.communication_channel_id,

--- a/xknx/knxip/connect_request.py
+++ b/xknx/knxip/connect_request.py
@@ -19,12 +19,18 @@ class ConnectRequest(KNXIPBody):
 
     CRI_LENGTH = 4
 
-    def __init__(self, xknx):
+    def __init__(
+        self,
+        xknx,
+        request_type: ConnectRequestType = None,
+        control_endpoint: HPAI = HPAI(),
+        data_endpoint: HPAI = HPAI(),
+    ):
         """Initialize ConnectRequest object."""
         super().__init__(xknx)
-        self.request_type = None
-        self.control_endpoint = HPAI()
-        self.data_endpoint = HPAI()
+        self.request_type = request_type
+        self.control_endpoint = control_endpoint
+        self.data_endpoint = data_endpoint
         # KNX layer, 0x02 = TUNNEL_LINKLAYER
         self.flags = 0x02
 

--- a/xknx/knxip/connect_response.py
+++ b/xknx/knxip/connect_response.py
@@ -22,15 +22,24 @@ class ConnectResponse(KNXIPBody):
 
     CRD_LENGTH = 4
 
-    def __init__(self, xknx):
+    def __init__(
+        self,
+        xknx,
+        communication_channel: int = 0,
+        status_code: ErrorCode = ErrorCode.E_NO_ERROR,
+        request_type: ConnectRequestType = None,
+        control_endpoint: HPAI = HPAI(),
+        identifier: int = None,
+    ):
         """Initialize ConnectResponse class."""
         super().__init__(xknx)
 
-        self.communication_channel = 0
-        self.status_code = ErrorCode.E_NO_ERROR
-        self.request_type = None
+        self.communication_channel = communication_channel
+        self.status_code = status_code
+        self.request_type = request_type
         self.control_endpoint = HPAI()
-        self.identifier = None
+        # identifier shall contain KNX Individual Address assigned to this KNXnet/IP Tunnelling connection
+        self.identifier = identifier
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/connectionstate_request.py
+++ b/xknx/knxip/connectionstate_request.py
@@ -17,11 +17,13 @@ class ConnectionStateRequest(KNXIPBody):
 
     service_type = KNXIPServiceType.CONNECTIONSTATE_REQUEST
 
-    def __init__(self, xknx):
+    def __init__(
+        self, xknx, communication_channel_id: int = 1, control_endpoint: HPAI = HPAI()
+    ):
         """Initialize ConnectionStateRequest object."""
         super().__init__(xknx)
-        self.communication_channel_id = 1
-        self.control_endpoint = HPAI()
+        self.communication_channel_id = communication_channel_id
+        self.control_endpoint = control_endpoint
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/connectionstate_response.py
+++ b/xknx/knxip/connectionstate_response.py
@@ -18,11 +18,16 @@ class ConnectionStateResponse(KNXIPBody):
 
     service_type = KNXIPServiceType.CONNECTIONSTATE_RESPONSE
 
-    def __init__(self, xknx):
+    def __init__(
+        self,
+        xknx,
+        communication_channel_id: int = 1,
+        status_code: ErrorCode = ErrorCode.E_NO_ERROR,
+    ):
         """Initialize ConnectionStateResponse object."""
         super().__init__(xknx)
-        self.communication_channel_id = 1
-        self.status_code = ErrorCode.E_NO_ERROR
+        self.communication_channel_id = communication_channel_id
+        self.status_code = status_code
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/disconnect_request.py
+++ b/xknx/knxip/disconnect_request.py
@@ -17,12 +17,14 @@ class DisconnectRequest(KNXIPBody):
 
     service_type = KNXIPServiceType.DISCONNECT_REQUEST
 
-    def __init__(self, xknx):
+    def __init__(
+        self, xknx, communication_channel_id: int = 1, control_endpoint: HPAI = HPAI()
+    ):
         """Initialize DisconnectRequest object."""
         super().__init__(xknx)
 
-        self.communication_channel_id = 1
-        self.control_endpoint = HPAI()
+        self.communication_channel_id = communication_channel_id
+        self.control_endpoint = control_endpoint
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/disconnect_response.py
+++ b/xknx/knxip/disconnect_response.py
@@ -18,12 +18,17 @@ class DisconnectResponse(KNXIPBody):
 
     service_type = KNXIPServiceType.DISCONNECT_RESPONSE
 
-    def __init__(self, xknx):
+    def __init__(
+        self,
+        xknx,
+        communication_channel_id: int = 1,
+        status_code: ErrorCode = ErrorCode.E_NO_ERROR,
+    ):
         """Initialize DisconnectResponse object."""
         super().__init__(xknx)
 
-        self.communication_channel_id = 1
-        self.status_code = ErrorCode.E_NO_ERROR
+        self.communication_channel_id = communication_channel_id
+        self.status_code = status_code
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/knxip.py
+++ b/xknx/knxip/knxip.py
@@ -6,6 +6,7 @@ Depending on the service_type_ident different types of body classes are instanci
 """
 from xknx.exceptions import CouldNotParseKNXIP
 
+from .body import KNXIPBody
 from .connect_request import ConnectRequest
 from .connect_response import ConnectResponse
 from .connectionstate_request import ConnectionStateRequest
@@ -58,6 +59,15 @@ class KNXIPFrame:
             self.body = ConnectionStateResponse(self.xknx)
         else:
             raise TypeError(self.header.service_type_ident)
+
+    @staticmethod
+    def init_from_body(knxip_body: KNXIPBody):
+        """Return KNXIPFrame from KNXIPBody."""
+        knxipframe = KNXIPFrame(knxip_body.xknx)
+        knxipframe.header.service_type_ident = knxip_body.__class__.service_type
+        knxipframe.body = knxip_body
+        knxipframe.normalize()
+        return knxipframe
 
     def from_knx(self, data):
         """Parse/deserialize from KNX/IP raw data."""

--- a/xknx/knxip/routing_indication.py
+++ b/xknx/knxip/routing_indication.py
@@ -7,7 +7,7 @@ from xknx.exceptions import UnsupportedCEMIMessage
 
 from .body import KNXIPBody
 from .cemi_frame import CEMIFrame
-from .knxip_enum import KNXIPServiceType
+from .knxip_enum import CEMIMessageCode, KNXIPServiceType
 
 
 class RoutingIndication(KNXIPBody):
@@ -20,7 +20,11 @@ class RoutingIndication(KNXIPBody):
     def __init__(self, xknx, cemi: CEMIFrame = None):
         """Initialize SearchRequest object."""
         super().__init__(xknx)
-        self.cemi = cemi if cemi is not None else CEMIFrame(xknx)
+        self.cemi = (
+            cemi
+            if cemi is not None
+            else CEMIFrame(xknx, code=CEMIMessageCode.L_DATA_IND)
+        )
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/routing_indication.py
+++ b/xknx/knxip/routing_indication.py
@@ -17,10 +17,10 @@ class RoutingIndication(KNXIPBody):
 
     service_type = KNXIPServiceType.ROUTING_INDICATION
 
-    def __init__(self, xknx):
+    def __init__(self, xknx, cemi: CEMIFrame = None):
         """Initialize SearchRequest object."""
         super().__init__(xknx)
-        self.cemi = CEMIFrame(xknx)
+        self.cemi = cemi if cemi is not None else CEMIFrame(xknx)
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/search_request.py
+++ b/xknx/knxip/search_request.py
@@ -15,11 +15,13 @@ class SearchRequest(KNXIPBody):
 
     service_type = KNXIPServiceType.SEARCH_REQUEST
 
-    def __init__(self, xknx):
+    def __init__(self, xknx, discovery_endpoint: HPAI = None):
         """Initialize SearchRequest object."""
         super().__init__(xknx)
-        self.discovery_endpoint = HPAI(
-            ip_addr=xknx.multicast_group, port=xknx.multicast_port
+        self.discovery_endpoint = (
+            discovery_endpoint
+            if discovery_endpoint is not None
+            else HPAI(ip_addr=xknx.multicast_group, port=xknx.multicast_port)
         )
 
     def calculated_length(self):

--- a/xknx/knxip/search_response.py
+++ b/xknx/knxip/search_response.py
@@ -19,10 +19,10 @@ class SearchResponse(KNXIPBody):
 
     service_type = KNXIPServiceType.SEARCH_RESPONSE
 
-    def __init__(self, xknx):
+    def __init__(self, xknx, control_endpoint: HPAI = HPAI()):
         """Initialize SearchResponse object."""
         super().__init__(xknx)
-        self.control_endpoint = HPAI()
+        self.control_endpoint = control_endpoint
         self.dibs = []
 
     def calculated_length(self):

--- a/xknx/knxip/tunnelling_ack.py
+++ b/xknx/knxip/tunnelling_ack.py
@@ -20,11 +20,13 @@ class TunnellingAck(KNXIPBody):
 
     BODY_LENGTH = 4
 
-    def __init__(self, xknx):
+    def __init__(
+        self, xknx, communication_channel_id: int = 1, sequence_counter: int = 0
+    ):
         """Initialize TunnellingAck object."""
         super().__init__(xknx)
-        self.communication_channel_id = 1
-        self.sequence_counter = 0
+        self.communication_channel_id = communication_channel_id
+        self.sequence_counter = sequence_counter
         self.status_code = ErrorCode.E_NO_ERROR
 
     def calculated_length(self):

--- a/xknx/knxip/tunnelling_request.py
+++ b/xknx/knxip/tunnelling_request.py
@@ -31,9 +31,11 @@ class TunnellingRequest(KNXIPBody):
 
         self.communication_channel_id = communication_channel_id
         self.sequence_counter = sequence_counter
-        self.cemi = cemi if cemi is not None else CEMIFrame(xknx)
-
-        self.cemi.code = CEMIMessageCode.L_Data_REQ
+        self.cemi = (
+            cemi
+            if cemi is not None
+            else CEMIFrame(xknx, code=CEMIMessageCode.L_Data_REQ)
+        )
 
     def calculated_length(self):
         """Get length of KNX/IP body."""

--- a/xknx/knxip/tunnelling_request.py
+++ b/xknx/knxip/tunnelling_request.py
@@ -19,13 +19,20 @@ class TunnellingRequest(KNXIPBody):
 
     HEADER_LENGTH = 4
 
-    def __init__(self, xknx):
+    def __init__(
+        self,
+        xknx,
+        communication_channel_id: int = 1,
+        sequence_counter: int = 0,
+        cemi: CEMIFrame = None,
+    ):
         """Initialize TunnellingRequest object."""
         super().__init__(xknx)
 
-        self.communication_channel_id = 1
-        self.sequence_counter = 0
-        self.cemi = CEMIFrame(xknx)
+        self.communication_channel_id = communication_channel_id
+        self.sequence_counter = sequence_counter
+        self.cemi = cemi if cemi is not None else CEMIFrame(xknx)
+
         self.cemi.code = CEMIMessageCode.L_Data_REQ
 
     def calculated_length(self):


### PR DESCRIPTION
- initialize KNXIPBody objects directly, instead of creating empty objects
- create (outgoing) KNXIPFrame from KNXIPBody

- initialize CEMIFrame objects directly, instead of creating empty objects
- create (outgoing) CEMIFrame from Telegram

This saves a couple of function calls and is better readable imho.