### PR TITLE
Rename `Telegram.group_address` to `Telegram.destination_address`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Internals
+
+- Telegram: `group_address` renamed to `address`, to prepare support for other APCI services.
+
 ## 0.15.5 A Telegram for everyone 2020-11-25
 
 ### Internals

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Internals
 
-- Telegram: `group_address` renamed to `address`, to prepare support for other APCI services.
+- Telegram: `group_address` renamed to `destination_address`, to prepare support for other APCI services.
 
 ## 0.15.6 Bugfix for StateUpater 2020-11-26
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -324,7 +324,10 @@ class KNXModule:
         """Call invoked after a KNX telegram was received."""
         self.hass.bus.async_fire(
             "knx_event",
-            {"address": str(telegram.address), "data": telegram.payload.value},
+            {
+                "address": str(telegram.destination_address),
+                "data": telegram.payload.value
+            },
         )
 
     async def service_send_to_knx_bus(self, call):
@@ -344,10 +347,10 @@ class KNXModule:
                 return DPTBinary(attr_payload)
             return DPTArray(attr_payload)
 
-        payload = calculate_payload(attr_payload)
-        address = GroupAddress(attr_address)
-
-        telegram = Telegram(address=address, payload=payload)
+        telegram = Telegram(
+            destination_address=GroupAddress(attr_address),
+            payload=calculate_payload(attr_payload)
+        )
         await self.xknx.telegrams.put(telegram)
 
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -324,7 +324,7 @@ class KNXModule:
         """Call invoked after a KNX telegram was received."""
         self.hass.bus.async_fire(
             "knx_event",
-            {"address": str(telegram.group_address), "data": telegram.payload.value},
+            {"address": str(telegram.address), "data": telegram.payload.value},
         )
 
     async def service_send_to_knx_bus(self, call):
@@ -347,7 +347,7 @@ class KNXModule:
         payload = calculate_payload(attr_payload)
         address = GroupAddress(attr_address)
 
-        telegram = Telegram(group_address=address, payload=payload)
+        telegram = Telegram(address=address, payload=payload)
         await self.xknx.telegrams.put(telegram)
 
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -326,7 +326,7 @@ class KNXModule:
             "knx_event",
             {
                 "address": str(telegram.destination_address),
-                "data": telegram.payload.value
+                "data": telegram.payload.value,
             },
         )
 
@@ -349,7 +349,7 @@ class KNXModule:
 
         telegram = Telegram(
             destination_address=GroupAddress(attr_address),
-            payload=calculate_payload(attr_payload)
+            payload=calculate_payload(attr_payload),
         )
         await self.xknx.telegrams.put(telegram)
 

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -38,9 +38,9 @@ class TestTelegramQueue(unittest.TestCase):
         xknx = XKNX()
 
         telegram_in = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -76,13 +76,13 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
         )
 
         telegram_out = Telegram(
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -118,9 +118,9 @@ class TestTelegramQueue(unittest.TestCase):
         xknx.telegram_queue.register_telegram_received_cb(async_telegram_received_cb)
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -142,9 +142,9 @@ class TestTelegramQueue(unittest.TestCase):
         xknx.telegram_queue.unregister_telegram_received_cb(callback)
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -168,9 +168,9 @@ class TestTelegramQueue(unittest.TestCase):
         devices_by_ga_mock.return_value = [test_device]
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -191,9 +191,9 @@ class TestTelegramQueue(unittest.TestCase):
         )
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -213,9 +213,9 @@ class TestTelegramQueue(unittest.TestCase):
         if_mock.send_telegram.return_value = async_if_send_telegram
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
 
         # log a warning if there is no KNXIP interface instanciated
@@ -247,9 +247,9 @@ class TestTelegramQueue(unittest.TestCase):
         process_tg_in_mock.return_value = asyncio.ensure_future(process_exception())
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
 
         xknx.telegrams.put_nowait(telegram)
@@ -277,14 +277,14 @@ class TestTelegramQueue(unittest.TestCase):
         process_telegram_outgoing_mock.return_value = async_process_mock
 
         telegram_in = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         telegram_out = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
 
         xknx.telegrams.put_nowait(telegram_in)
