### PR TITLE
StateUpdater: avoid race condition

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.15.6 Bugfix for StateUpater 2020-11-26
+
+### Bugfixes
+
+- StateUpdater: shield from cancellation so update_received() don't cancel ongoing RemoteValue.read_state()
+
 ## 0.15.5 A Telegram for everyone 2020-11-25
 
 ### Internals

--- a/xknx/__version__.py
+++ b/xknx/__version__.py
@@ -1,3 +1,3 @@
 """XKNX version."""
 
-__version__ = "0.15.5"
+__version__ = "0.15.6"

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -86,7 +86,9 @@ class StateUpdater:
                     remote_value.device_name,
                     remote_value.feature_name,
                 )
-                await remote_value.read_state(wait_for_result=True)
+                # shield from cancellation so update_received() don't cancel the
+                # ValueReader leaving the telegram_received_cb until next telegram
+                await asyncio.shield(remote_value.read_state(wait_for_result=True))
 
         tracker_type, update_interval = parse_tracker_options(tracker_options)
         tracker = _StateTracker(


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
we were cancelling https://github.com/XKNX/xknx/blob/be4008d6e19d9cde0178e6654cd2f7d5ff0a8128/xknx/core/state_updater.py#L164 from `update_received` before it is finished. 
This leaves the ValueReaders callback active and throws a lot of warnings "Error: KNX bus did not respond in time".

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
