### PR TITLE
Typecheck DPT

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased changes
+
+## Internals
+
+- split RemoteValueClimateMode into RemoteValueControllerMode and RemoteValueOperationMode
+
 ## 0.16.1 HA register services 2021-01-16
 
 ### HA integration

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ warn_unused_configs = true
 
 # add the modules below once we add typing for them so that we fail the build in the future if someone changes something without updating the typings
 # fully typechecked modules
-[mypy-xknx.xknx,xknx.core.*,xknx.devices.*,xknx.exceptions.*,xknx.io.*,xknx.knxip.*,xknx.telegram.*,]
+[mypy-xknx.xknx,xknx.core.*,xknx.devices.*,xknx.dpt.*,xknx.exceptions.*,xknx.io.*,xknx.knxip.*,xknx.telegram.*,]
 strict = true
 ignore_errors = false
 warn_unreachable = true
@@ -51,7 +51,7 @@ warn_unreachable = true
 implicit_reexport = true
 
 # partly typechecked modules (extra block for better overview)
-[mypy-xknx.dpt.dpt,xknx.remote_value.remote_value,xknx.remote_value.remote_value_climate_mode]
+[mypy-xknx.remote_value.remote_value,xknx.remote_value.remote_value_climate_mode]
 strict = true
 ignore_errors = false
 warn_unreachable = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ warn_unreachable = true
 implicit_reexport = true
 
 # partly typechecked modules (extra block for better overview)
-[mypy-xknx.remote_value.remote_value,xknx.remote_value.remote_value_climate_mode]
+[mypy-xknx.dpt.dpt,xknx.remote_value.remote_value,xknx.remote_value.remote_value_climate_mode]
 strict = true
 ignore_errors = false
 warn_unreachable = true

--- a/test/dpt_tests/dpt_1byte_uint_test.py
+++ b/test/dpt_tests/dpt_1byte_uint_test.py
@@ -13,17 +13,17 @@ class TestDPTValue1Ucount(unittest.TestCase):
     def test_value_50(self):
         """Test parsing and streaming of DPTValue1Ucount 50."""
         self.assertEqual(DPTValue1Ucount().to_knx(50), (0x32,))
-        self.assertEqual(DPTValue1Ucount().from_knx((0x32,)), 50)
+        self.assertEqual(DPTValue1Ucount().from_knx(bytes([0x32])), 50)
 
     def test_value_max(self):
         """Test parsing and streaming of DPTValue1Ucount 255."""
         self.assertEqual(DPTValue1Ucount().to_knx(255), (0xFF,))
-        self.assertEqual(DPTValue1Ucount().from_knx((0xFF,)), 255)
+        self.assertEqual(DPTValue1Ucount().from_knx(bytes([0xFF])), 255)
 
     def test_value_min(self):
         """Test parsing and streaming of DPTValue1Ucount 0."""
         self.assertEqual(DPTValue1Ucount().to_knx(0), (0x00,))
-        self.assertEqual(DPTValue1Ucount().from_knx((0x00,)), 0)
+        self.assertEqual(DPTValue1Ucount().from_knx(bytes([0x00])), 0)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTValue1Ucount with wrong value (underflow)."""
@@ -35,25 +35,10 @@ class TestDPTValue1Ucount(unittest.TestCase):
         with self.assertRaises(ConversionError):
             DPTValue1Ucount().to_knx(DPTValue1Ucount.value_max + 1)
 
-    def test_to_knx_wrong_parameter(self):
-        """Test parsing of DPTValue1Ucount with wrong value (string)."""
-        with self.assertRaises(ConversionError):
-            DPTValue1Ucount().to_knx("fnord")
-
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPTValue1Ucount with wrong value (3 byte array)."""
         with self.assertRaises(ConversionError):
