### PR TITLE
Fix Switch not initialized from StateUpdater

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Light, Switch: initialize state with `None` instead of `False` to account for unknown state.
 
+### Bugfixes
+
+- Switch.after_update was not called from RemoteValueSwitch.read_state (StateUpdater). Moved Switch.state to RemoteValue again.
+
 ## 0.15.3 Opposite day! 2020-10-29
 
 ### Devices

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -36,7 +36,6 @@ class Switch(Device):
 
         self.reset_after = reset_after
         self._reset_task = None
-        self.state = None
 
         self.switch = RemoteValueSwitch(
             xknx,
@@ -44,6 +43,7 @@ class Switch(Device):
             group_address_state,
             invert=invert,
             device_name=self.name,
+            after_update_cb=self.after_update,
         )
 
     def _iter_remote_values(self):
@@ -72,6 +72,11 @@ class Switch(Device):
             reset_after=reset_after,
         )
 
+    @property
+    def state(self) -> Optional[bool]:
+        """Return the current switch state of the device."""
+        return self.switch.value
+
     async def set_on(self):
         """Switch on switch."""
         await self.switch.on()
@@ -94,14 +99,12 @@ class Switch(Device):
     async def process_group_write(self, telegram):
         """Process incoming and outgoing GROUP WRITE telegram."""
         if await self.switch.process(telegram):
-            self.state = self.switch.value
-            if self.reset_after is not None and self.state:
+            if self.reset_after is not None and self.switch.value:
                 if self._reset_task:
                     self._reset_task.cancel()
                 self._reset_task = asyncio.create_task(
                     self._reset_state(self.reset_after)
                 )
-            await self.after_update()
 
     async def _reset_state(self, wait_seconds: float):
         await asyncio.sleep(wait_seconds)


### PR DESCRIPTION
by moving state to RemoteValue again

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Switch.after_update was not called from RemoteValueSwitch.read_state (StateUpdater). Moved Switch.state to RemoteValue again.
Now it should initialize state correctly from HA again.
I also added a bunch of tests that are mostly useless, but who knows, maybe they will be useful in the future.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
