### PR TITLE
HA: use Entity.force_update when appropriate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### HA integration
+
+- return BinarySensor.ignore_internal_state or Sensor.always_callback for Entity.force_update instead of defaulting to `False`
+
 ## 0.15.3 Opposite day! 2020-10-29
 
 ### Devices

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -41,3 +41,11 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity):
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return device specific state attributes."""
         return {ATTR_COUNTER: self._device.counter}
+
+    @property
+    def force_update(self) -> bool:
+        """Return True if state updates should be forced.
+        If True, a state change will be triggered anytime the state property is
+        updated, not just when the value changes.
+        """
+        return self._device.ignore_internal_state

--- a/home-assistant-plugin/custom_components/xknx/sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/sensor.py
@@ -41,3 +41,11 @@ class KNXSensor(KnxEntity, Entity):
         if device_class in DEVICE_CLASSES:
             return device_class
         return None
+
+    @property
+    def force_update(self) -> bool:
+        """Return True if state updates should be forced.
+        If True, a state change will be triggered anytime the state property is
+        updated, not just when the value changes.
+        """
+        return self._device.always_callback


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Use Entity.force_update to have state updates in HA when BinarySensor.ignore_internal_state or Sensor.always_callback is True.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