-            DPTValue1Ucount().from_knx((0x01, 0x02, 0x03))
-
-    def test_from_knx_wrong_value(self):
-        """Test parsing of DPTValue1Ucount with value which exceeds limits."""
-        with self.assertRaises(ConversionError):
-            DPTValue1Ucount().from_knx((0x256,))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTValue1Ucount with wrong value (array containing string)."""
-        with self.assertRaises(ConversionError):
-            DPTValue1Ucount().from_knx("0x23")
+            DPTValue1Ucount().from_knx(bytes([0x01, 0x02, 0x03]))
 
 
 class TestDPTTariff(unittest.TestCase):
@@ -62,4 +47,4 @@ class TestDPTTariff(unittest.TestCase):
     def test_from_knx_max_exceeded(self):
         """Test parsing of DPTTariff with wrong value (overflow)."""
         with self.assertRaises(ConversionError):
-            DPTTariff().from_knx((0xFF,))
+            DPTTariff().from_knx(bytes([0xFF]))

--- a/test/dpt_tests/dpt_2byte_signed_test.py
+++ b/test/dpt_tests/dpt_2byte_signed_test.py
@@ -30,29 +30,29 @@ class TestDPT2ByteSigned(unittest.TestCase):
     def test_signed_value_max_value(self):
         """Test DPT2ByteSigned parsing and streaming."""
         self.assertEqual(DPT2ByteSigned().to_knx(32767), (0x7F, 0xFF))
-        self.assertEqual(DPT2ByteSigned().from_knx((0x7F, 0xFF)), 32767)
+        self.assertEqual(DPT2ByteSigned().from_knx(bytes((0x7F, 0xFF))), 32767)
 
     def test_signed_value_min_value(self):
         """Test DPT2ByteSigned parsing and streaming with null values."""
         self.assertEqual(DPT2ByteSigned().to_knx(-20480), (0xB0, 0x00))
-        self.assertEqual(DPT2ByteSigned().from_knx((0xB0, 0x00)), -20480)
+        self.assertEqual(DPT2ByteSigned().from_knx(bytes((0xB0, 0x00))), -20480)
 
     def test_signed_value_0123(self):
         """Test DPT2ByteSigned parsing and streaming."""
         self.assertEqual(DPT2ByteSigned().to_knx(291), (0x01, 0x23))
-        self.assertEqual(DPT2ByteSigned().from_knx((0x01, 0x23)), 291)
+        self.assertEqual(DPT2ByteSigned().from_knx(bytes((0x01, 0x23))), 291)
 
     def test_signed_wrong_value_from_knx(self):
         """Test DPT2ByteSigned parsing with wrong value."""
         with self.assertRaises(ConversionError):
-            DPT2ByteSigned().from_knx((0xFF, 0x4E, 0x12))
+            DPT2ByteSigned().from_knx(bytes((0xFF, 0x4E, 0x12)))
 
     def test_from_knx_unpack_error(self):
         """Test DPT2ByteSigned parsing with unpack error."""
         with patch("struct.unpack") as unpackMock:
             unpackMock.side_effect = struct.error()
             with self.assertRaises(ConversionError):
-                DPT2ByteSigned().from_knx((0x01, 0x23))
+                DPT2ByteSigned().from_knx(bytes((0x01, 0x23)))
 
     def test_to_knx_pack_error(self):
         """Test serializing DPT2ByteSigned with pack error."""

--- a/test/dpt_tests/dpt_2byte_uint_test.py
+++ b/test/dpt_tests/dpt_2byte_uint_test.py
@@ -33,29 +33,29 @@ class TestDPT2byte(unittest.TestCase):
     def test_current_value_max_value(self):
         """Test DPTUElCurrentmA parsing and streaming."""
         self.assertEqual(DPTUElCurrentmA().to_knx(65535), (0xFF, 0xFF))
-        self.assertEqual(DPTUElCurrentmA().from_knx((0xFF, 0xFF)), 65535)
+        self.assertEqual(DPTUElCurrentmA().from_knx(bytes([0xFF, 0xFF])), 65535)
 
     def test_current_value_min_value(self):
         """Test DPTUElCurrentmA parsing and streaming with null values."""
         self.assertEqual(DPTUElCurrentmA().to_knx(0), (0x00, 0x00))
-        self.assertEqual(DPTUElCurrentmA().from_knx((0x00, 0x00)), 0)
+        self.assertEqual(DPTUElCurrentmA().from_knx(bytes([0x00, 0x00])), 0)
 
     def test_current_value_38(self):
         """Test DPTUElCurrentmA parsing and streaming 38mA."""
         self.assertEqual(DPTUElCurrentmA().to_knx(38), (0x00, 0x26))
-        self.assertEqual(DPTUElCurrentmA().from_knx((0x00, 0x26)), 38)
+        self.assertEqual(DPTUElCurrentmA().from_knx(bytes([0x00, 0x26])), 38)
 
     def test_current_value_78(self):
         """Test DPTUElCurrentmA parsing and streaming 78mA."""
         self.assertEqual(DPTUElCurrentmA().to_knx(78), (0x00, 0x4E))
-        self.assertEqual(DPTUElCurrentmA().from_knx((0x00, 0x4E)), 78)
+        self.assertEqual(DPTUElCurrentmA().from_knx(bytes([0x00, 0x4E])), 78)
 
     def test_current_value_1234(self):
         """Test DPTUElCurrentmA parsing and streaming 4660mA."""
         self.assertEqual(DPTUElCurrentmA().to_knx(4660), (0x12, 0x34))
-        self.assertEqual(DPTUElCurrentmA().from_knx((0x12, 0x34)), 4660)
+        self.assertEqual(DPTUElCurrentmA().from_knx(bytes([0x12, 0x34])), 4660)
 
     def test_current_wrong_value_from_knx(self):
         """Test DPTUElCurrentmA parsing with wrong value."""
         with self.assertRaises(ConversionError):
-            DPTUElCurrentmA().from_knx((0xFF, 0x4E, 0x12))
+            DPTUElCurrentmA().from_knx(bytes([0xFF, 0x4E, 0x12]))

--- a/test/dpt_tests/dpt_4byte_int_test.py
+++ b/test/dpt_tests/dpt_4byte_int_test.py
@@ -36,25 +36,27 @@ class TestDPT4Byte(unittest.TestCase):
             DPT4ByteUnsigned().to_knx(4294967295), (0xFF, 0xFF, 0xFF, 0xFF)
         )
         self.assertEqual(
-            DPT4ByteUnsigned().from_knx((0xFF, 0xFF, 0xFF, 0xFF)), 4294967295
+            DPT4ByteUnsigned().from_knx(bytes([0xFF, 0xFF, 0xFF, 0xFF])), 4294967295
         )
 
     def test_unsigned_value_min_value(self):
         """Test parsing and streaming with null values."""
         self.assertEqual(DPT4ByteUnsigned().to_knx(0), (0x00, 0x00, 0x00, 0x00))
-        self.assertEqual(DPT4ByteUnsigned().from_knx((0x00, 0x00, 0x00, 0x00)), 0)
+        self.assertEqual(
+            DPT4ByteUnsigned().from_knx(bytes([0x00, 0x00, 0x00, 0x00])), 0
+        )
 
     def test_unsigned_value_01234567(self):
         """Test DPT4ByteUnsigned parsing and streaming."""
         self.assertEqual(DPT4ByteUnsigned().to_knx(19088743), (0x01, 0x23, 0x45, 0x67))
         self.assertEqual(
-            DPT4ByteUnsigned().from_knx((0x01, 0x23, 0x45, 0x67)), 19088743
+            DPT4ByteUnsigned().from_knx(bytes([0x01, 0x23, 0x45, 0x67])), 19088743
         )
 
     def test_unsigned_wrong_value_from_knx(self):
         """Test DPT4ByteUnsigned parsing with wrong value."""
         with self.assertRaises(ConversionError):
-            DPT4ByteUnsigned().from_knx((0xFF, 0x4E, 0x12))
+            DPT4ByteUnsigned().from_knx(bytes([0xFF, 0x4E, 0x12]))
 
     # ####################################################################
     # DPT4ByteSigned
@@ -78,32 +80,34 @@ class TestDPT4Byte(unittest.TestCase):
         """Test DPT4ByteSigned parsing and streaming."""
         self.assertEqual(DPT4ByteSigned().to_knx(2147483647), (0x7F, 0xFF, 0xFF, 0xFF))
         self.assertEqual(
-            DPT4ByteSigned().from_knx((0x7F, 0xFF, 0xFF, 0xFF)), 2147483647
+            DPT4ByteSigned().from_knx(bytes([0x7F, 0xFF, 0xFF, 0xFF])), 2147483647
         )
 
     def test_signed_value_min_value(self):
         """Test DPT4ByteSigned parsing and streaming with null values."""
         self.assertEqual(DPT4ByteSigned().to_knx(-2147483648), (0x80, 0x00, 0x00, 0x00))
         self.assertEqual(
-            DPT4ByteSigned().from_knx((0x80, 0x00, 0x00, 0x00)), -2147483648
+            DPT4ByteSigned().from_knx(bytes([0x80, 0x00, 0x00, 0x00])), -2147483648
         )
 
     def test_signed_value_01234567(self):
         """Test DPT4ByteSigned parsing and streaming."""
         self.assertEqual(DPT4ByteSigned().to_knx(19088743), (0x01, 0x23, 0x45, 0x67))
-        self.assertEqual(DPT4ByteSigned().from_knx((0x01, 0x23, 0x45, 0x67)), 19088743)
+        self.assertEqual(
+            DPT4ByteSigned().from_knx(bytes([0x01, 0x23, 0x45, 0x67])), 19088743
+        )
 
     def test_signed_wrong_value_from_knx(self):
         """Test DPT4ByteSigned parsing with wrong value."""
         with self.assertRaises(ConversionError):
-            DPT4ByteSigned().from_knx((0xFF, 0x4E, 0x12))
+            DPT4ByteSigned().from_knx(bytes([0xFF, 0x4E, 0x12]))
 
     def test_from_knx_unpack_error(self):
         """Test DPT4ByteSigned parsing with unpack error."""
         with patch("struct.unpack") as unpackMock:
             unpackMock.side_effect = struct.error()
             with self.assertRaises(ConversionError):
-                DPT4ByteSigned().from_knx((0x01, 0x23, 0x45, 0x67))
+                DPT4ByteSigned().from_knx(bytes([0x01, 0x23, 0x45, 0x67]))
 
     def test_to_knx_pack_error(self):
         """Test serializing DPT4ByteSigned with pack error."""

--- a/test/dpt_tests/dpt_date_test.py
+++ b/test/dpt_tests/dpt_date_test.py
@@ -12,21 +12,21 @@ class TestDPTDate(unittest.TestCase):
     def test_from_knx(self):
         """Test parsing of DPTDate object from binary values. Example 1."""
         self.assertEqual(
-            DPTDate().from_knx((0x04, 0x01, 0x02)),
+            DPTDate().from_knx(bytes([0x04, 0x01, 0x02])),
             time.strptime("2002-01-04", "%Y-%m-%d"),
         )
 
     def test_from_knx_old_date(self):
         """Test parsing of DPTDate object from binary values. Example 2."""
         self.assertEqual(
-            DPTDate().from_knx((0x1F, 0x01, 0x5A)),
+            DPTDate().from_knx(bytes([0x1F, 0x01, 0x5A])),
             time.strptime("1990-01-31", "%Y-%m-%d"),
         )
 
     def test_from_knx_future_date(self):
         """Test parsing of DPTDate object from binary values. Example 3."""
         self.assertEqual(
-            DPTDate().from_knx((0x04, 0x0C, 0x59)),
+            DPTDate().from_knx(bytes([0x04, 0x0C, 0x59])),
             time.strptime("2089-12-4", "%Y-%m-%d"),
         )
 
@@ -48,7 +48,7 @@ class TestDPTDate(unittest.TestCase):
     def test_from_knx_wrong_parameter(self):
         """Test parsing from DPTDate object from wrong binary values."""
         with self.assertRaises(ConversionError):
-            DPTDate().from_knx((0xF8, 0x23))
+            DPTDate().from_knx(bytes([0xF8, 0x23]))
 
     def test_to_knx_wrong_parameter(self):
         """Test parsing from DPTDate object from wrong string value."""
@@ -58,9 +58,9 @@ class TestDPTDate(unittest.TestCase):
     def test_from_knx_wrong_range_month(self):
         """Test Exception when parsing DPTDAte from KNX with wrong month."""
         with self.assertRaises(ConversionError):
-            DPTDate().from_knx((0x04, 0x00, 0x59))
+            DPTDate().from_knx(bytes([0x04, 0x00, 0x59]))
 
     def test_from_knx_wrong_range_year(self):
         """Test Exception when parsing DPTDate from KNX with wrong year."""
         with self.assertRaises(ConversionError):
-            DPTDate().from_knx((0x04, 0x01, 0x64))
+            DPTDate().from_knx(bytes([0x04, 0x01, 0x64]))

--- a/test/dpt_tests/dpt_datetime_test.py
+++ b/test/dpt_tests/dpt_datetime_test.py
@@ -15,7 +15,9 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x20, 0x80)),
+            DPTDateTime().from_knx(
+                bytes([0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x20, 0x80])
+            ),
             time.strptime("2017-11-28 23:7:24", "%Y-%m-%d %H:%M:%S"),
         )
 
@@ -32,7 +34,9 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx_date_in_past(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00)),
+            DPTDateTime().from_knx(
+                bytes([0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00])
+            ),
             time.strptime("1900 1 1 0 0 0", "%Y %m %d %H %M %S"),
         )
 
@@ -49,7 +53,9 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx_date_in_future(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTDateTime().from_knx((0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80)),
+            DPTDateTime().from_knx(
+                bytes([0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80])
+            ),
             time.strptime("2155-12-31 0 23:59:59", "%Y-%m-%d %w %H:%M:%S"),
         )
 
@@ -66,13 +72,15 @@ class TestDPTDateTime(unittest.TestCase):
     def test_from_knx_wrong_size(self):
         """Test parsing DPTDateTime from KNX with wrong binary values (wrong size)."""
         with self.assertRaises(ConversionError):
-            DPTDateTime().from_knx((0xF8, 0x23))
+            DPTDateTime().from_knx(bytes([0xF8, 0x23]))
 
     def test_from_knx_wrong_bytes(self):
         """Test parsing DPTDateTime from KNX with wrong binary values (wrong bytes)."""
         with self.assertRaises(ConversionError):
             # (second byte exceeds value...)
-            DPTDateTime().from_knx((0xFF, 0x0D, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00))
+            DPTDateTime().from_knx(
+                bytes([0xFF, 0x0D, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00])
+            )
 
     #
     # TEST WRONG PARAMETER

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -32,35 +32,35 @@ class TestDPTFloat(unittest.TestCase):
     def test_value_from_documentation(self):
         """Test parsing and streaming of DPT2ByteFloat -30.00. Example from the internet[tm]."""
         self.assertEqual(DPT2ByteFloat().to_knx(-30.00), (0x8A, 0x24))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x8A, 0x24)), -30.00)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x8A, 0x24])), -30.00)
 
     def test_value_taken_from_live_thermostat(self):
         """Test parsing and streaming of DPT2ByteFloat 19.96."""
         self.assertEqual(DPT2ByteFloat().to_knx(16.96), (0x06, 0xA0))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x06, 0xA0)), 16.96)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x06, 0xA0])), 16.96)
 
     def test_zero_value(self):
         """Test parsing and streaming of DPT2ByteFloat zero value."""
         self.assertEqual(DPT2ByteFloat().to_knx(0.00), (0x00, 0x00))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x00, 0x00)), 0.00)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x00, 0x00])), 0.00)
 
     def test_room_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 21.00. Room temperature."""
         self.assertEqual(DPT2ByteFloat().to_knx(21.00), (0x0C, 0x1A))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x0C, 0x1A)), 21.00)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x0C, 0x1A])), 21.00)
 
     def test_high_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 500.00, 499.84, 500.16. Testing rounding issues."""
         self.assertEqual(DPT2ByteFloat().to_knx(500.00), (0x2E, 0x1A))
-        self.assertAlmostEqual(DPT2ByteFloat().from_knx((0x2E, 0x1A)), 499.84)
-        self.assertAlmostEqual(DPT2ByteFloat().from_knx((0x2E, 0x1B)), 500.16)
+        self.assertAlmostEqual(DPT2ByteFloat().from_knx(bytes([0x2E, 0x1A])), 499.84)
+        self.assertAlmostEqual(DPT2ByteFloat().from_knx(bytes([0x2E, 0x1B])), 500.16)
         self.assertEqual(DPT2ByteFloat().to_knx(499.84), (0x2E, 0x1A))
         self.assertEqual(DPT2ByteFloat().to_knx(500.16), (0x2E, 0x1B))
 
     def test_minor_negative_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat -10.00. Testing negative values."""
         self.assertEqual(DPT2ByteFloat().to_knx(-10.00), (0x84, 0x18))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x84, 0x18)), -10.00)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x84, 0x18])), -10.00)
 
     def test_very_cold_temperature(self):
         """
@@ -69,8 +69,8 @@ class TestDPTFloat(unittest.TestCase):
         Testing rounding issues of negative values.
         """
         self.assertEqual(DPT2ByteFloat().to_knx(-1000.00), (0xB1, 0xE6))
