### PR TITLE
New features to dockerize xknx

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,5 @@
 # Changelog
 
-## 0.15.3
-
-### Connection and dockerized apps
-
-- Add new optional config `bind_ip` and `bind_port` for connections to be able to dockerise xknx's apps.
-- Add optional config `local_port` to be able to map a host udp port to a container udp port.
-- Read env vars after reading config file to allow dynamic config for dockerized apps.
-
 ## 0.15.2 Winter is coming
 
 ### Devices

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,17 @@
 # Changelog
 
-## Unreleased changes
+## 0.15.2 Winter is coming
 
 ### Devices
 
-- Sensor: add `always_callback` option
 - ClimateMode: Refactor climate modes in operation_mode and controller_mode, also fixes a bug for binary operation modes where the mode would be set to AWAY no matter what value was sent to the bus.
+- Sensor: Add `always_callback` option
+- Switch: Allow resetting switches after x seconds with the new `reset_after` option.
 
 ### Internals
 
 - StateUpdater: Only request 3 GAs at a time.
+- RemoteValue: Add support for passive group addresses
 
 ## 0.15.1 bugfix for binary sensors
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 ## Unreleased Changes
 
+### New Features
+
+- Add new optional config `bind_ip` and `bind_port` for connections to be able to dockerise xknx's apps.
+- Add optional config `local_port` to be able to map a host udp port to a container udp port.
+- Read env vars after reading config file to allow dynamic config for dockerized apps.
+
 ### Devices
 
 - BinarySensor: added option to invert payloads

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,9 +28,6 @@ The configuration file can contain three sections.
     - `bind_port` (optional) sets the udp port sent into command telegrams by xknx (for dockerised app)
   - `routing` for a UDP multicast connection
     - `local_ip` (optional) sets the ip address that is used by xknx
-    - `local_port` (optional) sets the udp port that is used by xknx
-    - `bind_ip` (optional) sets the ip address sent into command telegrams by xknx (for dockerised app)
-    - `bind_port` (optional) sets the udp port sent into command telegrams by xknx (for dockerised app)
 - Within the `groups` sections all devices are defined. For each type of device more then one section might be specified. You need to append numbers or strings to differentiate the entries, as in the example below. The appended number or string must be unique.
 
 ## How to use

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -7,7 +7,17 @@ general:
     multicast_port: 1337
 
 connection:
+    # One of them: auto, tunneling or routing
     auto:
+    tunneling:
+        local_ip: "192.168.111.201"
+        local_port: 42424
+        bind_ip: "192.168.0.201"
+        bind_port: 42424
+        gateway_ip: "192.168.0.202"
+        gateway_port: 3671
+    routing:
+        local_ip: "192.168.111.201"
 
 groups:
     binary_sensor:

--- a/xknx/__version__.py
+++ b/xknx/__version__.py
@@ -1,3 +1,3 @@
 """XKNX version."""
 
-__version__ = "0.15.3"
+__version__ = "0.15.2"

--- a/xknx/__version__.py
+++ b/xknx/__version__.py
@@ -1,3 +1,3 @@
 """XKNX version."""
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"

--- a/xknx/config/config_v1.py
+++ b/xknx/config/config_v1.py
@@ -65,12 +65,16 @@ class ConfigV1:
     def env_general(self):
         """Get Env Vars for the general section."""
         if os.getenv('XKNX_GENERAL_OWN_ADDRESS', default=None):
+            logger.debug('XKNX_GENERAL_OWN_ADDRESS overwrite from env')
             self.xknx.own_address = os.getenv('XKNX_GENERAL_OWN_ADDRESS')
         if os.getenv('XKNX_GENERAL_RATE_LIMIT', default=None):
+            logger.debug('XKNX_GENERAL_RATE_LIMIT overwrite from env')
             self.xknx.rate_limit = os.getenv('XKNX_GENERAL_RATE_LIMIT')
         if os.getenv('XKNX_GENERAL_MULTICAST_GROUP', default=None):
