### PR TITLE
Add DEVICE_CLASS support for cover

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ groups:
         group_address_position_feedback: "1/4/11",
         travel_time_down: 50,
         travel_time_up: 60,
-        device_class="shutter",
+        device_class: "shutter",
       }
 
     # Central Shutters dont have short or position address

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,7 +117,7 @@ groups:
         travel_time_up: 60,
       }
 
-    # Covers without direct positioning:
+    # Covers without direct positioning and device class "shutter":
     Livingroom.Shutter_3:
       {
         group_address_long: "1/4/9",
@@ -125,6 +125,7 @@ groups:
         group_address_position_feedback: "1/4/11",
         travel_time_down: 50,
         travel_time_up: 60,
+        device_class="shutter",
       }
 
     # Central Shutters dont have short or position address

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -26,7 +26,7 @@ Shutters are simple representations of blind/roller cover actuators. With XKNX y
 - `travel_time_up` seconds to reach upper end position. Default: 22
 - `invert_position` invert position (payload for eg. set_up() and relative position). Default: False
 - `invert_angle` invert angle. Default: False
-- `device_class` may be used to store the type of cover, e.g. "shutter" for Home-Assistant.
+- `device_class` may be used to store the type of cover, e.g. "shutter" for Home-Assistant (see [cover documentation](https://www.home-assistant.io/integrations/cover/) for details).
 - `device_updated_cb` awaitable callback for each update.
 
 ## [](#header-2)Example

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -26,6 +26,7 @@ Shutters are simple representations of blind/roller cover actuators. With XKNX y
 - `travel_time_up` seconds to reach upper end position. Default: 22
 - `invert_position` invert position (payload for eg. set_up() and relative position). Default: False
 - `invert_angle` invert angle. Default: False
+- `device_class` may be used to store the type of sensor, e.g. "shutter" for Home-Assistant.
 - `device_updated_cb` awaitable callback for each update.
 
 ## [](#header-2)Example
@@ -42,7 +43,8 @@ cover = Cover(xknx,
               travel_time_down=50,
               travel_time_up=60,
               invert_position=False,
-              invert_angle=False)
+              invert_angle=False,
+              device_class='shutter')
 
 # Moving to up position
 await cover.set_up()

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -26,7 +26,7 @@ Shutters are simple representations of blind/roller cover actuators. With XKNX y
 - `travel_time_up` seconds to reach upper end position. Default: 22
 - `invert_position` invert position (payload for eg. set_up() and relative position). Default: False
 - `invert_angle` invert angle. Default: False
-- `device_class` may be used to store the type of sensor, e.g. "shutter" for Home-Assistant.
+- `device_class` may be used to store the type of cover, e.g. "shutter" for Home-Assistant.
 - `device_updated_cb` awaitable callback for each update.
 
 ## [](#header-2)Example

--- a/home-assistant-plugin/custom_components/xknx/cover.py
+++ b/home-assistant-plugin/custom_components/xknx/cover.py
@@ -5,6 +5,7 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DEVICE_CLASS_BLIND,
+    DEVICE_CLASSES,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
@@ -47,6 +48,8 @@ class KNXCover(KnxEntity, CoverEntity):
     @property
     def device_class(self):
         """Return the class of this device, from component DEVICE_CLASSES."""
+        if self._device.device_class in DEVICE_CLASSES:
+            return self._device.device_class
         if self._device.supports_angle:
             return DEVICE_CLASS_BLIND
         return None

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -82,6 +82,7 @@ def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
         travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],
         invert_position=config[CoverSchema.CONF_INVERT_POSITION],
         invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
+        device_class=config.get(CONF_DEVICE_CLASS),
     )
 
 

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -77,6 +77,7 @@ class CoverSchema:
             ): cv.positive_int,
             vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
             vol.Optional(CONF_INVERT_ANGLE, default=False): cv.boolean,
+            vol.Optional(CONF_DEVICE_CLASS): cv.string,
         }
     )
 

--- a/test/config_tests/config_v1_test.py
+++ b/test/config_tests/config_v1_test.py
@@ -267,7 +267,7 @@ class TestConfig(unittest.TestCase):
                 travel_time_up=60,
             ),
         )
-        
+
     def test_config_cover_device_class(self):
         """Test reading cover with device_class from config file."""
         self.assertEqual(

--- a/test/config_tests/config_v1_test.py
+++ b/test/config_tests/config_v1_test.py
@@ -275,10 +275,9 @@ class TestConfig(unittest.TestCase):
             Cover(
                 TestConfig.xknx,
                 "Livingroom.Shutter_3",
-                group_address_long="1/4/5",
-                group_address_short="1/4/6",
-                group_address_position_state="1/4/7",
-                group_address_position="1/4/8",
+                group_address_long="1/4/9",
+                group_address_short="1/4/10",
+                group_address_position_state="1/4/11",
                 travel_time_down=50,
                 travel_time_up=60,
                 device_class="shutter",

--- a/test/config_tests/config_v1_test.py
+++ b/test/config_tests/config_v1_test.py
@@ -267,6 +267,23 @@ class TestConfig(unittest.TestCase):
                 travel_time_up=60,
             ),
         )
