### PR TITLE
Add fan mode for steps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.xx 
+
+### Devices
+
+- Fan: Add "mode" parameter to control fans by steps instead of percentage.
+
 ## 0.16.1 HA register services 2021-01-16
 
 ### HA integration

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.xx 
+## 0.xx
 
 ### Devices
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Fan
+parent: Devices
+nav_order: 9
+---
+
+# [](#header-1)Fans
+
+## [](#header-2)Overview
+
+Fans are simple representations of KNX controlled fans. They support setting the speed.
+
+## [](#header-2)Interface
+
+- `xknx` XKNX object.
+- `name` name of the device.
+- `group_address` is the KNX group address of the fan device. Used for sending.
+- `group_address_state` is the KNX group address of the fan state. Used for updating and reading state.
+- `device_updated_cb` awaitable callback for each update.
+- `mode` Enum for the type of the fan control. Can be *Percentage* or *Step*. Default: FanSpeedMode.Percentage
+
+## [](#header-2)Example
+
+```python
+fan = Fan(xknx,
+              'TestFan',
+              group_address='1/2/1',
+              group_address_state='1/2/2')
+
+# Set the fan speed
+await fan.set_speed(50)
+
+# Accessing speed
+print(fan.current_speed)
+
+# Requesting state via KNX GroupValueRead
+await fan.sync()
+```
+
+## [](#header-2)Configuration via **xknx.yaml**
+
+Fans are usually configured via [`xknx.yaml`](/configuration):
+
+```yaml
+groups:
+    fan:
+        Livingroom.Fan_1: {group_address: '1/4/1', group_address_state: '1/4/2' }
+```

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -18,7 +18,7 @@ Fans are simple representations of KNX controlled fans. They support setting the
 - `group_address` is the KNX group address of the fan device. Used for sending.
 - `group_address_state` is the KNX group address of the fan state. Used for updating and reading state.
 - `device_updated_cb` awaitable callback for each update.
-- `mode` Enum for the type of the fan control. Can be *Percentage* or *Step*. Default: FanSpeedMode.Percentage
+- `mode` Enum for the type of the fan control. Can be *Percent* or *Step*. Default: FanSpeedMode.Percent
 
 ## [](#header-2)Example
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -2,7 +2,7 @@
 layout: default
 title: Fan
 parent: Devices
-nav_order: 9
+nav_order: 4
 ---
 
 # [](#header-1)Fans

--- a/docs/light.md
+++ b/docs/light.md
@@ -2,7 +2,7 @@
 layout: default
 title: Lights / Dimmer
 parent: Devices
-nav_order: 4
+nav_order: 5
 ---
 
 # [](#header-1)Light & Dimmer

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -2,7 +2,7 @@
 layout: default
 title: Sensor
 parent: Devices
-nav_order: 5
+nav_order: 6
 ---
 
 # [](#header-1)Sensor - Monitor values of KNX

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -2,7 +2,7 @@
 layout: default
 title: Switches
 parent: Devices
-nav_order: 6
+nav_order: 7
 ---
 
 # [](#header-1)Switches

--- a/docs/time.md
+++ b/docs/time.md
@@ -2,7 +2,7 @@
 layout: default
 title: Time
 parent: Devices
-nav_order: 7
+nav_order: 8
 ---
 
 # [](#header-1)Time

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -2,7 +2,7 @@
 layout: default
 title: Weather
 parent: Devices
-nav_order: 8
+nav_order: 9
 ---
 
 # [](#header-1)Weather device

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -8,7 +8,7 @@ pydocstyle==5.1.1
 pylint==2.6.0
 pylint-strict-informational==0.1
 pytest==6.2.1
-pytest-cov==2.11.0
+pytest-cov==2.11.1
 pytest-timeout==1.4.2
 setuptools==51.3.3
 tox==3.21.2

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -48,7 +48,12 @@ class TestFan(unittest.TestCase):
     def test_sync_step(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX()
-        fan = Fan(xknx, name="TestFan", group_address_speed_state="1/2/3", mode=FanSpeedMode.Step)
+        fan = Fan(
+            xknx,
+            name="TestFan",
+            group_address_speed_state="1/2/3",
+            mode=FanSpeedMode.Step,
+        )
         self.loop.run_until_complete(fan.sync())
 
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -107,12 +112,14 @@ class TestFan(unittest.TestCase):
 
     #
     #
-    # TEST SET SPEED STEP 
+    # TEST SET SPEED STEP
     #
     def test_set_speed_step(self):
         """Test setting the speed of a Fan."""
         xknx = XKNX()
-        fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step)
+        fan = Fan(
+            xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step
+        )
         self.loop.run_until_complete(fan.set_speed(2))
         self.assertEqual(xknx.telegrams.qsize(), 1)
         telegram = xknx.telegrams.get_nowait()
@@ -170,7 +177,9 @@ class TestFan(unittest.TestCase):
     def test_process_speed_step(self):
         """Test process / reading telegrams from telegram queue. Test if speed is processed."""
         xknx = XKNX()
