### PR TITLE
Add DEVICE_CLASS support for cover

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -4,6 +4,7 @@ from xknx.devices import Cover as XknxCover
 from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
+    DEVICE_CLASSES,
     DEVICE_CLASS_BLIND,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
@@ -47,6 +48,8 @@ class KNXCover(KnxEntity, CoverEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
+        if self._device.device_class in DEVICE_CLASSES:
+            return self._device.device_class
         if self._device.supports_angle:
             return DEVICE_CLASS_BLIND
         return None

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -82,6 +82,7 @@ def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
         travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],
         invert_position=config[CoverSchema.CONF_INVERT_POSITION],
         invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
+        device_class=config.get(CONF_DEVICE_CLASS),
     )
 
 

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -77,6 +77,7 @@ class CoverSchema:
             ): cv.positive_int,
             vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
             vol.Optional(CONF_INVERT_ANGLE, default=False): cv.boolean,
+            vol.Optional(CONF_DEVICE_CLASS): cv.string,
         }
     )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -49,6 +49,7 @@ class Cover(Device):
         invert_position=False,
         invert_angle=False,
         device_updated_cb=None,
+        device_class=None, 
     ):
         """Initialize Cover class."""
         # pylint: disable=too-many-arguments
@@ -109,6 +110,8 @@ class Cover(Device):
         self.travel_time_up = travel_time_up
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
+        
+        self.device_class = device_class
 
     def _iter_remote_values(self):
         """Iterate the devices RemoteValue classes."""
@@ -128,6 +131,7 @@ class Cover(Device):
         travel_time_up = config.get("travel_time_up", cls.DEFAULT_TRAVEL_TIME_UP)
         invert_position = config.get("invert_position", False)
         invert_angle = config.get("invert_angle", False)
+        device_class = config.get("device_class")
 
         return cls(
             xknx,
@@ -143,6 +147,7 @@ class Cover(Device):
             travel_time_up=travel_time_up,
             invert_position=invert_position,
             invert_angle=invert_angle,
+            device_class=device_class, 
         )
 
     def __str__(self):


### PR DESCRIPTION
DEVICE_CLASS will be supported for covers as it is already done for binary_sensors.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
DEVICE_CLASS will be supported for covers as it is already done for binary_sensors. It shall be possible in future to define the cover DEVICE_CLASS directly in the YAML file in home assistant. For the time being the DEVICE_CLASS definition could only be done by customization.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
