### PR TITLE
disable counter when context_timeout is 0

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -23,7 +23,9 @@ binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='1/2/3', devi
 - `name` is the name of the object.
 - `group_address_state` is the KNX group address of the sensor device.
 - `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
-- `reset_after` may be used to reset the internal state to `OFF` again after given time in ms. Defaults to `None`
+- `ignore_internal_state` allows callback call regardless of the current binary sensor state. Defaults to `True`
+- `context_timeout` time in seconds telegrams should be counted towards the current context to increment the counter. To be used with `ignore_internal_state=True`. Defaults to `None`
+- `reset_after` may be used to reset the internal state to `OFF` again after given time in sec. Defaults to `None`
 - `device_class` may be used to store the type of sensor, e.g. "motion" for motion detectors.
 
 ## [](#header-2)Example

--- a/docs/migration_ha_0116.md
+++ b/docs/migration_ha_0116.md
@@ -16,7 +16,7 @@ We've changed the default behavior of the `ignore_internal_state` attribute. It 
 If you encounter issues with your current automations please set it to `False` again. We've analysed the current state
 and it appears that most of the people using it have it set to `True`.
 
-The binary sensor now has an additional `context_timeout` attribute which can be used in order to define the time period
+The binary sensor now has an additional `context_timeout` attribute which allows to define a time period
 in which your clicks should be counted towards the current context (i.e. incrementing the counter variable that you can
 use in your automations).
 
@@ -54,6 +54,7 @@ Your new binary sensor will now look like:
 
 - name: cover_abstell
   state_address: "2/0/33"
+  context_timeout: 1.0
 
 ```
 
@@ -96,4 +97,4 @@ automation:
 
 If you intend to use the `counter` feature (counter > 1) make sure you also enable `ignore_internal_state`
 for your binary_sensor and set the `context_timeout` attribute to the time in between you want it to react to your
-sensor clicks (defaults to 1 - which should be fine). Otherwise the counter will _not_ work correctly.
+sensor clicks (defaults to None - which disables this feature). Otherwise the counter will _not_ work correctly.

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -246,7 +246,7 @@ def _create_binary_sensor(knx_module: XKNX, config: ConfigType) -> XknxBinarySen
         sync_state=config[BinarySensorSchema.CONF_SYNC_STATE],
         device_class=config.get(CONF_DEVICE_CLASS),
         ignore_internal_state=config[BinarySensorSchema.CONF_IGNORE_INTERNAL_STATE],
-        context_timeout=config[BinarySensorSchema.CONF_CONTEXT_TIMEOUT],
+        context_timeout=config.get(BinarySensorSchema.CONF_CONTEXT_TIMEOUT),
         reset_after=config.get(BinarySensorSchema.CONF_RESET_AFTER),
     )
 

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -102,7 +102,7 @@ class BinarySensorSchema:
                     cv.string,
                 ),
                 vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=True): cv.boolean,
-                vol.Optional(CONF_CONTEXT_TIMEOUT, default=1.0): vol.All(
+                vol.Optional(CONF_CONTEXT_TIMEOUT, default=0): vol.All(
                     vol.Coerce(float), vol.Range(min=0, max=10)
                 ),
                 vol.Required(CONF_STATE_ADDRESS): cv.string,

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -102,10 +102,10 @@ class BinarySensorSchema:
                     cv.string,
                 ),
                 vol.Optional(CONF_IGNORE_INTERNAL_STATE, default=True): cv.boolean,
-                vol.Optional(CONF_CONTEXT_TIMEOUT, default=0): vol.All(
+                vol.Required(CONF_STATE_ADDRESS): cv.string,
+                vol.Optional(CONF_CONTEXT_TIMEOUT): vol.All(
                     vol.Coerce(float), vol.Range(min=0, max=10)
                 ),
-                vol.Required(CONF_STATE_ADDRESS): cv.string,
                 vol.Optional(CONF_DEVICE_CLASS): cv.string,
                 vol.Optional(CONF_RESET_AFTER): cv.positive_int,
             }

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -304,7 +304,9 @@ class TestBinarySensor(unittest.TestCase):
     def test_counter(self):
         """Test counter functionality."""
         xknx = XKNX()
-        switch = BinarySensor(xknx, "TestInput", group_address_state="1/2/3")
+        switch = BinarySensor(
+            xknx, "TestInput", group_address_state="1/2/3", context_timeout=1
+        )
         with patch("time.time") as mock_time:
             mock_time.return_value = 1517000000.0
             self.assertEqual(switch.bump_and_get_counter(True), 1)

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -22,7 +22,7 @@ class BinarySensor(Device):
 
     # pylint: disable=too-many-instance-attributes
 
-    DEFAULT_CONTEXT_TIMEOUT = 1
+    DEFAULT_CONTEXT_TIMEOUT = 0
 
     def __init__(
         self,
@@ -30,7 +30,7 @@ class BinarySensor(Device):
         name,
         group_address_state=None,
         sync_state=True,
-        ignore_internal_state=False,
+        ignore_internal_state=True,
         device_class=None,
         reset_after=None,
         actions=None,
@@ -81,10 +81,10 @@ class BinarySensor(Device):
     def from_config(cls, xknx, name, config):
         """Initialize object from configuration structure."""
         group_address_state = config.get("group_address_state")
-        context_timeout = config.get("context_timeout", 1)
+        context_timeout = config.get("context_timeout", cls.DEFAULT_CONTEXT_TIMEOUT)
         sync_state = config.get("sync_state", True)
         device_class = config.get("device_class")
-        ignore_internal_state = config.get("ignore_internal_state", False)
+        ignore_internal_state = config.get("ignore_internal_state", True)
         actions = []
         if "actions" in config:
             for action in config["actions"]:

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -112,7 +112,7 @@ class BinarySensor(Device):
             self.state = state
             self.bump_and_get_counter(state)
 
-            if self.ignore_internal_state:
+            if self.ignore_internal_state and self._context_timeout:
                 if self._context_task:
                     self._context_task.cancel()
                 self._context_task = asyncio.create_task(


### PR DESCRIPTION
- enable use of ignore_internal_state without counter function
- don't run callbacks twice (2nd from finishing context_timeout immediately)

> cyberjunky on HA discord:
> I have windows sensors sending their stats every 10 minutes, the state doesn't change but the attribute counter: goes from 1 to 0 in 2 packets, so it triggers automation... and i have to code around it, ending up double automations (for on and off) it should be optional...