+            logger.debug('XKNX_GENERAL_MULTICAST_GROUP overwrite from env')
             self.xknx.multicast_group = os.getenv('XKNX_GENERAL_MULTICAST_GROUP')
         if os.getenv('XKNX_GENERAL_MULTICAST_PORT', default=None):
+            logger.debug('XKNX_GENERAL_MULTICAST_PORT overwrite from env')
             self.xknx.multicast_port = os.getenv('XKNX_GENERAL_MULTICAST_PORT')
 
     def parse_connection(self, doc):
@@ -117,17 +121,23 @@ class ConfigV1:
 
     def env_connection(self):
         if os.getenv('XKNX_CONNECTION_GATEWAY_IP', default=None):
+            logger.debug('XKNX_CONNECTION_GATEWAY_IP overwrite from env')
             self.xknx.connection_config.gateway_ip = os.getenv('XKNX_CONNECTION_GATEWAY_IP')
         if os.getenv('XKNX_CONNECTION_GATEWAY_PORT', default=None):
-            self.xknx.connection_config.gateway_port = os.getenv('XKNX_CONNECTION_GATEWAY_PORT')
+            logger.debug('XKNX_CONNECTION_GATEWAY_PORT overwrite from env')
+            self.xknx.connection_config.gateway_port = int(os.getenv('XKNX_CONNECTION_GATEWAY_PORT'))
         if os.getenv('XKNX_CONNECTION_LOCAL_IP', default=None):
+            logger.debug('XKNX_CONNECTION_LOCAL_IP overwrite from env')
             self.xknx.connection_config.local_ip = os.getenv('XKNX_CONNECTION_LOCAL_IP')
         if os.getenv('XKNX_CONNECTION_LOCAL_PORT', default=None):
-            self.xknx.connection_config.local_port = os.getenv('XKNX_CONNECTION_LOCAL_PORT')
+            logger.debug('XKNX_CONNECTION_LOCAL_PORT overwrite from env')
+            self.xknx.connection_config.local_port = int(os.getenv('XKNX_CONNECTION_LOCAL_PORT'))
         if os.getenv('XKNX_CONNECTION_BIND_IP', default=None):
+            logger.debug('XKNX_CONNECTION_BIND_IP overwrite from env')
             self.xknx.connection_config.bind_ip = os.getenv('XKNX_CONNECTION_BIND_IP')
         if os.getenv('XKNX_CONNECTION_BIND_PORT', default=None):
-            self.xknx.connection_config.bind_port = os.getenv('XKNX_CONNECTION_BIND_PORT')
+            logger.debug('XKNX_CONNECTION_BIND_PORT overwrite from env')
+            self.xknx.connection_config.bind_port = int(os.getenv('XKNX_CONNECTION_BIND_PORT'))
 
     def parse_groups(self, doc):
         """Parse the group section of xknx.yaml."""

--- a/xknx/io/connect.py
+++ b/xknx/io/connect.py
@@ -24,7 +24,7 @@ class Connect(RequestResponse):
         """Create KNX/IP Frame object to be sent to device."""
         (local_addr, local_port) = self.udp_client.getsockname()
         # set control_endpoint and data_endpoint to the same udp_connection
-        if self.net_bind:
+        if self.net_bind and self.net_bind[0]:
             endpoint = HPAI(ip_addr=self.net_bind[0], port=self.net_bind[1])
         else:
             endpoint = HPAI(ip_addr=local_addr, port=local_port)

--- a/xknx/io/connectionstate.py
+++ b/xknx/io/connectionstate.py
@@ -7,7 +7,7 @@ from .request_response import RequestResponse
 class ConnectionState(RequestResponse):
     """Class to send ConnectonStateRequest and wait for ConnectionStateResponse."""
 
-    def __init__(self, xknx, udp_client, communication_channel_id, net_bind):
+    def __init__(self, xknx, udp_client, communication_channel_id, net_bind=None):
         """Initialize ConnectionState class."""
         self.udp_client = udp_client
         super().__init__(xknx, self.udp_client, ConnectionStateResponse, net_bind=net_bind)

