### PR TITLE
Adjust tests for more specific voluptuous 0.12.1 exceptions

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
 netifaces==0.10.9
 pyyaml==5.3.1
-voluptuous==0.12.0
+voluptuous==0.12.1

--- a/test/config_tests/resources/climate/invalid_1.yaml
+++ b/test/config_tests/resources/climate/invalid_1.yaml
@@ -1,4 +1,4 @@
-name: "value is not allowed .*operation_modes.*"
+name: "value must be one of .*operation_modes.*"
 friendly_name: "Bathroom"
 target_temperature:
   address: "4/0/0"

--- a/test/config_tests/resources/climate/invalid_3.yaml
+++ b/test/config_tests/resources/climate/invalid_3.yaml
@@ -1,4 +1,4 @@
-name: "value is not allowed for .*mode.*"
+name: "value must be one of .*mode.*"
 friendly_name: "Bathroom"
 target_temperature:
   address: "4/0/0"

--- a/test/config_tests/resources/datetime/invalid_1.yaml
+++ b/test/config_tests/resources/datetime/invalid_1.yaml
@@ -1,4 +1,4 @@
-name: "value is not allowed .*broadcast_type.*"
+name: "value must be one of .*broadcast_type.*"
 time:
   address: "8/4/4"
   broadcast_type: sdaf

--- a/test/config_tests/resources/light/invalid_1.yaml
+++ b/test/config_tests/resources/light/invalid_1.yaml
@@ -1,4 +1,4 @@
-name: "value is not allowed .*mode.*"
+name: "value must be one of .*mode.*"
 friendly_name: "Office"
 switch:
   address: "2/1/5"


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

The new voluptuous version 0.12.1 provides improved exception messages if an `In` or `NotIn` requirement is not adhered to, by listing all the allowed values to help the user. Example:

> value must be one of ['Auto', 'Comfort', 'Cool', 'Dry', 'Fan only', 'Frost Protection', 'Heat', 'Night', 'Off', 'Standby'] @ data['operation_modes'][1]

The xknx tests did not yet account for that and were still checking the old messages.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [X] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