@@ -312,9 +312,9 @@ class TestTelegramQueue(unittest.TestCase):
         xknx.telegram_queue.register_telegram_received_cb(async_telegram_received_cb)
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -341,9 +341,9 @@ class TestTelegramQueue(unittest.TestCase):
         )
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -370,9 +370,9 @@ class TestTelegramQueue(unittest.TestCase):
         )
 
         telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -40,7 +40,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -76,13 +76,13 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         telegram_out = Telegram(
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         self.loop.run_until_complete(xknx.telegram_queue.start())
@@ -120,7 +120,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -144,7 +144,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -170,7 +170,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -193,7 +193,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         self.loop.run_until_complete(
             xknx.telegram_queue.process_telegram_incoming(telegram)
@@ -215,7 +215,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         # log a warning if there is no KNXIP interface instanciated
@@ -249,7 +249,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         xknx.telegrams.put_nowait(telegram)
@@ -279,12 +279,12 @@ class TestTelegramQueue(unittest.TestCase):
         telegram_in = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         telegram_out = Telegram(
             direction=TelegramDirection.OUTGOING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
 
         xknx.telegrams.put_nowait(telegram_in)
@@ -314,7 +314,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -343,7 +343,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())
@@ -372,7 +372,7 @@ class TestTelegramQueue(unittest.TestCase):
         telegram = Telegram(
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
         )
         xknx.telegrams.put_nowait(telegram)
         self.loop.run_until_complete(xknx.telegram_queue._process_all_telegrams())

--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -27,7 +27,7 @@ class TestValueReader(unittest.TestCase):
         xknx = XKNX()
         test_group_address = GroupAddress("0/0/0")
         response_telegram = Telegram(
-            group_address=test_group_address,
+            address=test_group_address,
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
@@ -94,7 +94,7 @@ class TestValueReader(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                group_address=GroupAddress("0/0/0"),
+                address=GroupAddress("0/0/0"),
                 telegramtype=TelegramType.GROUP_READ,
             ),
         )
@@ -104,25 +104,25 @@ class TestValueReader(unittest.TestCase):
         xknx = XKNX()
         test_group_address = GroupAddress("0/0/0")
         expected_telegram_1 = Telegram(
-            group_address=test_group_address,
+            address=test_group_address,
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         expected_telegram_2 = Telegram(
-            group_address=test_group_address,
+            address=test_group_address,
             telegramtype=TelegramType.GROUP_WRITE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         telegram_wrong_address = Telegram(
-            group_address=GroupAddress("0/0/1"),
+            address=GroupAddress("0/0/1"),
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         telegram_wrong_type = Telegram(
-            group_address=test_group_address,
+            address=test_group_address,
             telegramtype=TelegramType.GROUP_READ,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),

--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -27,7 +27,7 @@ class TestValueReader(unittest.TestCase):
         xknx = XKNX()
         test_group_address = GroupAddress("0/0/0")
         response_telegram = Telegram(
-            address=test_group_address,
+            destination_address=test_group_address,
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
@@ -94,7 +94,7 @@ class TestValueReader(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                address=GroupAddress("0/0/0"),
+                destination_address=GroupAddress("0/0/0"),
                 telegramtype=TelegramType.GROUP_READ,
             ),
         )
@@ -104,25 +104,25 @@ class TestValueReader(unittest.TestCase):
         xknx = XKNX()
         test_group_address = GroupAddress("0/0/0")
         expected_telegram_1 = Telegram(
-            address=test_group_address,
+            destination_address=test_group_address,
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         expected_telegram_2 = Telegram(
-            address=test_group_address,
+            destination_address=test_group_address,
             telegramtype=TelegramType.GROUP_WRITE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         telegram_wrong_address = Telegram(
-            address=GroupAddress("0/0/1"),
+            destination_address=GroupAddress("0/0/1"),
             telegramtype=TelegramType.GROUP_RESPONSE,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
         telegram_wrong_type = Telegram(
-            address=test_group_address,
+            destination_address=test_group_address,
             telegramtype=TelegramType.GROUP_READ,
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -243,8 +243,7 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because ignore_internal_state is False
@@ -272,8 +271,7 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.assertEqual(switch.counter, 0)
 
@@ -315,8 +313,7 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because context_timeout is False
@@ -343,8 +340,7 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         write_telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         response_telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -38,14 +38,14 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput.state, None)
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(binaryinput.process(telegram_on))
 
         self.assertEqual(binaryinput.state, True)
 
         telegram_off = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binaryinput.process(telegram_off))
         self.assertEqual(binaryinput.state, False)
@@ -54,7 +54,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput2.state, None)
 
         telegram_off2 = Telegram(
-            address=GroupAddress("1/2/4"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/4"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binaryinput2.process(telegram_off2))
         self.assertEqual(binaryinput2.state, False)
@@ -67,14 +67,14 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(bs_invert.state, None)
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(bs_invert.process(telegram_on))
 
         self.assertEqual(bs_invert.state, True)
 
         telegram_off = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(bs_invert.process(telegram_off))
         self.assertEqual(bs_invert.state, False)
@@ -92,7 +92,7 @@ class TestBinarySensor(unittest.TestCase):
             device_updated_cb=async_after_update_callback,
         )
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(binaryinput.process(telegram_on))
@@ -131,7 +131,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_on))
         # process outgoing telegram from queue
@@ -141,7 +141,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, True)
 
         telegram_off = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_off))
         self.loop.run_until_complete(switch.process(xknx.telegrams.get_nowait()))
@@ -164,7 +164,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         with patch("time.time") as mock_time, patch(
@@ -242,7 +242,10 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because ignore_internal_state is False
         self.assertIsNone(switch._context_task)
@@ -268,7 +271,10 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.assertEqual(switch.counter, 0)
 
         self.loop.run_until_complete(switch.process(telegram))
@@ -308,7 +314,10 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because context_timeout is False
         self.assertIsNone(switch._context_task)
@@ -334,10 +343,11 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         write_telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
         )
         response_telegram = Telegram(
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
             payload=DPTBinary(1),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -38,14 +38,14 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput.state, None)
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(binaryinput.process(telegram_on))
 
         self.assertEqual(binaryinput.state, True)
 
         telegram_off = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binaryinput.process(telegram_off))
         self.assertEqual(binaryinput.state, False)
@@ -54,7 +54,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(binaryinput2.state, None)
 
         telegram_off2 = Telegram(
-            group_address=GroupAddress("1/2/4"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/4"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binaryinput2.process(telegram_off2))
         self.assertEqual(binaryinput2.state, False)
@@ -67,14 +67,14 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(bs_invert.state, None)
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(bs_invert.process(telegram_on))
 
         self.assertEqual(bs_invert.state, True)
 
         telegram_off = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(bs_invert.process(telegram_off))
         self.assertEqual(bs_invert.state, False)
@@ -92,7 +92,7 @@ class TestBinarySensor(unittest.TestCase):
             device_updated_cb=async_after_update_callback,
         )
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(binaryinput.process(telegram_on))
@@ -131,7 +131,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_on))
         # process outgoing telegram from queue
@@ -141,7 +141,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, True)
 
         telegram_off = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.loop.run_until_complete(binary_sensor.process(telegram_off))
         self.loop.run_until_complete(switch.process(xknx.telegrams.get_nowait()))
