### PR TITLE
Add support for listening group addresses to RemoteValue

### DIFF
--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -143,7 +143,7 @@ class TestRemoteValue(unittest.TestCase):
         """Test if listening group addresses are processed."""
         xknx = XKNX()
         remote_value = RemoteValue(
-            xknx, group_address="1/2/3", listening_group_addresses=["1/1/1"]
+            xknx, group_address="1/2/3", passive_group_addresses=["1/1/1"]
         )
         self.assertTrue(remote_value.writable)
         self.assertFalse(remote_value.readable)

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -139,6 +139,27 @@ class TestRemoteValue(unittest.TestCase):
                 "State",
             )
 
+    def test_process_listening_address(self):
+        """Test if listening group addresses are processed."""
+        xknx = XKNX()
+        remote_value = RemoteValue(
+            xknx, group_address="1/2/3", listening_group_addresses=["1/1/1"]
+        )
+        self.assertTrue(remote_value.writable)
+        self.assertFalse(remote_value.readable)
+        # RemoteValue is initialized with only passive group address
+        self.assertTrue(remote_value.initialized)
+        with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid:
+            patch_valid.return_value = True
+            test_payload = DPTArray((0x01, 0x02))
+            telegram = Telegram(GroupAddress("1/1/1"), payload=test_payload)
+            self.assertTrue(
+                self.loop.run_until_complete(
+                    asyncio.Task(remote_value.process(telegram))
+                )
+            )
+            self.assertEqual(remote_value.payload, test_payload)
+
     def test_eq(self):
         """Test __eq__ operator."""
         xknx = XKNX()

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -66,7 +66,7 @@ class RemoteValue:
         return bool(
             self.group_address_state
             or self.group_address
-            or len(self.listening_group_addresses)
+            or self.listening_group_addresses
         )
 
     @property
@@ -240,5 +240,5 @@ class RemoteValue:
     def get_listening_group_addresses(passive_group_addresses: List[str]) -> List:
         """Obtain passive state group addresses."""
         if passive_group_addresses is None:
-            passive_group_addresses = []
+            return []
         return [GroupAddress(ga) for ga in passive_group_addresses]

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -7,6 +7,7 @@ Remote value can be :
 - or a group of both representing the same value.
 """
 import logging
+from typing import List
 
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram, TelegramType
@@ -27,10 +28,14 @@ class RemoteValue:
         device_name=None,
         feature_name=None,
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValue class."""
         # pylint: disable=too-many-arguments
         self.xknx = xknx
+        self.listening_group_addresses = RemoteValue.get_listening_group_addresses(
+            listening_group_addresses
+        )
         if group_address is not None:
             group_address = GroupAddress(group_address)
         if group_address_state is not None:
@@ -58,7 +63,11 @@ class RemoteValue:
     @property
     def initialized(self):
         """Evaluate if remote value is initialized with group address."""
-        return bool(self.group_address_state or self.group_address)
+        return bool(
+            self.group_address_state
+            or self.group_address
+            or len(self.listening_group_addresses)
+        )
 
     @property
     def readable(self):
@@ -72,7 +81,14 @@ class RemoteValue:
 
     def has_group_address(self, group_address):
         """Test if device has given group address."""
-        return group_address in [self.group_address, self.group_address_state]
+
+        def _internal_addresses():
+            """Yield all group_addresses."""
+            yield self.group_address
+            yield self.group_address_state
+            yield from self.listening_group_addresses
+
+        return group_address in _internal_addresses()
 
     def payload_valid(self, payload):
         """Test if telegram payload may be parsed - to be implemented in derived class.."""
@@ -219,3 +235,10 @@ class RemoteValue:
             if key not in self.__dict__:
                 return False
         return True
+
+    @staticmethod
+    def get_listening_group_addresses(passive_group_addresses: List[str]) -> List:
+        """Obtain passive state group addresses."""
+        if passive_group_addresses is None:
+            passive_group_addresses = []
+        return [GroupAddress(ga) for ga in passive_group_addresses]

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -28,13 +28,13 @@ class RemoteValue:
         device_name=None,
         feature_name=None,
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValue class."""
         # pylint: disable=too-many-arguments
         self.xknx = xknx
-        self.listening_group_addresses = RemoteValue.get_listening_group_addresses(
-            listening_group_addresses
+        self.passive_group_addresses = RemoteValue.get_passive_group_addresses(
+            passive_group_addresses
         )
         if group_address is not None:
             group_address = GroupAddress(group_address)
@@ -66,7 +66,7 @@ class RemoteValue:
         return bool(
             self.group_address_state
             or self.group_address
-            or self.listening_group_addresses
+            or self.passive_group_addresses
         )
 
     @property
@@ -86,7 +86,7 @@ class RemoteValue:
             """Yield all group_addresses."""
             yield self.group_address
             yield self.group_address_state
-            yield from self.listening_group_addresses
+            yield from self.passive_group_addresses
 
         return group_address in _internal_addresses()
 
@@ -237,7 +237,7 @@ class RemoteValue:
         return True
 
     @staticmethod
-    def get_listening_group_addresses(passive_group_addresses: List[str]) -> List:
+    def get_passive_group_addresses(passive_group_addresses: List[str]) -> List:
         """Obtain passive state group addresses."""
         if passive_group_addresses is None:
             return []

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -4,6 +4,7 @@ Module for managing an climate mode remote values.
 DPT .
 """
 from enum import Enum
