### PR TITLE
Cover: fix position update

### DIFF
--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -325,7 +325,7 @@ class Cover(Device):
                 self.travelcalculator.stop()
                 await self.after_update()
 
-        await self.position_current.process(telegram)
+        await self.position_current.process(telegram, always_callback=True)
         await self.position_target.process(telegram)
         await self.angle.process(telegram)
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -258,7 +258,7 @@ class Cover(Device):
             self.travelcalculator.update_position(self.position_current.value)
         else:
             self.travelcalculator.set_position(self.position_current.value)
-        if not position_before_update == self.travelcalculator.current_position():
+        if position_before_update != self.travelcalculator.current_position():
             await self.after_update()
 
     async def set_angle(self, angle):

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -253,11 +253,13 @@ class Cover(Device):
 
     async def _current_position_from_rv(self):
         """Update the current postion from RemoteValue (Callback)."""
+        position_before_update = self.travelcalculator.current_position()
         if self.is_traveling():
             self.travelcalculator.update_position(self.position_current.value)
         else:
             self.travelcalculator.set_position(self.position_current.value)
-        await self.after_update()
+        if not position_before_update == self.travelcalculator.current_position():
+            await self.after_update()
 
     async def set_angle(self, angle):
         """Move cover to designated angle."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
when a cover can't move (eg. locked) and `set_down()` is called the travelcalculator starts. because of _position_current.value has not changed in this case its callback is not called when a GroupValueResponse comes in - eg. `sync()` is used.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