@@ -164,7 +164,7 @@ class TestBinarySensor(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         with patch("time.time") as mock_time, patch(
@@ -242,7 +242,7 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because ignore_internal_state is False
         self.assertIsNone(switch._context_task)
@@ -268,7 +268,7 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.assertEqual(switch.counter, 0)
 
         self.loop.run_until_complete(switch.process(telegram))
@@ -308,7 +308,7 @@ class TestBinarySensor(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.loop.run_until_complete(switch.process(telegram))
         # no _context_task started because context_timeout is False
         self.assertIsNone(switch._context_task)
@@ -334,10 +334,10 @@ class TestBinarySensor(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         write_telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         response_telegram = Telegram(
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
             payload=DPTBinary(1),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -42,7 +42,7 @@ class TestDateTime(unittest.TestCase):
 
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 8)
         self.assertEqual(
@@ -68,7 +68,7 @@ class TestDateTime(unittest.TestCase):
         _throwaway_initial = xknx.telegrams.get_nowait()
 
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 3)
         self.assertEqual(telegram.payload.value, (0x07, 0x01, 0x11))
@@ -92,7 +92,7 @@ class TestDateTime(unittest.TestCase):
         _throwaway_initial = xknx.telegrams.get_nowait()
 
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.group_address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 3)
         self.assertEqual(telegram.payload.value, (0xE9, 0x0D, 0x0E))
@@ -111,7 +111,7 @@ class TestDateTime(unittest.TestCase):
         )
 
         telegram_read = Telegram(
-            group_address=GroupAddress("1/2/3"), telegramtype=TelegramType.GROUP_READ
+            address=GroupAddress("1/2/3"), telegramtype=TelegramType.GROUP_READ
         )
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
@@ -125,7 +125,7 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 telegramtype=TelegramType.GROUP_RESPONSE,
                 payload=DPTArray((0xE9, 0xD, 0xE)),
             ),

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -42,7 +42,7 @@ class TestDateTime(unittest.TestCase):
 
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 8)
         self.assertEqual(
@@ -68,7 +68,7 @@ class TestDateTime(unittest.TestCase):
         _throwaway_initial = xknx.telegrams.get_nowait()
 
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 3)
         self.assertEqual(telegram.payload.value, (0x07, 0x01, 0x11))
@@ -92,7 +92,7 @@ class TestDateTime(unittest.TestCase):
         _throwaway_initial = xknx.telegrams.get_nowait()
 
         telegram = xknx.telegrams.get_nowait()
-        self.assertEqual(telegram.address, GroupAddress("1/2/3"))
+        self.assertEqual(telegram.destination_address, GroupAddress("1/2/3"))
         self.assertEqual(telegram.telegramtype, TelegramType.GROUP_WRITE)
         self.assertEqual(len(telegram.payload.value), 3)
         self.assertEqual(telegram.payload.value, (0xE9, 0x0D, 0x0E))
@@ -111,7 +111,8 @@ class TestDateTime(unittest.TestCase):
         )
 
         telegram_read = Telegram(
-            address=GroupAddress("1/2/3"), telegramtype=TelegramType.GROUP_READ
+            destination_address=GroupAddress("1/2/3"),
+            telegramtype=TelegramType.GROUP_READ
         )
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])
@@ -125,7 +126,7 @@ class TestDateTime(unittest.TestCase):
         self.assertEqual(
             telegram,
             Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 telegramtype=TelegramType.GROUP_RESPONSE,
                 payload=DPTArray((0xE9, 0xD, 0xE)),
             ),

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -112,7 +112,7 @@ class TestDateTime(unittest.TestCase):
 
         telegram_read = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            telegramtype=TelegramType.GROUP_READ
+            telegramtype=TelegramType.GROUP_READ,
         )
         with patch("time.localtime") as mock_time:
             mock_time.return_value = time.struct_time([2017, 1, 7, 9, 13, 14, 6, 0, 0])

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -78,10 +78,7 @@ class TestSensor(unittest.TestCase):
         #  set initial payload of sensor
         sensor.sensor_value.payload = payload
 
-        telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=payload
-        )
+        telegram = Telegram(destination_address=GroupAddress("1/2/3"), payload=payload)
         response_telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=payload,

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -78,9 +78,9 @@ class TestSensor(unittest.TestCase):
         #  set initial payload of sensor
         sensor.sensor_value.payload = payload
 
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=payload)
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=payload)
         response_telegram = Telegram(
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
             payload=payload,
             telegramtype=TelegramType.GROUP_RESPONSE,
         )

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -78,9 +78,12 @@ class TestSensor(unittest.TestCase):
         #  set initial payload of sensor
         sensor.sensor_value.payload = payload
 
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=payload)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=payload
+        )
         response_telegram = Telegram(
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
             payload=payload,
             telegramtype=TelegramType.GROUP_RESPONSE,
         )

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -230,8 +230,7 @@ class TestSwitch(unittest.TestCase):
         switch.register_device_updated_cb(async_after_update_callback)
 
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.loop.run_until_complete(switch.process(telegram))
 

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -79,10 +79,10 @@ class TestSwitch(unittest.TestCase):
         callback_mock.assert_not_called()
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         telegram_off = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
 
         self.loop.run_until_complete(switch1.process(telegram_on))
@@ -127,12 +127,12 @@ class TestSwitch(unittest.TestCase):
         callback_mock.assert_not_called()
 
         telegram_on = Telegram(
-            address=GroupAddress("1/2/4"),
+            destination_address=GroupAddress("1/2/4"),
             payload=DPTBinary(1),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )
         telegram_off = Telegram(
-            address=GroupAddress("1/2/4"),
+            destination_address=GroupAddress("1/2/4"),
             payload=DPTBinary(0),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )
@@ -162,10 +162,10 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_inv_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         telegram_inv_off = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_inv_on))
@@ -181,7 +181,7 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -200,7 +200,7 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -229,7 +229,10 @@ class TestSwitch(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.loop.run_until_complete(switch.process(telegram))
 
         after_update_callback.assert_called_with(switch)

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -79,10 +79,10 @@ class TestSwitch(unittest.TestCase):
         callback_mock.assert_not_called()
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         telegram_off = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
 
         self.loop.run_until_complete(switch1.process(telegram_on))
@@ -127,12 +127,12 @@ class TestSwitch(unittest.TestCase):
         callback_mock.assert_not_called()
 
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/4"),
+            address=GroupAddress("1/2/4"),
             payload=DPTBinary(1),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )
         telegram_off = Telegram(
-            group_address=GroupAddress("1/2/4"),
+            address=GroupAddress("1/2/4"),
             payload=DPTBinary(0),
             telegramtype=TelegramType.GROUP_RESPONSE,
         )