+        
+    def test_config_cover_device_class(self):
+        """Test reading cover with device_class from config file."""
+        self.assertEqual(
+            TestConfig.xknx.devices["Livingroom.Shutter_3"],
+            Cover(
+                TestConfig.xknx,
+                "Livingroom.Shutter_3",
+                group_address_long="1/4/5",
+                group_address_short="1/4/6",
+                group_address_position_state="1/4/7",
+                group_address_position="1/4/8",
+                travel_time_down=50,
+                travel_time_up=60,
+                device_class="shutter",
+            ),
+        )
 
     def test_config_cover_venetian(self):
         """Test reading Cover with angle from config file."""

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -166,7 +166,6 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_angle_state="1/2/8",
             travel_time_down=8,
             travel_time_up=10,
-            device_class="shutter",
         )
         self.assertEqual(
             str(cover),

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -166,6 +166,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_angle_state="1/2/8",
             travel_time_down=8,
             travel_time_up=10,
+            device_class="shutter",
         )
         self.assertEqual(
             str(cover),

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -109,7 +109,7 @@ groups:
                 group_address_position_state: "1/4/11",
                 travel_time_down: 50,
                 travel_time_up: 60,
-                device_class="shutter",
+                device_class: "shutter",
             }
 
         # Central Shutters dont have short or position address

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -101,7 +101,7 @@ groups:
                 travel_time_up: 60,
             }
 
-        # Covers without direct positioning:
+        # Covers without direct positioning and device class "shutter":
         Livingroom.Shutter_3:
             {
                 group_address_long: "1/4/9",
@@ -109,6 +109,7 @@ groups:
                 group_address_position_state: "1/4/11",
                 travel_time_down: 50,
                 travel_time_up: 60,
+                device_class="shutter",
             }
 
         # Central Shutters dont have short or position address

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -49,7 +49,7 @@ class Cover(Device):
         invert_position=False,
         invert_angle=False,
         device_updated_cb=None,
-        device_class=None,  
+        device_class=None,
     ):
         """Initialize Cover class."""
         # pylint: disable=too-many-arguments
@@ -110,8 +110,8 @@ class Cover(Device):
         self.travel_time_up = travel_time_up
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
-        
-        self.device_class = device_class  
+
+        self.device_class = device_class
 
     def _iter_remote_values(self):
         """Iterate the devices RemoteValue classes."""
@@ -131,7 +131,7 @@ class Cover(Device):
         travel_time_up = config.get("travel_time_up", cls.DEFAULT_TRAVEL_TIME_UP)
         invert_position = config.get("invert_position", False)
         invert_angle = config.get("invert_angle", False)
-        device_class = config.get("device_class")   
+        device_class = config.get("device_class")
 
         return cls(
             xknx,
@@ -147,7 +147,7 @@ class Cover(Device):
             travel_time_up=travel_time_up,
             invert_position=invert_position,
             invert_angle=invert_angle,
-            device_class=device_class,   
+            device_class=device_class,
         )
 
     def __str__(self):

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -49,6 +49,7 @@ class Cover(Device):
         invert_position=False,
         invert_angle=False,
         device_updated_cb=None,
+        device_class=None,  
     ):
         """Initialize Cover class."""
         # pylint: disable=too-many-arguments
@@ -109,6 +110,8 @@ class Cover(Device):
         self.travel_time_up = travel_time_up
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
+        
+        self.device_class = device_class  
 
     def _iter_remote_values(self):
         """Iterate the devices RemoteValue classes."""
@@ -128,6 +131,7 @@ class Cover(Device):
         travel_time_up = config.get("travel_time_up", cls.DEFAULT_TRAVEL_TIME_UP)
         invert_position = config.get("invert_position", False)
         invert_angle = config.get("invert_angle", False)
+        device_class = config.get("device_class")   
 
         return cls(
             xknx,
@@ -143,6 +147,7 @@ class Cover(Device):
             travel_time_up=travel_time_up,
             invert_position=invert_position,
             invert_angle=invert_angle,
+            device_class=device_class,   
         )
 
     def __str__(self):


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
DEVICE_CLASS will be supported for covers as it is already done for binary_sensors. It will be possible in future to define the cover DEVICE_CLASS directly in the YAML file in home assistant. For the time being the DEVICE_CLASS definition could only be done by customization.
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