-        self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE6)), -999.68)
-        self.assertEqual(DPT2ByteFloat().from_knx((0xB1, 0xE5)), -1000.32)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0xB1, 0xE6])), -999.68)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0xB1, 0xE5])), -1000.32)
         self.assertEqual(DPT2ByteFloat().to_knx(-999.68), (0xB1, 0xE6))
         self.assertEqual(DPT2ByteFloat().to_knx(-1000.32), (0xB1, 0xE5))
 
@@ -78,25 +78,25 @@ class TestDPTFloat(unittest.TestCase):
         """Test parsing and streaming of DPT2ByteFloat with maximum value."""
         self.assertEqual(DPT2ByteFloat().to_knx(DPT2ByteFloat.value_max), (0x7F, 0xFF))
         self.assertEqual(
-            DPT2ByteFloat().from_knx((0x7F, 0xFF)), DPT2ByteFloat.value_max
+            DPT2ByteFloat().from_knx(bytes([0x7F, 0xFF])), DPT2ByteFloat.value_max
         )
 
     def test_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value."""
         self.assertEqual(DPT2ByteFloat().to_knx(DPT2ByteFloat.value_min), (0xF8, 0x00))
         self.assertEqual(
-            DPT2ByteFloat().from_knx((0xF8, 0x00)), DPT2ByteFloat.value_min
+            DPT2ByteFloat().from_knx(bytes([0xF8, 0x00])), DPT2ByteFloat.value_min
         )
 
     def test_close_to_max(self):
         """Test parsing and streaming of DPT2ByteFloat with maximum value -1."""
         self.assertEqual(DPT2ByteFloat().to_knx(670433.28), (0x7F, 0xFE))
-        self.assertEqual(DPT2ByteFloat().from_knx((0x7F, 0xFE)), 670433.28)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0x7F, 0xFE])), 670433.28)
 
     def test_close_to_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value +1."""
         self.assertEqual(DPT2ByteFloat().to_knx(-670760.96), (0xF8, 0x01))
-        self.assertEqual(DPT2ByteFloat().from_knx((0xF8, 0x01)), -670760.96)
+        self.assertEqual(DPT2ByteFloat().from_knx(bytes([0xF8, 0x01])), -670760.96)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPT2ByteFloat with wrong value (underflow)."""
@@ -116,12 +116,7 @@ class TestDPTFloat(unittest.TestCase):
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPT2ByteFloat with wrong value (wrong number of bytes)."""
         with self.assertRaises(ConversionError):