@@ -162,10 +162,10 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(switch.state, None)
 
         telegram_inv_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         telegram_inv_off = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_inv_on))
@@ -181,7 +181,7 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -200,7 +200,7 @@ class TestSwitch(unittest.TestCase):
             xknx, "TestInput", group_address="1/2/3", reset_after=reset_after_sec
         )
         telegram_on = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
 
         self.loop.run_until_complete(switch.process(telegram_on))
@@ -229,7 +229,7 @@ class TestSwitch(unittest.TestCase):
 
         switch.register_device_updated_cb(async_after_update_callback)
 
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.loop.run_until_complete(switch.process(telegram))
 
         after_update_callback.assert_called_with(switch)

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -183,3 +183,9 @@ def test_telegram_physical_address(frame):
 
     assert (frame.flags & CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS) == \
         CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
+
+
+def test_telegram_unsupported_address(frame):
+    """Test telegram conversion flags with an unsupported address"""
+    with raises(TypeError):
+        frame.telegram = Telegram(address=object())

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -171,7 +171,7 @@ def test_from_knx_physical_address(frame):
 
 def test_telegram_group_address(frame):
     """Test telegram conversion flags with a group address"""
-    frame.telegram = Telegram(address=GroupAddress(0))
+    frame.telegram = Telegram(destination_address=GroupAddress(0))
 
     assert (frame.flags & CEMIFlags.DESTINATION_GROUP_ADDRESS) == \
         CEMIFlags.DESTINATION_GROUP_ADDRESS
@@ -179,7 +179,7 @@ def test_telegram_group_address(frame):
 
 def test_telegram_physical_address(frame):
     """Test telegram conversion flags with a physical address"""
-    frame.telegram = Telegram(address=PhysicalAddress(0))
+    frame.telegram = Telegram(destination_address=PhysicalAddress(0))
 
     assert (frame.flags & CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS) == \
         CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
@@ -188,4 +188,4 @@ def test_telegram_physical_address(frame):
 def test_telegram_unsupported_address(frame):
     """Test telegram conversion flags with an unsupported address"""
     with raises(TypeError):
-        frame.telegram = Telegram(address=object())
+        frame.telegram = Telegram(destination_address=object())

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -6,8 +6,8 @@ from pytest import fixture, raises
 from xknx.dpt import DPTBinary, DPTComparator
 from xknx.exceptions import ConversionError, CouldNotParseKNXIP, UnsupportedCEMIMessage
 from xknx.knxip.cemi_frame import CEMIFrame
-from xknx.knxip.knxip_enum import APCICommand, CEMIMessageCode, CEMIFlags
-from xknx.telegram import PhysicalAddress, Telegram, GroupAddress
+from xknx.knxip.knxip_enum import APCICommand, CEMIFlags, CEMIMessageCode
+from xknx.telegram import GroupAddress, PhysicalAddress, Telegram
 
 
 def get_data(code, adil, flags, src, dst, mpdu_len, tpci_apci, payload):
@@ -173,16 +173,18 @@ def test_telegram_group_address(frame):
     """Test telegram conversion flags with a group address"""
     frame.telegram = Telegram(destination_address=GroupAddress(0))
 
-    assert (frame.flags & CEMIFlags.DESTINATION_GROUP_ADDRESS) == \
-        CEMIFlags.DESTINATION_GROUP_ADDRESS
+    assert (
+        frame.flags & CEMIFlags.DESTINATION_GROUP_ADDRESS
+    ) == CEMIFlags.DESTINATION_GROUP_ADDRESS
 
 
 def test_telegram_physical_address(frame):
     """Test telegram conversion flags with a physical address"""
     frame.telegram = Telegram(destination_address=PhysicalAddress(0))
 
-    assert (frame.flags & CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS) == \
-        CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
+    assert (
+        frame.flags & CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
+    ) == CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
 
 
 def test_telegram_unsupported_address(frame):

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -60,7 +60,7 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.body.cemi.src_addr = PhysicalAddress("1.2.2")
 
         telegram = Telegram(
-            group_address=GroupAddress(337),
+            address=GroupAddress(337),
             payload=DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S"))),
         )
 
@@ -84,7 +84,7 @@ class Test_KNXIP(unittest.TestCase):
 
         telegram = knxipframe.body.cemi.telegram
 
-        self.assertEqual(telegram.group_address, GroupAddress(337))
+        self.assertEqual(telegram.address, GroupAddress(337))
 
         self.assertEqual(len(telegram.payload.value), 1)
         self.assertEqual(telegram.payload.value[0], 0xF0)
@@ -240,7 +240,7 @@ class Test_KNXIP(unittest.TestCase):
     def test_maximum_apci(self):
         """Test parsing and streaming CEMIFrame KNX/IP packet, testing maximum APCI."""
         telegram = Telegram(
-            group_address=GroupAddress(337), payload=DPTBinary(DPTBinary.APCI_MAX_VALUE)
+            address=GroupAddress(337), payload=DPTBinary(DPTBinary.APCI_MAX_VALUE)
         )
         xknx = XKNX()
         knxipframe = KNXIPFrame(xknx)

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -60,7 +60,7 @@ class Test_KNXIP(unittest.TestCase):
         knxipframe.body.cemi.src_addr = PhysicalAddress("1.2.2")
 
         telegram = Telegram(
-            address=GroupAddress(337),
+            destination_address=GroupAddress(337),
             payload=DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S"))),
         )
 
