### PR TITLE
process every incoming Telegram in all Devices

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Light, Switch: initialize state with `None` instead of `False` to account for unknown state.
 
+### Internals
+
+- process every incoming Telegram in all Devices, regardless if a callback for the GA is registered (eg. StateUpdater) or not.
+
 ## 0.15.3 Opposite day! 2020-10-29
 
 ### Devices

--- a/examples/example_telegram_monitor.py
+++ b/examples/example_telegram_monitor.py
@@ -10,7 +10,6 @@ from xknx.telegram import AddressFilter
 async def telegram_received_cb(telegram):
     """Do something with the received telegram."""
     print(f"Telegram received: {telegram}")
-    return True
 
 
 def show_help():

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -326,8 +326,6 @@ class KNXModule:
             "knx_event",
             {"address": str(telegram.group_address), "data": telegram.payload.value},
         )
-        # False signals XKNX to proceed with processing telegrams.
-        return False
 
     async def service_send_to_knx_bus(self, call):
         """Service for sending an arbitrary KNX message to the KNX bus."""

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -176,9 +176,9 @@ class TestTelegramQueue(unittest.TestCase):
         devices_by_ga_mock.assert_called_once_with(GroupAddress("1/2/3"))
         test_device.process.assert_called_once_with(telegram)
 
-    @patch("xknx.devices.Devices.devices_by_group_address")
-    def test_process_to_callback(self, devices_by_ga_mock):
-        """Test process_telegram_incoming for returning after processing callback."""
+    @patch("xknx.devices.Devices.process")
+    def test_process_to_callback(self, devices_process):
+        """Test process_telegram_incoming with callback."""
         # pylint: disable=no-self-use
         xknx = XKNX()
 
@@ -200,7 +200,7 @@ class TestTelegramQueue(unittest.TestCase):
             xknx.telegram_queue.process_telegram_incoming(telegram)
         )
         telegram_received_callback.assert_called_once_with(telegram)
-        devices_by_ga_mock.assert_not_called()
+        devices_process.assert_called_once_with(telegram)
 
     @patch("xknx.io.KNXIPInterface")
     @patch("logging.Logger.warning")

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -9,6 +9,14 @@ from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import AddressFilter, GroupAddress, Telegram, TelegramDirection
 
 
+class AsyncMock(MagicMock):
+    """Async Mock."""
+
+    # pylint: disable=invalid-overridden-method
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
 class TestTelegramQueue(unittest.TestCase):
     """Test class for telegram queue."""
 
@@ -127,7 +135,7 @@ class TestTelegramQueue(unittest.TestCase):
         # pylint: disable=no-self-use
         xknx = XKNX()
 
-        telegram_received_callback = Mock()
+        telegram_received_callback = AsyncMock()
 
         async def async_telegram_received_cb(device):
             """Async callback."""

--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -135,12 +135,18 @@ class TestValueReader(unittest.TestCase):
                 value_reader.telegram_received(test_telegram)
             )
 
-        self.assertFalse(async_telegram_received(telegram_wrong_address))
-        self.assertFalse(async_telegram_received(telegram_wrong_type))
+        async_telegram_received(telegram_wrong_address)
         self.assertIsNone(value_reader.received_telegram)
+        self.assertFalse(value_reader.success)
 
-        self.assertTrue(async_telegram_received(expected_telegram_1))
+        async_telegram_received(telegram_wrong_type)
+        self.assertIsNone(value_reader.received_telegram)
+        self.assertFalse(value_reader.success)
+
+        async_telegram_received(expected_telegram_1)
         self.assertEqual(value_reader.received_telegram, expected_telegram_1)
+        self.assertTrue(value_reader.success)
 
-        self.assertTrue(async_telegram_received(expected_telegram_2))
+        async_telegram_received(expected_telegram_2)
         self.assertEqual(value_reader.received_telegram, expected_telegram_2)
+        self.assertTrue(value_reader.success)

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -141,12 +141,7 @@ class TelegramQueue:
     async def process_telegram_incoming(self, telegram):
         """Process incoming telegram."""
         telegram_logger.debug(telegram)
-        processed = False
         for telegram_received_cb in self.telegram_received_cbs:
             if telegram_received_cb.is_within_filter(telegram):
-                ret = await telegram_received_cb.callback(telegram)
-                if ret:
-                    processed = True
-        # TODO: why don't we process every incoming telegram by device?
-        if not processed:
-            await self.xknx.devices.process(telegram)
+                await telegram_received_cb.callback(telegram)
+        await self.xknx.devices.process(telegram)

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -53,17 +53,13 @@ class ValueReader:
 
     async def telegram_received(self, telegram):
         """Test if telegram has correct group address and trigger event."""
-        if telegram.telegramtype not in (
+        if telegram.group_address == self.group_address and telegram.telegramtype in (
             TelegramType.GROUP_RESPONSE,
             TelegramType.GROUP_WRITE,
         ):
-            return False
-        if self.group_address != telegram.group_address:
-            return False
-        self.success = True
-        self.received_telegram = telegram
-        self.response_received_or_timeout.set()
-        return True
+            self.success = True
+            self.received_telegram = telegram
+            self.response_received_or_timeout.set()
 
     def timeout(self):
         """Handle timeout for not having received expected group response."""

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -109,7 +109,7 @@ class RemoteValue:
         logger.warning("'to_knx()' not implemented for %s", self.__class__.__name__)
 
     async def process(self, telegram, always_callback=False):
-        """Process incoming telegram."""
+        """Process incoming or outgoing telegram."""
         if not self.has_group_address(telegram.group_address):
             return False
         if not self.payload_valid(telegram.payload):


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
process every incoming Telegram in all Devices regardless if a callback for the GA is registered (eg. StateUpdater) or not.

This will process Telegrams from the Device class even when a callback for this GA is registered ge. from StateUpdater. Some RemoteValues have no callbacks set (ClimateMode, Cover.position) from their Device so the state would not get initialized properly. 
Also devices that use same GAs will be updated each, instead only one.

I'm not sure why this even was prohibited before - maybe @Julius2342 can help me out here?


This will need some testing - especially for climate modes and cover positions (which I don't have in my installation).

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