-            DPT2ByteFloat().from_knx((0xF8, 0x01, 0x23))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPT2ByteFloat with wrong value (second parameter is a string)."""
-        with self.assertRaises(ConversionError):
-            DPT2ByteFloat().from_knx((0xF8, "0x23"))
+            DPT2ByteFloat().from_knx(bytes([0xF8, 0x01, 0x23]))
 
     #
     # DPTTemperature
@@ -141,7 +136,7 @@ class TestDPTFloat(unittest.TestCase):
     def test_temperature_assert_min_exceeded_from_knx(self):
         """Testing parsing of DPTTemperature with wrong value."""
         with self.assertRaises(ConversionError):
-            DPTTemperature().from_knx((0xB1, 0xE6))  # -1000
+            DPTTemperature().from_knx(bytes([0xB1, 0xE6]))  # -1000
 
     #
     # DPTLux
@@ -199,9 +194,9 @@ class TestDPTFloat(unittest.TestCase):
     #
     def test_4byte_float_values_from_power_meter(self):
         """Test parsing DPT4ByteFloat value from power meter."""
-        self.assertEqual(DPT4ByteFloat().from_knx((0x43, 0xC6, 0x80, 00)), 397)
+        self.assertEqual(DPT4ByteFloat().from_knx(bytes([0x43, 0xC6, 0x80, 00])), 397)
         self.assertEqual(DPT4ByteFloat().to_knx(397), (0x43, 0xC6, 0x80, 00))
-        self.assertEqual(DPT4ByteFloat().from_knx((0x42, 0x38, 0x00, 00)), 46)
+        self.assertEqual(DPT4ByteFloat().from_knx(bytes([0x42, 0x38, 0x00, 00])), 46)
         self.assertEqual(DPT4ByteFloat().to_knx(46), (0x42, 0x38, 0x00, 00))
 
     def test_14_033(self):
@@ -210,14 +205,17 @@ class TestDPTFloat(unittest.TestCase):
 
     def test_14_055(self):
         """Test DPTPhaseAngleDeg object."""
-        self.assertEqual(DPT4ByteFloat().from_knx((0x42, 0xEF, 0x00, 0x00)), 119.5)
+        self.assertEqual(
+            DPT4ByteFloat().from_knx(bytes([0x42, 0xEF, 0x00, 0x00])), 119.5
+        )
         self.assertEqual(DPT4ByteFloat().to_knx(119.5), (0x42, 0xEF, 0x00, 0x00))
         self.assertEqual(DPTPhaseAngleDeg().unit, "°")
 
     def test_14_057(self):
         """Test DPT4ByteFloat object."""
         self.assertEqual(
-            round(DPT4ByteFloat().from_knx((0x3F, 0x71, 0xEB, 0x86)), 7), 0.9450001
+            round(DPT4ByteFloat().from_knx(bytes([0x3F, 0x71, 0xEB, 0x86])), 7),
+            0.9450001,
         )
         self.assertEqual(
             DPT4ByteFloat().to_knx(0.945000052452), (0x3F, 0x71, 0xEB, 0x86)
@@ -227,13 +225,15 @@ class TestDPTFloat(unittest.TestCase):
     def test_4byte_float_values_from_voltage_meter(self):
         """Test parsing DPT4ByteFloat from voltage meter."""
         self.assertEqual(
-            round(DPT4ByteFloat().from_knx((0x43, 0x65, 0xE3, 0xD7)), 2), 229.89
+            round(DPT4ByteFloat().from_knx(bytes([0x43, 0x65, 0xE3, 0xD7])), 2), 229.89
         )
         self.assertEqual(DPT4ByteFloat().to_knx(229.89), (0x43, 0x65, 0xE3, 0xD7))
 
     def test_4byte_float_zero_value(self):
         """Test parsing and streaming of DPT4ByteFloat zero value."""
-        self.assertEqual(DPT4ByteFloat().from_knx((0x00, 0x00, 0x00, 0x00)), 0.00)
+        self.assertEqual(
+            DPT4ByteFloat().from_knx(bytes([0x00, 0x00, 0x00, 0x00])), 0.00
+        )
         self.assertEqual(DPT4ByteFloat().to_knx(0.00), (0x00, 0x00, 0x00, 0x00))
 
     def test_4byte_float_to_knx_wrong_parameter(self):
@@ -244,19 +244,14 @@ class TestDPTFloat(unittest.TestCase):
     def test_4byte_float_from_knx_wrong_parameter(self):
         """Test parsing of DPT4ByteFloat with wrong value (wrong number of bytes)."""
         with self.assertRaises(ConversionError):
-            DPT4ByteFloat().from_knx((0xF8, 0x01, 0x23))
-
-    def test_4byte_float_from_knx_wrong_parameter2(self):
-        """Test parsing of DPT4ByteFloat with wrong value (second parameter is a string)."""
-        with self.assertRaises(ConversionError):
-            DPT4ByteFloat().from_knx((0xF8, "0x23", 0x00, 0x00))
+            DPT4ByteFloat().from_knx(bytes([0xF8, 0x01, 0x23]))
 
     def test_4byte_flaot_from_knx_unpack_error(self):
         """Test DPT4ByteFloat parsing with unpack error."""
         with patch("struct.unpack") as unpackMock:
             unpackMock.side_effect = struct.error()
             with self.assertRaises(ConversionError):
-                DPT4ByteFloat().from_knx((0x01, 0x23, 0x02, 0x02))
+                DPT4ByteFloat().from_knx(bytes([0x01, 0x23, 0x02, 0x02]))
 
     #
     # DPTElectricCurrent

--- a/test/dpt_tests/dpt_hvac_mode_test.py
+++ b/test/dpt_tests/dpt_hvac_mode_test.py
@@ -28,12 +28,12 @@ class TestDPTControllerStatus(unittest.TestCase):
 
     def test_mode_from_knx(self):
         """Test parsing DPTHVACMode from KNX."""
-        self.assertEqual(DPTHVACMode.from_knx((0x00,)), HVACOperationMode.AUTO)
-        self.assertEqual(DPTHVACMode.from_knx((0x01,)), HVACOperationMode.COMFORT)
-        self.assertEqual(DPTHVACMode.from_knx((0x02,)), HVACOperationMode.STANDBY)
-        self.assertEqual(DPTHVACMode.from_knx((0x03,)), HVACOperationMode.NIGHT)
+        self.assertEqual(DPTHVACMode.from_knx(bytes([0x00])), HVACOperationMode.AUTO)
+        self.assertEqual(DPTHVACMode.from_knx(bytes([0x01])), HVACOperationMode.COMFORT)
+        self.assertEqual(DPTHVACMode.from_knx(bytes([0x02])), HVACOperationMode.STANDBY)
+        self.assertEqual(DPTHVACMode.from_knx(bytes([0x03])), HVACOperationMode.NIGHT)
         self.assertEqual(
-            DPTHVACMode.from_knx((0x04,)), HVACOperationMode.FROST_PROTECTION
+            DPTHVACMode.from_knx(bytes([0x04])), HVACOperationMode.FROST_PROTECTION
         )
 
     def test_controller_status_to_knx(self):
@@ -55,45 +55,51 @@ class TestDPTControllerStatus(unittest.TestCase):
     def test_controller_status_from_knx(self):
         """Test parsing DPTControllerStatus from KNX."""
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x21,)), HVACOperationMode.COMFORT
+            DPTControllerStatus.from_knx(bytes([0x21])), HVACOperationMode.COMFORT
         )
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x22,)), HVACOperationMode.STANDBY
+            DPTControllerStatus.from_knx(bytes([0x22])), HVACOperationMode.STANDBY
         )
-        self.assertEqual(DPTControllerStatus.from_knx((0x24,)), HVACOperationMode.NIGHT)
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x28,)), HVACOperationMode.FROST_PROTECTION
+            DPTControllerStatus.from_knx(bytes([0x24])), HVACOperationMode.NIGHT
+        )
+        self.assertEqual(
+            DPTControllerStatus.from_knx(bytes([0x28])),
+            HVACOperationMode.FROST_PROTECTION,
         )
 
     def test_controller_status_from_knx_other_bits_set(self):
         """Test parsing DPTControllerStatus from KNX."""
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x21,)), HVACOperationMode.COMFORT
+            DPTControllerStatus.from_knx(bytes([0x21])), HVACOperationMode.COMFORT
         )
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x23,)), HVACOperationMode.STANDBY
+            DPTControllerStatus.from_knx(bytes([0x23])), HVACOperationMode.STANDBY
         )
-        self.assertEqual(DPTControllerStatus.from_knx((0x27,)), HVACOperationMode.NIGHT)
         self.assertEqual(
-            DPTControllerStatus.from_knx((0x2F,)), HVACOperationMode.FROST_PROTECTION
+            DPTControllerStatus.from_knx(bytes([0x27])), HVACOperationMode.NIGHT
+        )
+        self.assertEqual(
+            DPTControllerStatus.from_knx(bytes([0x2F])),
+            HVACOperationMode.FROST_PROTECTION,
         )
 
     def test_mode_from_knx_wrong_value(self):
         """Test parsing of DPTControllerStatus with wrong value)."""
         with self.assertRaises(ConversionError):
-            DPTHVACMode.from_knx((1, 2))
+            DPTHVACMode.from_knx(bytes([1, 2]))
 
     def test_mode_from_knx_wrong_code(self):
         """Test parsing of DPTHVACMode with wrong code."""
         with self.assertRaises(CouldNotParseKNXIP):
-            DPTHVACMode.from_knx((0x05,))
+            DPTHVACMode.from_knx(bytes([0x05]))
 
     def test_controller_status_from_knx_wrong_value(self):
         """Test parsing of DPTControllerStatus with wrong value)."""
         with self.assertRaises(ConversionError):
-            DPTControllerStatus.from_knx((1, 2))
+            DPTControllerStatus.from_knx(bytes([1, 2]))
 
     def test_controller_status_from_knx_wrong_code(self):
         """Test parsing of DPTControllerStatus with wrong code."""
         with self.assertRaises(CouldNotParseKNXIP):
-            DPTControllerStatus.from_knx((0x00,))
+            DPTControllerStatus.from_knx(bytes([0x00]))

--- a/test/dpt_tests/dpt_scaling_test.py
+++ b/test/dpt_tests/dpt_scaling_test.py
@@ -13,22 +13,22 @@ class TestDPTScaling(unittest.TestCase):
     def test_value_30_pct(self):
         """Test parsing and streaming of DPTScaling 30%."""
         self.assertEqual(DPTScaling().to_knx(30), (0x4C,))
-        self.assertEqual(DPTScaling().from_knx((0x4C,)), 30)
+        self.assertEqual(DPTScaling().from_knx(bytes([0x4C])), 30)
 
     def test_value_99_pct(self):
         """Test parsing and streaming of DPTScaling 99%."""
         self.assertEqual(DPTScaling().to_knx(99), (0xFC,))
-        self.assertEqual(DPTScaling().from_knx((0xFC,)), 99)
+        self.assertEqual(DPTScaling().from_knx(bytes([0xFC])), 99)
 
     def test_value_max(self):
         """Test parsing and streaming of DPTScaling 100%."""
         self.assertEqual(DPTScaling().to_knx(100), (0xFF,))
-        self.assertEqual(DPTScaling().from_knx((0xFF,)), 100)
+        self.assertEqual(DPTScaling().from_knx(bytes([0xFF])), 100)
 
     def test_value_min(self):
         """Test parsing and streaming of DPTScaling 0."""
         self.assertEqual(DPTScaling().to_knx(0), (0x00,))
-        self.assertEqual(DPTScaling().from_knx((0x00,)), 0)
+        self.assertEqual(DPTScaling().from_knx(bytes([0x00])), 0)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTScaling with wrong value (underflow)."""
@@ -48,17 +48,7 @@ class TestDPTScaling(unittest.TestCase):
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPTScaling with wrong value (3 byte array)."""
         with self.assertRaises(ConversionError):
-            DPTScaling().from_knx((0x01, 0x02, 0x03))
-
-    def test_from_knx_wrong_value(self):
-        """Test parsing of DPTScaling with value which exceeds limits."""
-        with self.assertRaises(ConversionError):
-            DPTScaling().from_knx((0x256,))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTScaling with wrong value (array containing string)."""
-        with self.assertRaises(ConversionError):
-            DPTScaling().from_knx("0x23")
+            DPTScaling().from_knx(bytes([0x01, 0x02, 0x03]))
 
 
 class TestDPTAngle(unittest.TestCase):