-        fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step)
+        fan = Fan(
+            xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step
+        )
         self.assertEqual(fan.current_speed, None)
 
         telegram = Telegram(

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from xknx import XKNX
 from xknx.devices import Fan
+from xknx.devices.fan import FanSpeedMode
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
@@ -32,6 +33,22 @@ class TestFan(unittest.TestCase):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX()
         fan = Fan(xknx, name="TestFan", group_address_speed_state="1/2/3")
+        self.loop.run_until_complete(fan.sync())
+
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+
+        telegram1 = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram1,
+            Telegram(
+                destination_address=GroupAddress("1/2/3"), payload=GroupValueRead()
+            ),
+        )
+
+    def test_sync_step(self):
+        """Test sync function / sending group reads to KNX bus."""
+        xknx = XKNX()
+        fan = Fan(xknx, name="TestFan", group_address_speed_state="1/2/3", mode=FanSpeedMode.Step)
         self.loop.run_until_complete(fan.sync())
 
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -89,6 +106,25 @@ class TestFan(unittest.TestCase):
         )
 
     #
+    #
+    # TEST SET SPEED STEP 
+    #
+    def test_set_speed_step(self):
+        """Test setting the speed of a Fan."""
+        xknx = XKNX()
+        fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step)
+        self.loop.run_until_complete(fan.set_speed(2))
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram,
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray(2)),
+            ),
+        )
+
+    #
     # TEST PROCESS
     #
     def test_process_speed(self):
@@ -127,6 +163,22 @@ class TestFan(unittest.TestCase):
         )
         with self.assertRaises(CouldNotParseTelegram):
             self.loop.run_until_complete(fan.process(telegram))
+
+    #
+    # TEST PROCESS STEP MODE
+    #
+    def test_process_speed_step(self):
+        """Test process / reading telegrams from telegram queue. Test if speed is processed."""
+        xknx = XKNX()
+        fan = Fan(xknx, name="TestFan", group_address_speed="1/2/3", mode=FanSpeedMode.Step)
+        self.assertEqual(fan.current_speed, None)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(2)),
+        )
+        self.loop.run_until_complete(fan.process(telegram))
+        self.assertEqual(fan.current_speed, 2)
 
     #
     # TEST DO

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -26,11 +26,11 @@ logger = logging.getLogger("xknx.log")
 class FanSpeedMode(Enum):
     """Enum for setting the fan speed mode."""
 
-    Percentage = 1
+    Percent = 1
     Step = 2
 
 
-DEFAULT_MODE = FanSpeedMode.Percentage
+DEFAULT_MODE = FanSpeedMode.Percent
 
 
 class Fan(Device):
@@ -46,7 +46,7 @@ class Fan(Device):
         group_address_speed: Optional["GroupAddressableType"] = None,
         group_address_speed_state: Optional["GroupAddressableType"] = None,
         device_updated_cb: Optional[DeviceCallbackType] = None,
-        mode: Optional[FanSpeedMode] = DEFAULT_MODE,
+        mode: FanSpeedMode = DEFAULT_MODE,
     ):
         """Initialize fan class."""
         # pylint: disable=too-many-arguments

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -6,23 +6,22 @@ It provides functionality for
 * setting fan to specific speed / step
 * reading the current speed from KNX bus.
 """
-import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Iterator, Optional
+import logging
+from typing import TYPE_CHECKING, Any, Iterator, Optional, Union
 
-from xknx.remote_value import (
-    RemoteValueScaling, 
-    RemoteValueDptValue1Ucount
-)
+from xknx.remote_value import RemoteValueDptValue1Ucount, RemoteValueScaling
 
 from .device import Device, DeviceCallbackType
 
 if TYPE_CHECKING:
+    from xknx.remote_value import RemoteValue
     from xknx.telegram import Telegram
     from xknx.telegram.address import GroupAddressableType
     from xknx.xknx import XKNX
 
 logger = logging.getLogger("xknx.log")
+
 
 class FanSpeedMode(Enum):
     """Enum for setting the fan speed mode."""
@@ -53,6 +52,7 @@ class Fan(Device):
         # pylint: disable=too-many-arguments
         super().__init__(xknx, name, device_updated_cb)
 
+        self.speed: Union[RemoteValueDptValue1Ucount, RemoteValueScaling]
         if mode == FanSpeedMode.Step:
             self.speed = RemoteValueDptValue1Ucount(
                 xknx,
@@ -60,7 +60,7 @@ class Fan(Device):
                 group_address_speed_state,
                 device_name=self.name,
                 feature_name="Speed",
-                after_update_cb=self.after_update
+                after_update_cb=self.after_update,
             )
         else:
             self.speed = RemoteValueScaling(
@@ -74,7 +74,7 @@ class Fan(Device):
                 range_to=100,
             )
 
-    def _iter_remote_values(self) -> Iterator[RemoteValueScaling]:
+    def _iter_remote_values(self) -> Iterator["RemoteValue"]:
         """Iterate the devices RemoteValue classes."""
         yield self.speed
 
@@ -90,7 +90,7 @@ class Fan(Device):
             name,
             group_address_speed=group_address_speed,
             group_address_speed_state=group_address_speed_state,
-            mode=mode
+            mode=mode,
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Our controlled domestic ventilation can be control by KNX. 
The ventilation fan cannot be controlled directly with percentage but with 4 predefined levels 0-3. The communication object has DPT5.010.

To enable xknx (and furthermore HA) integration, I've added a fan mode parameter which allows the switch between percentage controlled fans and step controlled ones.

If this is merged, I'm going to add the KNX Fan entity to HA. The code is already finished, I just need to add the new mode parameter :)

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
