### PR TITLE
Properly stop heartbeat before reconnecting

### DIFF
--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -228,6 +228,7 @@ class Tunnel:
     async def reconnect(self):
         """Reconnect to tunnel device."""
         self._is_reconnecting = True
+        await self.stop_heartbeat()
         await self.disconnect(True)
         self.init_udp_client()
         await self.start()


### PR DESCRIPTION
We should stop any pending heartbeat tasks before doing the reconnect as it will start another heartbeat.

probably fixes https://github.com/home-assistant/core/issues/40526