### PR TITLE
StateUpdater: only request one group address at once

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Internals
+
+- StateUpdater: Only request one GA at a time.
+
 ## 0.15.1 bugfix for binary sensors
 
 ### Devices

--- a/test/core_tests/state_updater_test.py
+++ b/test/core_tests/state_updater_test.py
@@ -142,13 +142,18 @@ class TestStateUpdater(unittest.TestCase):
         self.assertEqual(_get_only_tracker().tracker_type, StateTrackerType.EXPIRE)
         self.assertEqual(_get_only_tracker().update_interval, 60 * 60)
         remote_value_float.__del__()
+        logging_warning_mock.reset_mock()
         # intervall too long
-        with (self.assertRaises(ConversionError)):
-            remote_value_long = RemoteValue(
-                xknx, sync_state=1441, group_address_state=GroupAddress("1/1/1")
-            )
-
-            remote_value_long.__del__()
+        remote_value_long = RemoteValue(
+            xknx, sync_state=1441, group_address_state=GroupAddress("1/1/1")
+        )
+        logging_warning_mock.assert_called_once_with(
+            "StateUpdater interval of %s to long for %s. Using maximum of %s minutes (1 day)",
+            1441,
+            remote_value_long,
+            1440,
+        )
+        remote_value_long.__del__()
 
     def test_state_updater_start_update_stop(self):
         """Test start, update_received and stop of StateUpdater."""

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -20,7 +20,7 @@ class ValueReader:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, xknx, group_address, timeout_in_seconds=2):
+    def __init__(self, xknx, group_address, timeout_in_seconds=1):
         """Initialize ValueReader class."""
         self.xknx = xknx
         self.group_address = group_address

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -176,7 +176,6 @@ class RemoteValue:
     async def read_state(self, wait_for_result=False):
         """Send GroupValueRead telegram for state address to KNX bus."""
         if self.readable:
-            logger.debug("Sync %s - %s", self.device_name, self.feature_name)
             # pylint: disable=import-outside-toplevel
             # TODO: send a ReadRequset and start a timeout from here instead of ValueReader
             #       cancel timeout form process(); delete ValueReader


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Request one group address at a time. StateUpdater now waits for a response (or timeout) and only then triggers the next GroupValueRead request.
- set timeout for GroupValueRead requests back to 1 sec (from 2)
- remove some debug logs

This PR does what #364 was intended for 🙃

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