@@ -84,7 +84,7 @@ class Test_KNXIP(unittest.TestCase):
 
         telegram = knxipframe.body.cemi.telegram
 
-        self.assertEqual(telegram.address, GroupAddress(337))
+        self.assertEqual(telegram.destination_address, GroupAddress(337))
 
         self.assertEqual(len(telegram.payload.value), 1)
         self.assertEqual(telegram.payload.value[0], 0xF0)
@@ -240,7 +240,8 @@ class Test_KNXIP(unittest.TestCase):
     def test_maximum_apci(self):
         """Test parsing and streaming CEMIFrame KNX/IP packet, testing maximum APCI."""
         telegram = Telegram(
-            address=GroupAddress(337), payload=DPTBinary(DPTBinary.APCI_MAX_VALUE)
+            destination_address=GroupAddress(337),
+            payload=DPTBinary(DPTBinary.APCI_MAX_VALUE)
         )
         xknx = XKNX()
         knxipframe = KNXIPFrame(xknx)

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -241,7 +241,7 @@ class Test_KNXIP(unittest.TestCase):
         """Test parsing and streaming CEMIFrame KNX/IP packet, testing maximum APCI."""
         telegram = Telegram(
             destination_address=GroupAddress(337),
-            payload=DPTBinary(DPTBinary.APCI_MAX_VALUE)
+            payload=DPTBinary(DPTBinary.APCI_MAX_VALUE),
         )
         xknx = XKNX()
         knxipframe = KNXIPFrame(xknx)

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -59,7 +59,7 @@ class TestRemoteValue1Count(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 100)
@@ -70,12 +70,12 @@ class TestRemoteValue1Count(unittest.TestCase):
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -59,7 +59,8 @@ class TestRemoteValue1Count(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x64,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 100)
@@ -70,12 +71,13 @@ class TestRemoteValue1Count(unittest.TestCase):
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -59,8 +59,7 @@ class TestRemoteValue1Count(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x64,))
+            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 100)
@@ -71,8 +70,7 @@ class TestRemoteValue1Count(unittest.TestCase):
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -219,7 +219,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE,
         )
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x00,))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x00,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.AUTO)
@@ -233,7 +233,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             operation_mode=HVACOperationMode.FROST_PROTECTION,
         )
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTBinary(True)
+            address=GroupAddress("1/2/3"), payload=DPTBinary(True)
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.FROST_PROTECTION)
@@ -248,12 +248,12 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,
@@ -273,12 +273,12 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTArray((0x01,))
+                address=GroupAddress("1/2/3"), payload=DPTArray((0x01,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -219,8 +219,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE,
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x00,))
+            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x00,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.AUTO)
@@ -234,8 +233,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             operation_mode=HVACOperationMode.FROST_PROTECTION,
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(True)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(True)
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.FROST_PROTECTION)
@@ -250,8 +248,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
@@ -276,8 +273,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x01,))
+                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x01,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -219,7 +219,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE,
         )
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x00,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x00,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.AUTO)
@@ -233,7 +234,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             operation_mode=HVACOperationMode.FROST_PROTECTION,
         )
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTBinary(True)
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(True)
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, HVACOperationMode.FROST_PROTECTION)
@@ -248,12 +250,13 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,
@@ -273,12 +276,13 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTArray((0x01,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x01,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -79,7 +79,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x64, 0x65, 0x66))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x64, 0x65, 0x66))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, (100, 101, 102))
@@ -90,12 +90,12 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x64, 0x65, 0x66, 0x67)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -79,7 +79,8 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x64, 0x65, 0x66))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x64, 0x65, 0x66))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, (100, 101, 102))
@@ -90,12 +91,13 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x64, 0x65, 0x66, 0x67)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -80,7 +80,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x64, 0x65, 0x66))
+            payload=DPTArray((0x64, 0x65, 0x66)),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, (100, 101, 102))
@@ -91,8 +91,7 @@ class TestRemoteValueColorRGB(unittest.TestCase):
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -113,7 +113,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
             payload=DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F)),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -125,18 +125,19 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x64, 0x65, 0x66)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -125,8 +125,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -113,7 +113,7 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
             payload=DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F)),
         )
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -125,18 +125,18 @@ class TestRemoteValueColorRGBW(unittest.TestCase):
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x64, 0x65, 0x66)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67)),
             )
             self.loop.run_until_complete(remote_value.process(telegram))

--- a/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
@@ -77,7 +77,7 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A, 0x0B))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A, 0x0B))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 2571)
@@ -90,17 +90,17 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+                address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
@@ -77,8 +77,7 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x0A, 0x0B))
+            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A, 0x0B))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 2571)
@@ -91,14 +90,12 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray((0x64,))
+                destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
@@ -77,7 +77,8 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A, 0x0B))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x0A, 0x0B))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 2571)
@@ -90,17 +91,19 @@ class TestRemoteValueDptValue2Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTArray((0x64,))
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTArray((0x64,))
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -68,8 +68,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 10)
@@ -82,8 +81,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -68,7 +68,8 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 10)
@@ -81,12 +82,13 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -68,7 +68,7 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
             xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 10)