--- a/xknx/io/disconnect.py
+++ b/xknx/io/disconnect.py
@@ -16,11 +16,11 @@ class Disconnect(RequestResponse):
 
     def create_knxipframe(self) -> KNXIPFrame:
         """Create KNX/IP Frame object to be sent to device."""
-        (local_addr, local_port) = self.udpclient.getsockname()
         if self.net_bind:
-            endpoint = HPAI(ip_addr=self.net_bind[0], port=self.net_bind[1])
+            (local_addr, local_port) = net_bind
         else:
-            endpoint = HPAI(ip_addr=local_addr, port=local_port)
+            (local_addr, local_port) = self.udpclient.getsockname()
+        endpoint = HPAI(ip_addr=local_addr, port=local_port)
         disconnect_request = DisconnectRequest(
             self.xknx,
             communication_channel_id=self.communication_channel_id,

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -98,7 +98,7 @@ class KNXIPInterface:
             self.connection_config.connection_type == ConnectionType.ROUTING
             and self.connection_config.local_ip is not None
         ):
-            await self.start_routing(self.connection_config.local_ip, self.connection_config.local_port)
+            await self.start_routing(self.connection_config.local_ip)
         elif self.connection_config.connection_type == ConnectionType.TUNNELING:
             await self.start_tunnelling(
                 self.connection_config.local_ip,
@@ -139,7 +139,7 @@ class KNXIPInterface:
                 bind_port=self.connection_config.bind_port,
             )
         elif gateway.supports_routing:
-            await self.start_routing(local_interface_ip, self.connection_config.local_port)
+            await self.start_routing(local_interface_ip)
 
     async def start_tunnelling(
         self, local_ip, local_port, gateway_ip, gateway_port, auto_reconnect, auto_reconnect_wait,
@@ -168,11 +168,11 @@ class KNXIPInterface:
         )
         await self.interface.start()
 
-    async def start_routing(self, local_ip: str, local_port: int) -> None:
+    async def start_routing(self, local_ip: str) -> None:
         """Start KNX/IP Routing."""
         validate_ip(local_ip, address_name="Local IP address")
         logger.debug("Starting Routing from %s", local_ip)
-        self.interface = Routing(self.xknx, self.telegram_received, local_ip, local_port)
+        self.interface = Routing(self.xknx, self.telegram_received, local_ip)
         await self.interface.start()
 
     async def stop(self) -> None:

--- a/xknx/io/request_response.py
+++ b/xknx/io/request_response.py
@@ -16,11 +16,10 @@ class RequestResponse:
 
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, xknx, udp_client, awaited_response_class, timeout_in_seconds=1, net_bind=None):
+    def __init__(self, xknx, udp_client, awaited_response_class, timeout_in_seconds=1):
         """Initialize RequstResponse class."""
         self.xknx = xknx
         self.udpclient = udp_client
-        self.net_bind = net_bind
         self.awaited_response_class = awaited_response_class
         self.response_received_or_timeout = asyncio.Event()
         self.success = False

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("xknx.log")
 class Routing:
     """Class for handling KNX/IP routing."""
 
-    def __init__(self, xknx, telegram_received_callback, local_ip, local_port):
+    def __init__(self, xknx, telegram_received_callback, local_ip):
         """Initialize Routing class."""
         self.xknx = xknx
         self.telegram_received_callback = telegram_received_callback
@@ -31,7 +31,7 @@ class Routing:
 
         self.udpclient = UDPClient(
             self.xknx,
-            (local_ip, local_port),
+            (local_ip, 0),
             (self.xknx.multicast_group, self.xknx.multicast_port),
             multicast=True,
         )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

To be able to run xknx into a docker container, their is some changes to do:
- automatic local udp port (throw 0) do not allowed us to forward the host's udp port to a named udp port of the container
- using the local ip and port in the Connect, Disconnect and ConnectionState is not working, it is the host ip and port that must be sent to the KNX Gateway.

So new implemented features are:
- Add new optional config `bind_ip` and `bind_port` for connections to be able to dockerised xknx's apps.
- Add optional config `local_port` to be able to map a host udp port to a container udp port.
- Read env vars after reading config file to allow dynamic config for dockerized apps.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
