### PR TITLE
parse ConnectResponse Telegrams with Error codes

### DIFF
--- a/test/knxip_tests/connect_response_test.py
+++ b/test/knxip_tests/connect_response_test.py
@@ -133,9 +133,78 @@ class Test_KNXIP_ConnectResponse(unittest.TestCase):
         with self.assertRaises(CouldNotParseKNXIP):
             knxipframe.from_knx(raw)
 
-    def test_connect_response_connection_error(self):
-        """Test parsing and streaming connection response KNX/IP packet with error."""
-        raw = (0x06, 0x10, 0x02, 0x06, 0x00, 0x08, 0x00, 0x24)
+    def test_connect_response_connection_error_gira(self):
+        """
+        Test parsing and streaming connection response KNX/IP packet with error e_no_more_connections.
+        HPAI and CRD normal. This was received from Gira devices (2020).
+        """
+        raw = (
+            0x06,
+            0x10,
+            0x02,
+            0x06,
+            0x00,
+            0x14,
+            0xC0,
+            0x24,
+            0x08,
+            0x01,
+            0x0A,
+            0x01,
+            0x00,
+            0x29,
+            0x0E,
+            0x57,
+            0x04,
+            0x04,
+            0x00,
+            0x00,
+        )
+        xknx = XKNX()
+        knxipframe = KNXIPFrame(xknx)
+        knxipframe.from_knx(raw)
+        self.assertTrue(isinstance(knxipframe.body, ConnectResponse))
+        self.assertEqual(knxipframe.body.status_code, ErrorCode.E_NO_MORE_CONNECTIONS)
+        self.assertEqual(knxipframe.body.communication_channel, 192)
+
+        knxipframe2 = KNXIPFrame(xknx)
+        knxipframe2.init(KNXIPServiceType.CONNECT_RESPONSE)
+        knxipframe2.body.status_code = ErrorCode.E_NO_MORE_CONNECTIONS
+        knxipframe2.body.communication_channel = 192
+        knxipframe2.body.request_type = ConnectRequestType.TUNNEL_CONNECTION
+        knxipframe2.body.control_endpoint = HPAI(ip_addr="10.1.0.41", port=3671)
+        knxipframe2.body.identifier = 0
+        knxipframe2.normalize()
+
+        self.assertEqual(knxipframe2.to_knx(), list(raw))
+
+    def test_connect_response_connection_error_lox(self):
+        """
+        Test parsing and streaming connection response KNX/IP packet with error e_no_more_connections.
+        HPAI given, CRD all zero. This was received from Loxone device (2020).
+        """
+        raw = (
+            0x06,
+            0x10,
+            0x02,
+            0x06,
+            0x00,
+            0x14,
+            0x00,
+            0x24,
+            0x08,
+            0x01,
+            0xC0,
+            0xA8,
+            0x01,
+            0x01,
+            0x0E,
+            0x57,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        )
         xknx = XKNX()
         knxipframe = KNXIPFrame(xknx)
         knxipframe.from_knx(raw)
@@ -143,9 +212,38 @@ class Test_KNXIP_ConnectResponse(unittest.TestCase):
         self.assertEqual(knxipframe.body.status_code, ErrorCode.E_NO_MORE_CONNECTIONS)
         self.assertEqual(knxipframe.body.communication_channel, 0)
 
-        knxipframe2 = KNXIPFrame(xknx)
-        knxipframe2.init(KNXIPServiceType.CONNECT_RESPONSE)
-        knxipframe2.body.status_code = ErrorCode.E_NO_MORE_CONNECTIONS
-        knxipframe2.normalize()
+        # no further tests: the current API can't (and shouldn't) create such odd packets
 
-        self.assertEqual(knxipframe2.to_knx(), list(raw))
+    def test_connect_response_connection_error_mdt(self):
+        """
+        Test parsing and streaming connection response KNX/IP packet with error e_no_more_connections.
+        HPAI and CRD all zero. This was received from MDT device (2020).
+        """
+        raw = (
+            0x06,
+            0x10,
+            0x02,
+            0x06,
+            0x00,
+            0x08,
+            0x00,
+            0x24,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        )
+        xknx = XKNX()
+        knxipframe = KNXIPFrame(xknx)
+        knxipframe.from_knx(raw)
+        self.assertTrue(isinstance(knxipframe.body, ConnectResponse))
+        self.assertEqual(knxipframe.body.status_code, ErrorCode.E_NO_MORE_CONNECTIONS)
+        self.assertEqual(knxipframe.body.communication_channel, 0)
+
+        # no further tests: the current API can't (and shouldn't) create such odd packets

--- a/xknx/knxip/connect_response.py
+++ b/xknx/knxip/connect_response.py
@@ -85,8 +85,6 @@ class ConnectResponse(KNXIPBody):
         data = []
         data.append(self.communication_channel)
         data.append(self.status_code.value)
-
-        # if self.status_code == ErrorCode.E_NO_ERROR:
         data.extend(self.control_endpoint.to_knx())
         data.extend(crd_to_knx())
 

--- a/xknx/knxip/connect_response.py
+++ b/xknx/knxip/connect_response.py
@@ -43,9 +43,7 @@ class ConnectResponse(KNXIPBody):
 
     def calculated_length(self):
         """Get length of KNX/IP body."""
-        if self.status_code == ErrorCode.E_NO_ERROR:
-            return 2 + HPAI.LENGTH + ConnectResponse.CRD_LENGTH
-        return 2
+        return 2 + HPAI.LENGTH + ConnectResponse.CRD_LENGTH
 
     def from_knx(self, raw):
         """Parse/deserialize from KNX/IP raw data."""
@@ -67,6 +65,9 @@ class ConnectResponse(KNXIPBody):
         if self.status_code == ErrorCode.E_NO_ERROR:
             pos += self.control_endpoint.from_knx(raw[pos:])
             pos += crd_from_knx(raw[pos:])
+        else:
+            # do not parse HPAI and CRD in case of errors - just check length
+            pos += len(raw[pos:])
         return pos
 
     def to_knx(self):
@@ -85,9 +86,9 @@ class ConnectResponse(KNXIPBody):
         data.append(self.communication_channel)
         data.append(self.status_code.value)
 
-        if self.status_code == ErrorCode.E_NO_ERROR:
-            data.extend(self.control_endpoint.to_knx())
-            data.extend(crd_to_knx())
+        # if self.status_code == ErrorCode.E_NO_ERROR:
+        data.extend(self.control_endpoint.to_knx())
+        data.extend(crd_to_knx())
 
         return data
 


### PR DESCRIPTION
from @uweswrtz in #272

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
I've taken some changes form #272 to parse ConnectionResponse Telegrams with Error codes "correctly". 
From my local tests nothing changes to current xknx behaviour with these changes, but the parsed error code can be used later in the RequestResponse() or Tunnel() class. I plan to do that in #443 

Also added tests from #272 (rebasing this was too much trouble at this time) Thanks @uweswrtz !

closes #272 

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