@@ -81,12 +81,12 @@ class TestRemoteValueDptValue1Ucount(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -64,8 +64,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 11)
@@ -76,8 +75,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -64,7 +64,7 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 11)
@@ -75,12 +75,12 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -64,7 +64,8 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"), payload=DPTArray((0x0A,))
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTArray((0x0A,))
         )
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, 11)
@@ -75,12 +76,13 @@ class TestRemoteValueSceneNumber(unittest.TestCase):
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -93,7 +93,7 @@ class TestRemoteValueStep(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(0))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(0))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, RemoteValueStep.Direction.DECREASE)
@@ -104,12 +104,12 @@ class TestRemoteValueStep(unittest.TestCase):
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -93,7 +93,9 @@ class TestRemoteValueStep(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(0))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(0))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, RemoteValueStep.Direction.DECREASE)
@@ -104,12 +106,14 @@ class TestRemoteValueStep(unittest.TestCase):
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -94,8 +94,8 @@ class TestRemoteValueStep(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(0))
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
+        )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, RemoteValueStep.Direction.DECREASE)
@@ -106,14 +106,12 @@ class TestRemoteValueStep(unittest.TestCase):
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -112,7 +112,7 @@ class TestRemoteValueString(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
             payload=DPTArray(
                 (
                     0x41,
@@ -141,12 +141,12 @@ class TestRemoteValueString(unittest.TestCase):
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"),
+                address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -112,7 +112,7 @@ class TestRemoteValueString(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
             payload=DPTArray(
                 (
                     0x41,
@@ -141,12 +141,13 @@ class TestRemoteValueString(unittest.TestCase):
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"),
+                destination_address=GroupAddress("1/2/3"),
                 payload=DPTArray(
                     (
                         0x64,

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -141,8 +141,7 @@ class TestRemoteValueString(unittest.TestCase):
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(1)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -78,8 +78,7 @@ class TestRemoteValueSwitch(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -91,8 +90,7 @@ class TestRemoteValueSwitch(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(0)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(0)
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -105,14 +103,12 @@ class TestRemoteValueSwitch(unittest.TestCase):
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -77,7 +77,7 @@ class TestRemoteValueSwitch(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertIsNotNone(remote_value.payload)
@@ -87,7 +87,7 @@ class TestRemoteValueSwitch(unittest.TestCase):
         """Test process OFF telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(0))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(0))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertIsNotNone(remote_value.payload)
@@ -99,12 +99,12 @@ class TestRemoteValueSwitch(unittest.TestCase):
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -77,7 +77,10 @@ class TestRemoteValueSwitch(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertIsNotNone(remote_value.payload)
@@ -87,7 +90,10 @@ class TestRemoteValueSwitch(unittest.TestCase):
         """Test process OFF telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(0))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(0)
+        )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertIsNotNone(remote_value.payload)
@@ -99,12 +105,14 @@ class TestRemoteValueSwitch(unittest.TestCase):
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -93,7 +93,7 @@ class TestRemoteValueUpDown(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, RemoteValueUpDown.Direction.DOWN)
@@ -104,12 +104,12 @@ class TestRemoteValueUpDown(unittest.TestCase):
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                group_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -94,8 +94,7 @@ class TestRemoteValueUpDown(unittest.TestCase):
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(1)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(1)
         )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
@@ -107,14 +106,12 @@ class TestRemoteValueUpDown(unittest.TestCase):
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"), payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -93,7 +93,10 @@ class TestRemoteValueUpDown(unittest.TestCase):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(1))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(1)
+        )
         self.assertEqual(remote_value.value, None)
         self.loop.run_until_complete(remote_value.process(telegram))
         self.assertEqual(remote_value.value, RemoteValueUpDown.Direction.DOWN)
@@ -104,12 +107,14 @@ class TestRemoteValueUpDown(unittest.TestCase):
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTArray(0x01)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTArray(0x01)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
         with self.assertRaises(CouldNotParseTelegram):
             telegram = Telegram(
-                address=GroupAddress("1/2/3"), payload=DPTBinary(3)
+                destination_address=GroupAddress("1/2/3"),
+                payload=DPTBinary(3)
             )
             self.loop.run_until_complete(remote_value.process(telegram))
             # pylint: disable=pointless-statement

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -281,7 +281,7 @@ class TestStringRepresentations(unittest.TestCase):
         )
         # self.loop.run_until_complete(sensor.sensor_value.set(25))
         telegram = Telegram(
-            address=GroupAddress("1/2/3"),
+            destination_address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTArray(0x40),
         )
@@ -350,7 +350,7 @@ class TestStringRepresentations(unittest.TestCase):
         )
 
         telegram = Telegram(
-            address=GroupAddress("7/0/10"),
+            destination_address=GroupAddress("7/0/10"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
@@ -468,10 +468,13 @@ class TestStringRepresentations(unittest.TestCase):
 
     def test_telegram(self):
         """Test string representation of Telegram."""
-        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(7))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=DPTBinary(7)
+        )
         self.assertEqual(
             str(telegram),
-            '<Telegram address="GroupAddress("1/2/3")", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
+            '<Telegram destination_address="GroupAddress("1/2/3")", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
             '"TelegramDirection.OUTGOING" />',
         )
 
@@ -660,7 +663,8 @@ class TestStringRepresentations(unittest.TestCase):
         cemi_frame = CEMIFrame(xknx)
         cemi_frame.src_addr = GroupAddress("1/2/3")
         cemi_frame.telegram = Telegram(
-            address=GroupAddress("1/2/5"), payload=DPTBinary(7)
+            destination_address=GroupAddress("1/2/5"),
+            payload=DPTBinary(7)
         )
         self.assertEqual(
             str(cemi_frame),

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -281,7 +281,7 @@ class TestStringRepresentations(unittest.TestCase):
         )
         # self.loop.run_until_complete(sensor.sensor_value.set(25))
         telegram = Telegram(
-            group_address=GroupAddress("1/2/3"),
+            address=GroupAddress("1/2/3"),
             direction=TelegramDirection.INCOMING,
             payload=DPTArray(0x40),
         )
@@ -350,7 +350,7 @@ class TestStringRepresentations(unittest.TestCase):
         )
 
         telegram = Telegram(
-            group_address=GroupAddress("7/0/10"),
+            address=GroupAddress("7/0/10"),
             direction=TelegramDirection.INCOMING,
             payload=DPTBinary(1),
         )
@@ -468,10 +468,10 @@ class TestStringRepresentations(unittest.TestCase):
 
     def test_telegram(self):
         """Test string representation of Telegram."""
-        telegram = Telegram(group_address=GroupAddress("1/2/3"), payload=DPTBinary(7))
+        telegram = Telegram(address=GroupAddress("1/2/3"), payload=DPTBinary(7))
         self.assertEqual(
             str(telegram),
-            '<Telegram group_address="GroupAddress("1/2/3")", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
+            '<Telegram address="GroupAddress("1/2/3")", payload="<DPTBinary value="7" />" telegramtype="TelegramType.GROUP_WRITE" direction='
             '"TelegramDirection.OUTGOING" />',
         )
 
@@ -660,7 +660,7 @@ class TestStringRepresentations(unittest.TestCase):
         cemi_frame = CEMIFrame(xknx)
         cemi_frame.src_addr = GroupAddress("1/2/3")
         cemi_frame.telegram = Telegram(
-            group_address=GroupAddress("1/2/5"), payload=DPTBinary(7)
+            address=GroupAddress("1/2/5"), payload=DPTBinary(7)
         )
         self.assertEqual(
             str(cemi_frame),

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -469,8 +469,7 @@ class TestStringRepresentations(unittest.TestCase):
     def test_telegram(self):
         """Test string representation of Telegram."""
         telegram = Telegram(
-            destination_address=GroupAddress("1/2/3"),
-            payload=DPTBinary(7)
+            destination_address=GroupAddress("1/2/3"), payload=DPTBinary(7)
         )
         self.assertEqual(
             str(telegram),
@@ -663,8 +662,7 @@ class TestStringRepresentations(unittest.TestCase):
         cemi_frame = CEMIFrame(xknx)
         cemi_frame.src_addr = GroupAddress("1/2/3")
         cemi_frame.telegram = Telegram(
-            destination_address=GroupAddress("1/2/5"),
-            payload=DPTBinary(7)
+            destination_address=GroupAddress("1/2/5"), payload=DPTBinary(7)
         )
         self.assertEqual(
             str(cemi_frame),

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -35,7 +35,7 @@ class TelegramQueue:
             if self.address_filters is None:
                 return True
             for address_filter in self.address_filters:
-                if address_filter.match(telegram.address):
+                if address_filter.match(telegram.destination_address):
                     return True
             return False
 

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -35,7 +35,7 @@ class TelegramQueue:
             if self.address_filters is None:
                 return True
             for address_filter in self.address_filters:
-                if address_filter.match(telegram.group_address):
+                if address_filter.match(telegram.address):
                     return True
             return False
 

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -53,7 +53,7 @@ class ValueReader:
 
     async def telegram_received(self, telegram):
         """Test if telegram has correct group address and trigger event."""
-        if telegram.group_address == self.group_address and telegram.telegramtype in (
+        if telegram.address == self.group_address and telegram.telegramtype in (
             TelegramType.GROUP_RESPONSE,
             TelegramType.GROUP_WRITE,
         ):

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -53,7 +53,7 @@ class ValueReader:
 
     async def telegram_received(self, telegram):
         """Test if telegram has correct group address and trigger event."""
-        if telegram.address == self.group_address and telegram.telegramtype in (
+        if telegram.destination_address == self.group_address and telegram.telegramtype in (
             TelegramType.GROUP_RESPONSE,
             TelegramType.GROUP_WRITE,
         ):

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -53,9 +53,13 @@ class ValueReader:
 
     async def telegram_received(self, telegram):
         """Test if telegram has correct group address and trigger event."""
-        if telegram.destination_address == self.group_address and telegram.telegramtype in (
-            TelegramType.GROUP_RESPONSE,
-            TelegramType.GROUP_WRITE,
+        if (
+            telegram.destination_address == self.group_address
+            and telegram.telegramtype
+            in (
+                TelegramType.GROUP_RESPONSE,
+                TelegramType.GROUP_WRITE,
+            )
         ):
             self.success = True
             self.received_telegram = telegram

--- a/xknx/devices/devices.py
+++ b/xknx/devices/devices.py
@@ -66,7 +66,7 @@ class Devices:
 
     async def process(self, telegram):
         """Process telegram."""
-        for device in self.devices_by_group_address(telegram.address):
+        for device in self.devices_by_group_address(telegram.destination_address):
             await device.process(telegram)
 
     async def sync(self):

--- a/xknx/devices/devices.py
+++ b/xknx/devices/devices.py
@@ -66,7 +66,7 @@ class Devices:
 
     async def process(self, telegram):
         """Process telegram."""
-        for device in self.devices_by_group_address(telegram.group_address):
+        for device in self.devices_by_group_address(telegram.address):
             await device.process(telegram)
 
     async def sync(self):

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -94,9 +94,15 @@ class CEMIFrame:
             | CEMIFlags.PRIORITY_LOW
             | CEMIFlags.NO_ACK_REQUESTED
             | CEMIFlags.CONFIRM_NO_ERROR
-            | CEMIFlags.DESTINATION_GROUP_ADDRESS
             | CEMIFlags.HOP_COUNT_1ST
         )
+
+        if isinstance(telegram.address, GroupAddress):
+            self.flags |= CEMIFlags.DESTINATION_GROUP_ADDRESS
+        elif isinstance(telegram.address, PhysicalAddress):
+            self.flags |= CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
+        else:
+            raise TypeError()
 
         # TODO: use telegram.direction
         def resolve_cmd(telegramtype: TelegramType) -> APCICommand:

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -74,7 +74,7 @@ class CEMIFrame:
             raise ConversionError(f"Telegram not implemented for {self.cmd}")
 
         return Telegram(
-            group_address=self.dst_addr,
+            address=self.dst_addr,
             payload=self.payload,
             telegramtype=resolve_telegram_type(self.cmd),
         )
@@ -82,7 +82,7 @@ class CEMIFrame:
     @telegram.setter
     def telegram(self, telegram: Telegram):
         """Set telegram."""
-        self.dst_addr = telegram.group_address
+        self.dst_addr = telegram.address
         self.payload = telegram.payload
 
         # TODO: Move to separate function, together with setting of

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -74,7 +74,7 @@ class CEMIFrame:
             raise ConversionError(f"Telegram not implemented for {self.cmd}")
 
         return Telegram(
-            address=self.dst_addr,
+            destination_address=self.dst_addr,
             payload=self.payload,
             telegramtype=resolve_telegram_type(self.cmd),
         )
@@ -82,7 +82,7 @@ class CEMIFrame:
     @telegram.setter
     def telegram(self, telegram: Telegram):
         """Set telegram."""
-        self.dst_addr = telegram.address
+        self.dst_addr = telegram.destination_address
         self.payload = telegram.payload
 
         # TODO: Move to separate function, together with setting of
@@ -97,9 +97,9 @@ class CEMIFrame:
             | CEMIFlags.HOP_COUNT_1ST
         )
 
-        if isinstance(telegram.address, GroupAddress):
+        if isinstance(telegram.destination_address, GroupAddress):
             self.flags |= CEMIFlags.DESTINATION_GROUP_ADDRESS
-        elif isinstance(telegram.address, PhysicalAddress):
+        elif isinstance(telegram.destination_address, PhysicalAddress):
             self.flags |= CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
         else:
             raise TypeError()

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -110,13 +110,13 @@ class RemoteValue:
 
     async def process(self, telegram, always_callback=False):
         """Process incoming or outgoing telegram."""
-        if not self.has_group_address(telegram.group_address):
+        if not self.has_group_address(telegram.address):
             return False
         if not self.payload_valid(telegram.payload):
             raise CouldNotParseTelegram(
                 "payload invalid",
                 payload=telegram.payload,
-                group_address=telegram.group_address,
+                address=telegram.address,
                 device_name=self.device_name,
                 feature_name=self.feature_name,
             )
@@ -137,7 +137,7 @@ class RemoteValue:
     async def _send(self, payload, response=False):
         """Send payload as telegram to KNX bus."""
         telegram = Telegram(
-            group_address=self.group_address,
+            address=self.group_address,
             telegramtype=(
                 TelegramType.GROUP_RESPONSE if response else TelegramType.GROUP_WRITE
             ),

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -110,13 +110,13 @@ class RemoteValue:
 
     async def process(self, telegram, always_callback=False):
         """Process incoming or outgoing telegram."""
-        if not self.has_group_address(telegram.address):
+        if not self.has_group_address(telegram.destination_address):
             return False
         if not self.payload_valid(telegram.payload):
             raise CouldNotParseTelegram(
                 "payload invalid",
                 payload=telegram.payload,
-                address=telegram.address,
+                address=telegram.destination_address,
                 device_name=self.device_name,
                 feature_name=self.feature_name,
             )
@@ -137,7 +137,7 @@ class RemoteValue:
     async def _send(self, payload, response=False):
         """Send payload as telegram to KNX bus."""
         telegram = Telegram(
-            address=self.group_address,
+            destination_address=self.group_address,
             telegramtype=(
                 TelegramType.GROUP_RESPONSE if response else TelegramType.GROUP_WRITE
             ),

--- a/xknx/telegram/telegram.py
+++ b/xknx/telegram/telegram.py
@@ -15,9 +15,9 @@ It contains
 
 """
 from enum import Enum
-from typing import Any
+from typing import Any, Union
 
-from .address import GroupAddress
+from .address import GroupAddress, PhysicalAddress
 
 
 class TelegramDirection(Enum):
@@ -42,7 +42,7 @@ class Telegram:
 
     def __init__(
         self,
-        group_address: GroupAddress = GroupAddress(None),
+        address: Union[GroupAddress, PhysicalAddress] = GroupAddress(None),
         telegramtype: TelegramType = TelegramType.GROUP_WRITE,
         direction: TelegramDirection = TelegramDirection.OUTGOING,
         payload: Any = None,
@@ -50,15 +50,15 @@ class Telegram:
         """Initialize Telegram class."""
         self.direction = direction
         self.telegramtype = telegramtype
-        self.group_address = group_address
+        self.address = address
         self.payload = payload
 
     def __str__(self) -> str:
         """Return object as readable string."""
         return (
-            '<Telegram group_address="{}", payload="{}" '
+            '<Telegram address="{}", payload="{}" '
             'telegramtype="{}" direction="{}" />'.format(
-                self.group_address.__repr__(),
+                self.address.__repr__(),
                 self.payload,
                 self.telegramtype,
                 self.direction,

--- a/xknx/telegram/telegram.py
+++ b/xknx/telegram/telegram.py
@@ -42,7 +42,7 @@ class Telegram:
 
     def __init__(
         self,
-        address: Union[GroupAddress, PhysicalAddress] = GroupAddress(None),
+        destination_address: Union[GroupAddress, PhysicalAddress] = GroupAddress(None),
         telegramtype: TelegramType = TelegramType.GROUP_WRITE,
         direction: TelegramDirection = TelegramDirection.OUTGOING,
         payload: Any = None,
@@ -50,15 +50,15 @@ class Telegram:
         """Initialize Telegram class."""
         self.direction = direction
         self.telegramtype = telegramtype
-        self.address = address
+        self.destination_address = destination_address
         self.payload = payload
 
     def __str__(self) -> str:
         """Return object as readable string."""
         return (
-            '<Telegram address="{}", payload="{}" '
+            '<Telegram destination_address="{}", payload="{}" '
             'telegramtype="{}" direction="{}" />'.format(
-                self.address.__repr__(),
+                self.destination_address.__repr__(),
                 self.payload,
                 self.telegramtype,
                 self.direction,


### PR DESCRIPTION
## Description
This PR is a part of #253, for easier reviewing.

In this PR, I refactored `Telegram.group_address` to ~~`Telegram.address`~~ `telegram.destination_address`. Based on the type of address, the CEMIFrame is build with the proper flags set. This changes allows for the other changes of #253 to support non-broadcast APCI services.

All high-level devices still use `group_address`, which still makes sense over there. They just update a `Telegram.destination_address` with their `group_address`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