+from typing import List
 
 from xknx.dpt import (
     DPTArray,
@@ -38,6 +39,7 @@ class RemoteValueClimateMode(RemoteValue):
         feature_name="Climate Mode",
         climate_mode_type=None,
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX climate mode."""
         # pylint: disable=too-many-arguments
@@ -49,6 +51,7 @@ class RemoteValueClimateMode(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         if not isinstance(climate_mode_type, self.ClimateModeType):
             raise ConversionError(

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -39,7 +39,7 @@ class RemoteValueClimateMode(RemoteValue):
         feature_name="Climate Mode",
         climate_mode_type=None,
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX climate mode."""
         # pylint: disable=too-many-arguments
@@ -51,7 +51,7 @@ class RemoteValueClimateMode(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         if not isinstance(climate_mode_type, self.ClimateModeType):
             raise ConversionError(

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -3,6 +3,8 @@ Module for managing an RGB remote value.
 
 DPT 232.600.
 """
+from typing import List
+
 from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError
 
@@ -20,6 +22,7 @@ class RemoteValueColorRGB(RemoteValue):
         device_name=None,
         feature_name="Color RGB",
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 232.600 (DPT_Color_RGB)."""
         # pylint: disable=too-many-arguments
@@ -30,6 +33,7 @@ class RemoteValueColorRGB(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -22,7 +22,7 @@ class RemoteValueColorRGB(RemoteValue):
         device_name=None,
         feature_name="Color RGB",
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 232.600 (DPT_Color_RGB)."""
         # pylint: disable=too-many-arguments
@@ -33,7 +33,7 @@ class RemoteValueColorRGB(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -22,7 +22,7 @@ class RemoteValueColorRGBW(RemoteValue):
         device_name=None,
         feature_name="Color RGBW",
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
         # pylint: disable=too-many-arguments
@@ -33,7 +33,7 @@ class RemoteValueColorRGBW(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         self.previous_value = (0, 0, 0, 0)
 

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -3,6 +3,8 @@ Module for managing an RGBW remote value.
 
 DPT 251.600.
 """
+from typing import List
+
 from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError
 
@@ -20,6 +22,7 @@ class RemoteValueColorRGBW(RemoteValue):
         device_name=None,
         feature_name="Color RGBW",
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
         # pylint: disable=too-many-arguments
@@ -30,6 +33,7 @@ class RemoteValueColorRGBW(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         self.previous_value = (0, 0, 0, 0)
 

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -5,6 +5,7 @@ DPT 10.001, 11.001 and 19.001
 """
 from enum import Enum
 import time
+from typing import List
 
 from xknx.dpt import DPTArray, DPTDate, DPTDateTime, DPTTime
 from xknx.exceptions import ConversionError
@@ -33,6 +34,7 @@ class RemoteValueDateTime(RemoteValue):
         device_name=None,
         feature_name="DateTime",
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
@@ -53,6 +55,7 @@ class RemoteValueDateTime(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -34,7 +34,7 @@ class RemoteValueDateTime(RemoteValue):
         device_name=None,
         feature_name="DateTime",
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
@@ -55,7 +55,7 @@ class RemoteValueDateTime(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -21,7 +21,7 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue):
         device_name=None,
         feature_name="Value",
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 7.001."""
         # pylint: disable=too-many-arguments
@@ -32,7 +32,7 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -3,6 +3,8 @@ Module for managing a DTP 7001 remote value.
 
 DPT 7.001.
 """
+from typing import List
+
 from xknx.dpt import DPT2ByteUnsigned, DPTArray
 
 from .remote_value import RemoteValue
@@ -19,6 +21,7 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue):
         device_name=None,
         feature_name="Value",
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 7.001."""
         # pylint: disable=too-many-arguments
@@ -29,6 +32,7 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -3,6 +3,8 @@ Module for managing a Scaling remote value.
 
 DPT 5.001.
 """
+from typing import List
+
 from xknx.dpt import DPTArray
 
 from .remote_value import RemoteValue
@@ -21,6 +23,7 @@ class RemoteValueScaling(RemoteValue):
         after_update_cb=None,
         range_from=0,
         range_to=100,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 5.001 (DPT_Scaling)."""
         # pylint: disable=too-many-arguments
@@ -31,6 +34,7 @@ class RemoteValueScaling(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         self.range_from = range_from
         self.range_to = range_to

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -23,7 +23,7 @@ class RemoteValueScaling(RemoteValue):
         after_update_cb=None,
         range_from=0,
         range_to=100,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 5.001 (DPT_Scaling)."""
         # pylint: disable=too-many-arguments
@@ -34,7 +34,7 @@ class RemoteValueScaling(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         self.range_from = range_from
         self.range_to = range_to

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -25,7 +25,7 @@ class RemoteValueSensor(RemoteValue):
         device_name=None,
         feature_name="Value",
         after_update_cb=None,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
@@ -43,7 +43,7 @@ class RemoteValueSensor(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -4,6 +4,8 @@ Module for managing a remote value typically used within a sensor.
 The module maps a given value_type to a DPT class and uses this class
 for serialization and deserialization of the KNX value.
 """
+from typing import List
+
 from xknx.dpt import DPTArray, DPTBase
 from xknx.exceptions import ConversionError
 
@@ -23,6 +25,7 @@ class RemoteValueSensor(RemoteValue):
         device_name=None,
         feature_name="Value",
         after_update_cb=None,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSensor class."""
         # pylint: disable=too-many-arguments
@@ -40,6 +43,7 @@ class RemoteValueSensor(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
 
     def payload_valid(self, payload):

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -3,6 +3,8 @@ Module for managing setpoint shifting.
 
 DPT 6.010.
 """
+from typing import List
+
 from xknx.remote_value import RemoteValue1Count
 
 
@@ -17,6 +19,7 @@ class RemoteValueSetpointShift(RemoteValue1Count):
         device_name=None,
         after_update_cb=None,
         setpoint_shift_step=0.1,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSetpointShift class."""
         # pylint: disable=too-many-arguments
@@ -27,6 +30,7 @@ class RemoteValueSetpointShift(RemoteValue1Count):
             device_name=device_name,
             feature_name="Setpoint shift value",
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
 
         self.setpoint_shift_step = setpoint_shift_step

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -19,7 +19,7 @@ class RemoteValueSetpointShift(RemoteValue1Count):
         device_name=None,
         after_update_cb=None,
         setpoint_shift_step=0.1,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize RemoteValueSetpointShift class."""
         # pylint: disable=too-many-arguments
@@ -30,7 +30,7 @@ class RemoteValueSetpointShift(RemoteValue1Count):
             device_name=device_name,
             feature_name="Setpoint shift value",
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
 
         self.setpoint_shift_step = setpoint_shift_step

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -4,6 +4,7 @@ Module for managing an DPT Step remote value.
 DPT 1.007.
 """
 from enum import Enum
+from typing import List
 
 from xknx.dpt import DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
@@ -29,6 +30,7 @@ class RemoteValueStep(RemoteValue):
         feature_name="Step",
         after_update_cb=None,
         invert=False,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.007."""
         # pylint: disable=too-many-arguments
@@ -39,6 +41,7 @@ class RemoteValueStep(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         self.invert = invert
 

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -30,7 +30,7 @@ class RemoteValueStep(RemoteValue):
         feature_name="Step",
         after_update_cb=None,
         invert=False,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.007."""
         # pylint: disable=too-many-arguments
@@ -41,7 +41,7 @@ class RemoteValueStep(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         self.invert = invert
 

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -24,7 +24,7 @@ class RemoteValueSwitch(RemoteValue):
         feature_name="State",
         after_update_cb=None,
         invert=False,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.001."""
         # pylint: disable=too-many-arguments
@@ -36,7 +36,7 @@ class RemoteValueSwitch(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         self.invert = invert
 

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -3,6 +3,8 @@ Module for managing an DPT Switch remote value.
 
 DPT 1.001.
 """
+from typing import List
+
 from xknx.dpt import DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
@@ -22,6 +24,7 @@ class RemoteValueSwitch(RemoteValue):
         feature_name="State",
         after_update_cb=None,
         invert=False,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.001."""
         # pylint: disable=too-many-arguments
@@ -33,6 +36,7 @@ class RemoteValueSwitch(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         self.invert = invert
 

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -4,6 +4,7 @@ Module for managing an DPT Up/Down remote value.
 DPT 1.008.
 """
 from enum import Enum
+from typing import List
 
 from xknx.dpt import DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
@@ -30,6 +31,7 @@ class RemoteValueUpDown(RemoteValue):
         feature_name="Up/Down",
         after_update_cb=None,
         invert=False,
+        listening_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.008."""
         # pylint: disable=too-many-arguments
@@ -40,6 +42,7 @@ class RemoteValueUpDown(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
+            listening_group_addresses=listening_group_addresses,
         )
         self.invert = invert
 

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -31,7 +31,7 @@ class RemoteValueUpDown(RemoteValue):
         feature_name="Up/Down",
         after_update_cb=None,
         invert=False,
-        listening_group_addresses: List[str] = None,
+        passive_group_addresses: List[str] = None,
     ):
         """Initialize remote value of KNX DPT 1.008."""
         # pylint: disable=too-many-arguments
@@ -42,7 +42,7 @@ class RemoteValueUpDown(RemoteValue):
             device_name=device_name,
             feature_name=feature_name,
             after_update_cb=after_update_cb,
-            listening_group_addresses=listening_group_addresses,
+            passive_group_addresses=passive_group_addresses,
         )
         self.invert = invert
 


### PR DESCRIPTION
Based on #321.

The only difference is that we use a dedicated `listening_group_addresses` setting instead of mixing it with the main GA.

The integration into the devices is not yet part of this PR but will be possible once the new config schema is ready.  (#437)