@@ -69,22 +59,22 @@ class TestDPTAngle(unittest.TestCase):
     def test_value_30_deg(self):
         """Test parsing and streaming of DPTAngle 30°."""
         self.assertEqual(DPTAngle().to_knx(30), (0x15,))
-        self.assertEqual(DPTAngle().from_knx((0x15,)), 30)
+        self.assertEqual(DPTAngle().from_knx(bytes([0x15])), 30)
 
     def test_value_270_deg(self):
         """Test parsing and streaming of DPTAngle 270°."""
         self.assertEqual(DPTAngle().to_knx(270), (0xBF,))
-        self.assertEqual(DPTAngle().from_knx((0xBF,)), 270)
+        self.assertEqual(DPTAngle().from_knx(bytes([0xBF])), 270)
 
     def test_value_max(self):
         """Test parsing and streaming of DPTAngle 360°."""
         self.assertEqual(DPTAngle().to_knx(360), (0xFF,))
-        self.assertEqual(DPTAngle().from_knx((0xFF,)), 360)
+        self.assertEqual(DPTAngle().from_knx(bytes([0xFF])), 360)
 
     def test_value_min(self):
         """Test parsing and streaming of DPTAngle 0°."""
         self.assertEqual(DPTAngle().to_knx(0), (0x00,))
-        self.assertEqual(DPTAngle().from_knx((0x00,)), 0)
+        self.assertEqual(DPTAngle().from_knx(bytes([0x00])), 0)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTAngle with wrong value (underflow)."""

--- a/test/dpt_tests/dpt_scene_number_test.py
+++ b/test/dpt_tests/dpt_scene_number_test.py
@@ -13,17 +13,17 @@ class TestDPTSceneNumber(unittest.TestCase):
     def test_value_50(self):
         """Test parsing and streaming of DPTSceneNumber 50."""
         self.assertEqual(DPTSceneNumber().to_knx(50), (0x31,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x31,)), 50)
+        self.assertEqual(DPTSceneNumber().from_knx(bytes([0x31])), 50)
 
     def test_value_max(self):
         """Test parsing and streaming of DPTSceneNumber 64."""
         self.assertEqual(DPTSceneNumber().to_knx(64), (0x3F,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x3F,)), 64)
+        self.assertEqual(DPTSceneNumber().from_knx(bytes([0x3F])), 64)
 
     def test_value_min(self):
         """Test parsing and streaming of DPTSceneNumber 0."""
         self.assertEqual(DPTSceneNumber().to_knx(1), (0x00,))
-        self.assertEqual(DPTSceneNumber().from_knx((0x00,)), 1)
+        self.assertEqual(DPTSceneNumber().from_knx(bytes([0x00])), 1)
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTSceneNumber with wrong value (underflow)."""
@@ -43,14 +43,9 @@ class TestDPTSceneNumber(unittest.TestCase):
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPTSceneNumber with wrong value (3 byte array)."""
         with self.assertRaises(ConversionError):
-            DPTSceneNumber().from_knx((0x01, 0x02, 0x03))
+            DPTSceneNumber().from_knx(bytes([0x01, 0x02, 0x03]))
 
     def test_from_knx_wrong_value(self):
         """Test parsing of DPTSceneNumber with value which exceeds limits."""
         with self.assertRaises(ConversionError):
-            DPTSceneNumber().from_knx((0x64,))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTSceneNumber with wrong value (array containing string)."""
-        with self.assertRaises(ConversionError):
-            DPTSceneNumber().from_knx("0x23")
+            DPTSceneNumber().from_knx(bytes([0x64]))

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -12,88 +12,96 @@ class TestDPTString(unittest.TestCase):
 
     def test_value_from_documentation(self):
         """Test parsing and streaming Example from documentation."""
-        raw = [
-            0x4B,
-            0x4E,
-            0x58,
-            0x20,
-            0x69,
-            0x73,
-            0x20,
-            0x4F,
-            0x4B,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
+        raw = bytes(
+            [
+                0x4B,
+                0x4E,
+                0x58,
+                0x20,
+                0x69,
+                0x73,
+                0x20,
+                0x4F,
+                0x4B,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ]
+        )
         string = "KNX is OK"
         self.assertEqual(DPTString.to_knx(string), raw)
         self.assertEqual(DPTString.from_knx(raw), string)
 
     def test_value_empty_string(self):
         """Test parsing and streaming empty string."""
-        raw = [
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
+        raw = bytes(
+            [
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ]
+        )
         string = ""
         self.assertEqual(DPTString.to_knx(string), raw)
         self.assertEqual(DPTString.from_knx(raw), string)
 
     def test_value_max_string(self):
         """Test parsing and streaming large string."""
-        raw = [
-            0x41,
-            0x41,
-            0x41,
-            0x41,
-            0x41,
-            0x42,
-            0x42,
-            0x42,
-            0x42,
-            0x42,
-            0x43,
-            0x43,
-            0x43,
-            0x43,
-        ]
+        raw = bytes(
+            [
+                0x41,
+                0x41,
+                0x41,
+                0x41,
+                0x41,
+                0x42,
+                0x42,
+                0x42,
+                0x42,
+                0x42,
+                0x43,
+                0x43,
+                0x43,
+                0x43,
+            ]
+        )
         string = "AAAAABBBBBCCCC"
         self.assertEqual(DPTString.to_knx(string), raw)
         self.assertEqual(DPTString.from_knx(raw), string)
 
     def test_value_special_chars(self):
         """Test parsing and streaming string with special chars."""
-        raw = [
-            0x48,
-            0x65,
-            0x79,
-            0x21,
-            0x3F,
-            0x24,
-            0x20,
-            0xC4,
-            0xD6,
-            0xDC,
-            0xE4,
-            0xF6,
-            0xFC,
-            0xDF,
-        ]
+        raw = bytes(
+            [
+                0x48,
+                0x65,
+                0x79,
+                0x21,
+                0x3F,
+                0x24,
+                0x20,
+                0xC4,
+                0xD6,
+                0xDC,
+                0xE4,
+                0xF6,
+                0xFC,
+                0xDF,
+            ]
+        )
         string = "Hey!?$ ÄÖÜäöüß"
         self.assertEqual(DPTString.to_knx(string), raw)
         self.assertEqual(DPTString.from_knx(raw), string)
@@ -105,42 +113,46 @@ class TestDPTString(unittest.TestCase):
 
     def test_from_knx_wrong_parameter_too_large(self):
         """Test parsing of KNX string with too many elements."""
-        raw = [
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
+        raw = bytes(
+            [
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ]
+        )
         with self.assertRaises(ConversionError):
             DPTString().from_knx(raw)
 
     def test_from_knx_wrong_parameter_too_small(self):
         """Test parsing of KNX string with too less elements."""
-        raw = [
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-        ]
+        raw = bytes(
+            [
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+                0x00,
+            ]
+        )
         with self.assertRaises(ConversionError):
             DPTString().from_knx(raw)

--- a/test/dpt_tests/dpt_test.py
+++ b/test/dpt_tests/dpt_test.py
@@ -79,44 +79,38 @@ class TestDPTBase(unittest.TestCase):
     def test_dpt_subclasses_definition_types(self):
         """Test value_type and dpt_*_number values for correct type in subclasses of DPTBase."""
         for dpt in DPTBase.__recursive_subclasses__():
-            if hasattr(dpt, "value_type"):
+            if dpt.value_type is not None:
                 self.assertTrue(
                     isinstance(dpt.value_type, str),
-                    msg="Wrong type for value_type in %s - str expected" % dpt,
+                    msg="Wrong type for value_type in %s : %s - str `None` expected"
+                    % (dpt, type(dpt.value_type)),
                 )
-            if hasattr(dpt, "dpt_main_number"):
+            if dpt.dpt_main_number is not None:
                 self.assertTrue(
                     isinstance(dpt.dpt_main_number, int),
-                    msg="Wrong type for dpt_main_number in %s - int expected" % dpt,
+                    msg="Wrong type for dpt_main_number in %s : %s - int or `None` expected"
+                    % (dpt, type(dpt.dpt_main_number)),
                 )
-            if hasattr(dpt, "dpt_sub_number"):
+            if dpt.dpt_sub_number is not None:
                 self.assertTrue(
-                    isinstance(dpt.dpt_sub_number, (int, type(None))),
-                    msg="Wrong type for dpt_sub_number in %s - int or `None` expected"
-                    % dpt,
+                    isinstance(dpt.dpt_sub_number, int),
+                    msg="Wrong type for dpt_sub_number in %s : %s - int or `None` expected"
+                    % (dpt, type(dpt.dpt_sub_number)),
                 )
 
     def test_dpt_subclasses_no_duplicate_value_types(self):
         """Test for duplicate value_type values in subclasses of DPTBase."""
         value_types = []
         for dpt in DPTBase.__recursive_subclasses__():
-            if hasattr(dpt, "value_type"):
+            if dpt.value_type is not None:
                 value_types.append(dpt.value_type)
         self.assertCountEqual(value_types, set(value_types))
-
-    def test_dpt_subclasses_have_both_dpt_number_attributes(self):
-        """Test DPTBase subclasses for having both dpt number attributes set."""
-        for dpt in DPTBase.__recursive_subclasses__():
-            if hasattr(dpt, "dpt_main_number"):
-                self.assertTrue(
-                    hasattr(dpt, "dpt_sub_number"), "No dpt_sub_number in %s" % dpt
-                )
 
     def test_dpt_subclasses_no_duplicate_dpt_number(self):
         """Test for duplicate value_type values in subclasses of DPTBase."""
         dpt_tuples = []
         for dpt in DPTBase.__recursive_subclasses__():
-            if hasattr(dpt, "dpt_main_number") and hasattr(dpt, "dpt_sub_number"):
+            if dpt.dpt_main_number is not None and dpt.dpt_sub_number is not None:
                 dpt_tuples.append((dpt.dpt_main_number, dpt.dpt_sub_number))
         self.assertCountEqual(dpt_tuples, set(dpt_tuples))
 

--- a/test/dpt_tests/dpt_time_test.py
+++ b/test/dpt_tests/dpt_time_test.py
@@ -15,7 +15,7 @@ class TestDPTTime(unittest.TestCase):
     def test_from_knx(self):
         """Test parsing of DPTTime object from binary values. Example 1."""
         self.assertEqual(
-            DPTTime().from_knx((0x4D, 0x17, 0x2A)),
+            DPTTime().from_knx(bytes([0x4D, 0x17, 0x2A])),
             time.strptime("13 23 42 2", "%H %M %S %w"),
         )
 
@@ -35,7 +35,7 @@ class TestDPTTime(unittest.TestCase):
     def test_from_knx_max(self):
         """Test parsing of DPTTime object from binary values. Example 2."""
         self.assertEqual(
-            DPTTime().from_knx((0xF7, 0x3B, 0x3B)),
+            DPTTime().from_knx(bytes([0xF7, 0x3B, 0x3B])),
             time.strptime("23 59 59 0", "%H %M %S %w"),
         )
 
@@ -50,7 +50,8 @@ class TestDPTTime(unittest.TestCase):
     def test_from_knx_min(self):
         """Test parsing of DPTTime object from binary values. Example 3."""
         self.assertEqual(
-            DPTTime().from_knx((0x0, 0x0, 0x0)), time.strptime("0 0 0", "%H %M %S")
+            DPTTime().from_knx(bytes([0x0, 0x0, 0x0])),
+            time.strptime("0 0 0", "%H %M %S"),
         )
 
     #
@@ -63,18 +64,13 @@ class TestDPTTime(unittest.TestCase):
     def test_from_knx_wrong_size(self):
         """Test parsing from DPTTime object from wrong binary values (wrong size)."""
         with self.assertRaises(ConversionError):
-            DPTTime().from_knx((0xF8, 0x23))
+            DPTTime().from_knx(bytes([0xF8, 0x23]))
 
     def test_from_knx_wrong_bytes(self):
         """Test parsing from DPTTime object from wrong binary values (wrong bytes)."""
         with self.assertRaises(ConversionError):
             # this parameter exceeds limit
-            DPTTime().from_knx((0xF7, 0x3B, 0x3C))
-
-    def test_from_knx_wrong_type(self):
-        """Test parsing from DPTTime object from wrong binary values (wrong type)."""
-        with self.assertRaises(ConversionError):
-            DPTTime().from_knx((0xF8, "0x23"))
+            DPTTime().from_knx(bytes([0xF7, 0x3B, 0x3C]))
 
     def test_to_knx_wrong_parameter(self):
         """Test parsing from DPTTime object from wrong string value."""

--- a/test/remote_value_tests/remote_value_control_test.py
+++ b/test/remote_value_tests/remote_value_control_test.py
@@ -28,11 +28,6 @@ class TestRemoteValueControl(unittest.TestCase):
         with self.assertRaises(ConversionError):
             RemoteValueControl(xknx, value_type="wrong_value_type")
 
-    def test_valid_payload(self):
-        """Test valid_payload method."""
-        self.assertTrue(DPTBinary(0))
-        self.assertTrue(DPTArray([0]))
-
     def test_set(self):
         """Test setting value."""
         xknx = XKNX()

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -12,8 +12,9 @@ from xknx.exceptions import DeviceIllegalValue
 from xknx.remote_value.remote_value_climate_mode import (
     RemoteValueBinaryHeatCool,
     RemoteValueBinaryOperationMode,
-    RemoteValueClimateMode,
     RemoteValueClimateModeBase,
+    RemoteValueControllerMode,
+    RemoteValueOperationMode,
 )
 
 from .device import Device, DeviceCallbackType
@@ -56,40 +57,33 @@ class ClimateMode(Device):
         # pylint: disable=too-many-arguments, too-many-locals, too-many-branches, too-many-statements
         super().__init__(xknx, name, device_updated_cb)
 
-        self.remote_value_operation_mode: RemoteValueClimateMode[
-            HVACOperationMode
-        ] = RemoteValueClimateMode(
+        self.remote_value_operation_mode = RemoteValueOperationMode(
             xknx,
             group_address=group_address_operation_mode,
             group_address_state=group_address_operation_mode_state,
             sync_state=True,
             device_name=name,
             feature_name="Operation mode",
-            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_MODE,
+            climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
             after_update_cb=None,
         )
-        self.remote_value_controller_mode: RemoteValueClimateMode[
-            HVACControllerMode
-        ] = RemoteValueClimateMode(
+        self.remote_value_controller_mode = RemoteValueControllerMode(
             xknx,
             group_address=group_address_controller_mode,
             group_address_state=group_address_controller_mode_state,
             sync_state=True,
             device_name=name,
             feature_name="Controller mode",
-            climate_mode_type=RemoteValueClimateMode.ClimateModeType.HVAC_CONTR_MODE,
             after_update_cb=None,
         )
-        self.remote_value_controller_status: RemoteValueClimateMode[
-            HVACOperationMode
-        ] = RemoteValueClimateMode(
+        self.remote_value_controller_status = RemoteValueOperationMode(
             xknx,
             group_address=group_address_controller_status,
             group_address_state=group_address_controller_status_state,
             sync_state=True,
             device_name=name,
             feature_name="Controller status",
-            climate_mode_type=RemoteValueClimateMode.ClimateModeType.CONTROLLER_STATUS,
+            climate_mode_type=RemoteValueOperationMode.ClimateModeType.CONTROLLER_STATUS,
             after_update_cb=None,
         )
 
@@ -244,7 +238,7 @@ class ClimateMode(Device):
 
     def _iter_byte_operation_modes(
         self,
-    ) -> Iterator[RemoteValueClimateMode[HVACOperationMode]]:
+    ) -> Iterator[RemoteValueOperationMode]:
         """Iterate normal DPT 20.102 operation mode remote values."""
         yield from (
             self.remote_value_operation_mode,

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -1,6 +1,6 @@
 """Implementation of Basic KNX datatypes."""
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Iterator, List, Optional, Tuple, Type, Union, cast
 
 from xknx.exceptions import ConversionError
 
@@ -42,10 +42,10 @@ class DPTBase(ABC):
 
     """
 
-    payload_length: ClassVar[int] = cast(int, None)
-    dpt_main_number: ClassVar[Optional[int]] = None
-    dpt_sub_number: ClassVar[Optional[int]] = None
-    value_type: ClassVar[Optional[str]] = None
+    payload_length: int = cast(int, None)
+    dpt_main_number: Optional[int] = None
+    dpt_sub_number: Optional[int] = None
+    value_type: Optional[str] = None
 
     @classmethod
     @abstractmethod
@@ -54,7 +54,7 @@ class DPTBase(ABC):
 
     @classmethod
     @abstractmethod
-    def to_knx(cls, value: Any) -> List[int]:
+    def to_knx(cls, value: Any) -> Union[bytes, Tuple[int, ...]]:
         """Serialize to KNX/IP raw data."""
 
     @classmethod

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -1,10 +1,11 @@
 """Implementation of Basic KNX datatypes."""
-from typing import Union
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Iterator, List, Optional, Tuple, Type, Union, cast
 
 from xknx.exceptions import ConversionError
 
 
-class DPTBase:
+class DPTBase(ABC):
     """
     Base class for KNX data point type transcoder.
 
@@ -41,41 +42,53 @@ class DPTBase:
 
     """
 
-    payload_length = None
+    payload_length: ClassVar[int] = cast(int, None)
+    dpt_main_number: ClassVar[Optional[int]] = None
+    dpt_sub_number: ClassVar[Optional[int]] = None
+    value_type: ClassVar[Optional[str]] = None
 
     @classmethod
-    def test_bytesarray(cls, raw):
+    @abstractmethod
+    def from_knx(cls, raw: bytes) -> Any:
+        """Parse/deserialize from KNX/IP raw data (big endian)."""
+
+    @classmethod
+    @abstractmethod
+    def to_knx(cls, value: Any) -> List[int]:
+        """Serialize to KNX/IP raw data."""
+
+    @classmethod
+    def test_bytesarray(cls, raw: bytes) -> None:
         """Test if array of raw bytes has the correct length and values of correct type."""
         if cls.payload_length is None:
             raise NotImplementedError("payload_length has to be defined for: %s" % cls)
-        if (
-            not isinstance(raw, (tuple, list))
-            or len(raw) != cls.payload_length
-            or any(not isinstance(byte, int) for byte in raw)
-            or any(byte < 0 for byte in raw)
-            or any(byte > 255 for byte in raw)
-        ):
-            raise ConversionError("Invalid raw bytes", raw=raw)
+        if len(raw) != cls.payload_length:
+            raise ConversionError(
+                f"Invalid raw bytes. Expected length: {cls.payload_length}",
+                raw=raw.hex(),
+            )
 
     @classmethod
-    def __recursive_subclasses__(cls):
+    def __recursive_subclasses__(cls) -> Iterator[Type["DPTBase"]]:
         """Yield all subclasses and their subclasses."""
         for subclass in cls.__subclasses__():
             yield from subclass.__recursive_subclasses__()
             yield subclass
 
     @classmethod
-    def has_distinct_dpt_numbers(cls):
+    def has_distinct_dpt_numbers(cls) -> bool:
         """Return True if dpt numbers are defined (not inherited)."""
         return "dpt_main_number" in cls.__dict__ and "dpt_sub_number" in cls.__dict__
 
     @classmethod
-    def has_distinct_value_type(cls):
+    def has_distinct_value_type(cls) -> bool:
         """Return True if value_type is defined (not inherited)."""
         return "value_type" in cls.__dict__
 
     @staticmethod
-    def transcoder_by_dpt(dpt_main, dpt_sub=None):
+    def transcoder_by_dpt(
+        dpt_main: int, dpt_sub: Optional[int] = None
+    ) -> Optional[Type["DPTBase"]]:
         """Return Class reference of DPTBase subclass with matching DPT number."""
         for dpt in DPTBase.__recursive_subclasses__():
             if dpt.has_distinct_dpt_numbers():
@@ -84,7 +97,7 @@ class DPTBase:
         return None
 
     @staticmethod
-    def transcoder_by_value_type(value_type):
+    def transcoder_by_value_type(value_type: str) -> Optional[Type["DPTBase"]]:
         """Return Class reference of DPTBase subclass with matching value_type."""
         for dpt in DPTBase.__recursive_subclasses__():
             if dpt.has_distinct_value_type():
@@ -93,7 +106,9 @@ class DPTBase:
         return None
 
     @staticmethod
-    def parse_transcoder(value_type):
+    def parse_transcoder(
+        value_type: Union[int, float, str]
+    ) -> Optional[Type["DPTBase"]]:
         """Return Class reference of DPTBase subclass from value_type or DPT number."""
         if isinstance(value_type, int):
             return DPTBase.transcoder_by_dpt(value_type)
@@ -116,7 +131,6 @@ class DPTBase:
                     except ValueError:
                         pass
             return transcoder
-        return None
 
 
 class DPTBinary:
@@ -133,7 +147,7 @@ class DPTBinary:
         if not isinstance(value, int):
             raise TypeError()
         if value > DPTBinary.APCI_BITMASK:
-            raise ConversionError("Could not init DPTBinary", value=value)
+            raise ConversionError("Could not init DPTBinary", value=str(value))
 
         self.value = value
 
@@ -152,8 +166,9 @@ class DPTArray:
     """The DPTArray is a base class for all datatypes appended to the KNX telegram."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, value: Union[int, list, bytes, tuple]) -> None:
+    def __init__(self, value: Union[int, bytes, Tuple[int, ...], List[int]]) -> None:
         """Initialize DPTArray class."""
+        self.value: Tuple[int, ...]
         if isinstance(value, int):
             self.value = (value,)
         elif isinstance(value, (list, bytes)):

--- a/xknx/dpt/dpt_1byte_signed.py
+++ b/xknx/dpt/dpt_1byte_signed.py
@@ -1,4 +1,5 @@
 """Implementation of Basic KNX 1-Byte signed integer values."""
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -15,13 +16,13 @@ class DPTSignedRelativeValue(DPTBase):
     value_min = -128
     value_max = 127
     dpt_main_number = 6
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "1byte_signed"
     unit = ""
     payload_length = 1
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
         if raw[0] > cls.value_max:
@@ -29,7 +30,7 @@ class DPTSignedRelativeValue(DPTBase):
         return raw[0]
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -42,7 +43,7 @@ class DPTSignedRelativeValue(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: int) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 

--- a/xknx/dpt/dpt_1byte_uint.py
+++ b/xknx/dpt/dpt_1byte_uint.py
@@ -1,4 +1,6 @@
 """Implementation of Basic KNX DPT_1_Ucount Values."""
+from typing import Optional, Tuple
+
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
@@ -14,14 +16,14 @@ class DPTValue1ByteUnsigned(DPTBase):
     value_min = 0
     value_max = 255
     dpt_main_number = 5
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "1byte_unsigned"
     unit = ""
     resolution = 1
     payload_length = 1
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
@@ -35,7 +37,7 @@ class DPTValue1ByteUnsigned(DPTBase):
         return value
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -46,7 +48,7 @@ class DPTValue1ByteUnsigned(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: int) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 
@@ -117,7 +119,7 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
     unit = ""
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
@@ -131,7 +133,7 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
         return value
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value) - 1

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -3,6 +3,7 @@ Implementation of KNX 2 byte Float-values.
 
 They correspond to the the following KDN DPT 9 class.
 """
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -19,14 +20,14 @@ class DPT2ByteFloat(DPTBase):
     value_min = -671088.64
     value_max = 670760.96
     dpt_main_number = 9
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "2byte_float"
     unit = ""
     resolution = 1
     payload_length = 2
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> float:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
         data = (raw[0] * 256) + raw[1]
@@ -45,10 +46,10 @@ class DPT2ByteFloat(DPTBase):
         return value
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: float) -> Tuple[int, int]:
         """Serialize to KNX/IP raw data."""
 
-        def calc_exponent(float_value, sign):
+        def calc_exponent(float_value: float, sign: bool) -> Tuple[int, int]:
             """Return float exponent."""
             exponent = 0
             significand = abs(int(float_value * 100))
@@ -68,7 +69,7 @@ class DPT2ByteFloat(DPTBase):
             if not cls._test_boundaries(knx_value):
                 raise ValueError
 
-            sign = 1 if knx_value < 0 else 0
+            sign = knx_value < 0
             exponent, significand = calc_exponent(knx_value, sign)
 
             return (sign << 7) | (exponent << 3) | (
@@ -78,7 +79,7 @@ class DPT2ByteFloat(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: float) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -4,8 +4,8 @@ Implementation of Basic KNX 2-Byte Signed Values.
 They correspond the following KNX DPTs:
     8.*** 2-byte/octet signed (2's complement), i.e. percentV16, delta time
 """
-
 import struct
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -22,26 +22,26 @@ class DPT2ByteSigned(DPTBase):
     value_min = -32768
     value_max = 32767
     dpt_main_number = 8
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "2byte_signed"
     unit = ""
-    resolution = 1
+    resolution: float = 1
     payload_length = 2
 
     _struct_format = ">h"
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
         try:
-            return struct.unpack(cls._struct_format, bytes(raw))[0]
+            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore
         except struct.error:
             raise ConversionError("Could not parse %s" % cls.__name__, raw=raw)
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int, ...]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -52,7 +52,7 @@ class DPT2ByteSigned(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: int) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -1,4 +1,5 @@
 """Implementation of Basic KNX 2-Byte/octet values."""
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -17,20 +18,20 @@ class DPT2ByteUnsigned(DPTBase):
     value_min = 0
     value_max = 65535
     dpt_main_number = 7
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "2byte_unsigned"
     unit = ""
     resolution = 1
     payload_length = 2
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
         return (raw[0] * 256) + raw[1]
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int, int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -41,7 +42,7 @@ class DPT2ByteUnsigned(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: int) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -3,8 +3,8 @@ Implementation of KNX 4 byte Float-values.
 
 They correspond to the the following KDN DPT 14 class.
 """
-
 import struct
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -24,22 +24,22 @@ class DPT4ByteFloat(DPTBase):
     """
 
     dpt_main_number = 14
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "4byte_float"
     unit = ""
     payload_length = 4
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> float:
         """Parse/deserialize from KNX/IP raw data (big endian)."""
         cls.test_bytesarray(raw)
         try:
-            return struct.unpack(">f", bytes(raw))[0]
+            return struct.unpack(">f", bytes(raw))[0]  # type: ignore
         except struct.error:
             raise ConversionError("Could not parse %s" % cls.__name__, raw=raw)
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: float) -> Tuple[int, ...]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = float(value)

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -5,8 +5,8 @@ They correspond the following KNX DPTs:
     12.yyy 4-byte/octet unsigned value, i.e. pulse counter
     13.yyy 4-byte/octet signed (2's complement), i.e. flow, energy
 """
-
 import struct
+from typing import Optional, Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -23,26 +23,26 @@ class DPT4ByteUnsigned(DPTBase):
     value_min = 0
     value_max = 4294967295
     dpt_main_number = 12
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "4byte_unsigned"
     unit = ""
-    resolution = 1
+    resolution: float = 1
     payload_length = 4
 
     _struct_format = ">I"
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
         try:
-            return struct.unpack(cls._struct_format, bytes(raw))[0]
+            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore
         except struct.error:
             raise ConversionError("Could not parse %s" % cls.__name__, raw=raw)
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: int) -> Tuple[int, ...]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -53,7 +53,7 @@ class DPT4ByteUnsigned(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: int) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 
@@ -68,10 +68,10 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     value_min = -2147483648
     value_max = 2147483647
     dpt_main_number = 13
-    dpt_sub_number = None
+    dpt_sub_number: Optional[int] = None
     value_type = "4byte_signed"
     unit = ""
-    resolution = 1
+    resolution: float = 1
 
     _struct_format = ">i"
 

--- a/xknx/dpt/dpt_date.py
+++ b/xknx/dpt/dpt_date.py
@@ -1,6 +1,6 @@
 """Implementation of the KNX date data point."""
-
 import time
+from typing import Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -13,7 +13,7 @@ class DPTDate(DPTBase):
     payload_length = 3
 
     @classmethod
-    def from_knx(cls, raw) -> time.struct_time:
+    def from_knx(cls, raw: bytes) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
@@ -36,10 +36,10 @@ class DPTDate(DPTBase):
             raise ConversionError("Could not parse DPTDate", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time):
+    def to_knx(cls, value: time.struct_time) -> Tuple[int, int, int]:
         """Serialize to KNX/IP raw data from time.struct_time."""
 
-        def _knx_year(year):
+        def _knx_year(year: int) -> int:
             if 2000 <= year < 2090:
                 return year - 2000
             if 1990 <= year < 2000:

--- a/xknx/dpt/dpt_datetime.py
+++ b/xknx/dpt/dpt_datetime.py
@@ -1,6 +1,6 @@
 """Implementation of the KNX datetime data point."""
-
 import time
+from typing import Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -13,7 +13,7 @@ class DPTDateTime(DPTBase):
     payload_length = 8
 
     @classmethod
-    def from_knx(cls, raw) -> time.struct_time:
+    def from_knx(cls, raw: bytes) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
         # pylint: disable=too-many-locals
         cls.test_bytesarray(raw)
@@ -68,7 +68,7 @@ class DPTDateTime(DPTBase):
             raise ConversionError("Could not parse DPTDateTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time):
+    def to_knx(cls, value: time.struct_time) -> Tuple[int, ...]:
         """Serialize to KNX/IP raw data from time.struct_time."""
         if not isinstance(value, time.struct_time):
             raise ConversionError("Could not serialize DPTDateTime", value=value)

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -1,4 +1,6 @@
 """Implementation of scaled KNX DPT_1_Ucount Values."""
+from typing import Tuple
+
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
@@ -21,7 +23,7 @@ class DPTScaling(DPTBase):
     payload_length = 1
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
@@ -37,7 +39,7 @@ class DPTScaling(DPTBase):
         return value
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: float) -> Tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             percent_value = float(value)
@@ -51,7 +53,7 @@ class DPTScaling(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: float) -> bool:
         """Test if value is within defined range for this object."""
         return cls.value_min <= value <= cls.value_max
 

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -38,7 +38,7 @@ class DPTString(DPTBase):
             for character in knx_value:
                 raw.append(ord(character))
             raw.extend([0] * (cls.payload_length - len(raw)))
-            return raw
+            return bytes(raw)
         except ValueError:
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -18,7 +18,7 @@ class DPTString(DPTBase):
     unit = ""
 
     @classmethod
-    def from_knx(cls, raw):
+    def from_knx(cls, raw: bytes) -> str:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
         value = ""
@@ -28,7 +28,7 @@ class DPTString(DPTBase):
         return value
 
     @classmethod
-    def to_knx(cls, value):
+    def to_knx(cls, value: str) -> bytes:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = str(value)
@@ -43,6 +43,6 @@ class DPTString(DPTBase):
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 
     @classmethod
-    def _test_boundaries(cls, value):
+    def _test_boundaries(cls, value: str) -> bool:
         """Test if value is within defined range for this object."""
         return len(value) <= cls.payload_length

--- a/xknx/dpt/dpt_time.py
+++ b/xknx/dpt/dpt_time.py
@@ -1,6 +1,6 @@
 """Implementation of Basic KNX Time."""
-
 import time
+from typing import Tuple
 
 from xknx.exceptions import ConversionError
 
@@ -17,7 +17,7 @@ class DPTTime(DPTBase):
     payload_length = 3
 
     @classmethod
-    def from_knx(cls, raw) -> time.struct_time:
+    def from_knx(cls, raw: bytes) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
 
@@ -44,7 +44,7 @@ class DPTTime(DPTBase):
             raise ConversionError("Could not parse DPTTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time):
+    def to_knx(cls, value: time.struct_time) -> Tuple[int, int, int]:
         """Serialize to KNX/IP raw data from dict with elements weekday,hours,minutes,seconds."""
         if not isinstance(value, time.struct_time):
             raise ConversionError(
@@ -62,7 +62,7 @@ class DPTTime(DPTBase):
         return (weekday << 5 | value.tm_hour, value.tm_min, value.tm_sec)
 
     @staticmethod
-    def _test_range(weekday, hours, minutes, seconds):
+    def _test_range(weekday: int, hours: int, minutes: int, seconds: int) -> bool:
         """Test if values are in the correct value range."""
         if weekday < 0 or weekday > 7:
             return False

--- a/xknx/exceptions/exception.py
+++ b/xknx/exceptions/exception.py
@@ -31,7 +31,7 @@ class CommunicationError(XKNXException):
 class CouldNotParseTelegram(XKNXException):
     """Could not parse telegram error."""
 
-    def __init__(self, description: str, **kwargs: str) -> None:
+    def __init__(self, description: str, **kwargs: Any) -> None:
         """Initialize CouldNotParseTelegram class."""
         super().__init__()
         self.description = description
@@ -78,7 +78,7 @@ class UnsupportedCEMIMessage(XKNXException):
 class ConversionError(XKNXException):
     """Exception class for error while converting one type to another."""
 
-    def __init__(self, description: str, **kwargs: str) -> None:
+    def __init__(self, description: str, **kwargs: Any) -> None:
         """Initialize ConversionError class."""
         super().__init__()
         self.description = description

--- a/xknx/remote_value/__init__.py
+++ b/xknx/remote_value/__init__.py
@@ -5,7 +5,8 @@ from .remote_value_1count import RemoteValue1Count
 from .remote_value_climate_mode import (
     RemoteValueBinaryHeatCool,
     RemoteValueBinaryOperationMode,
-    RemoteValueClimateMode,
+    RemoteValueControllerMode,
+    RemoteValueOperationMode,
 )
 from .remote_value_color_rgb import RemoteValueColorRGB
 from .remote_value_color_rgbw import RemoteValueColorRGBW
@@ -28,13 +29,14 @@ __all__ = [
     "RemoteValue1Count",
     "RemoteValueBinaryHeatCool",
     "RemoteValueBinaryOperationMode",
-    "RemoteValueClimateMode",
     "RemoteValueColorRGB",
     "RemoteValueColorRGBW",
     "RemoteValueControl",
+    "RemoteValueControllerMode",
     "RemoteValueDateTime",
     "RemoteValueDpt2ByteUnsigned",
     "RemoteValueDptValue1Ucount",
+    "RemoteValueOperationMode",
     "RemoteValueScaling",
     "RemoteValueSceneNumber",
     "RemoteValueSensor",


### PR DESCRIPTION
## TODO
- [ ] change DPTControl* from_knx and to_knx signature - invert should be handled by RemoteValue
- [ ] return only `bytes` type from DPTBase.to_knx
- [ ] accept only `bytes` type for DPTArray(value)
- [ ] find a way to not use `Any` for DPTBase.from_knx return value / DPTBase.to_knx(value) (Generics? - same will probably be needed for RemoteValue)

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- DPTBase inherits from ABC
- use only `bytes` type for DPTBase.from_knx(raw)

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
