### PR TITLE
Adds support for unique id

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -68,6 +68,10 @@
 
 ## 0.16.3 Fan contributions 2021-02-06
 
+### HA integration
+
+- Add experimental (opt-in) support for unique ids
+
 ### Devices
 
 - Fan: Add `max_step` attribute which defines the maximum amount of steps. If set, the fan is controlled by steps instead of percentage.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 ## Unreleased changes
 
--
+### HA integration
+
+- Add experimental (opt-in) support for unique ids
 
 ## 0.17.4 Bugfix for ValueReader 2021-03-26
 
@@ -67,10 +69,6 @@
 - Tunnel: default `auto_reconnect`to True
 
 ## 0.16.3 Fan contributions 2021-02-06
-
-### HA integration
-
-- Add experimental (opt-in) support for unique ids
 
 ### Devices
 

--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -64,6 +64,7 @@ CONF_XKNX_MCAST_GRP = "multicast_group"
 CONF_XKNX_MCAST_PORT = "multicast_port"
 CONF_XKNX_STATE_UPDATER = "state_updater"
 CONF_XKNX_RATE_LIMIT = "rate_limit"
+CONF_XKNX_USE_UNIQUE_ID = "use_unique_id"
 CONF_XKNX_EXPOSE = "expose"
 
 SERVICE_XKNX_SEND = "send"
@@ -108,6 +109,7 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Optional(CONF_XKNX_RATE_LIMIT, default=20): vol.All(
                         vol.Coerce(int), vol.Range(min=1, max=100)
                     ),
+                    vol.Optional(CONF_XKNX_USE_UNIQUE_ID, default=False): cv.boolean,
                     vol.Optional(CONF_XKNX_EXPOSE): vol.All(
                         cv.ensure_list, [ExposeSchema.SCHEMA]
                     ),
@@ -301,6 +303,7 @@ class KNXModule:
         self.hass = hass
         self.config = config
         self.connected = False
+        self.use_unique_id = config[DOMAIN][CONF_XKNX_USE_UNIQUE_ID]
         self.exposures = []
         self.service_exposures = {}
 

--- a/home-assistant-plugin/custom_components/xknx/knx_entity.py
+++ b/home-assistant-plugin/custom_components/xknx/knx_entity.py
@@ -24,6 +24,14 @@ class KnxEntity(Entity):
         return self.hass.data[DOMAIN].connected
 
     @property
+    def unique_id(self):
+        """Return the unique id of the device if enabled."""
+        if self.hass.data[DOMAIN].use_unique_id:
+            return self._device.unique_id
+
+        return None
+
+    @property
     def should_poll(self):
         """No polling needed within KNX."""
         return False

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -410,3 +410,11 @@ class TestBinarySensor(unittest.TestCase):
 
             mock_time.return_value = 1517000004.1  # TIME OUT ...
             self.assertEqual(switch.bump_and_get_counter(False), 1)
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        switch = BinarySensor(
+            xknx, "TestInput", group_address_state="1/2/3", context_timeout=1
+        )
+        self.assertEqual(switch.unique_id, "1/2/3")

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1496,3 +1496,16 @@ class TestClimate(unittest.TestCase):
         )
 
         self.assertEqual(len(xknx.devices), 3)
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        climate = Climate(
+            xknx,
+            "TestClimate",
+            group_address_temperature="1/2/1",
+            group_address_target_temperature="1/2/2",
+            group_address_setpoint_shift="1/2/3",
+            temperature_step=0.3,
+        )
+        self.assertEqual(climate.unique_id, "1/2/1")

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -988,7 +988,7 @@ class TestCover(unittest.TestCase):
             return None
 
         xknx = XKNX()
-        cover = Cover(xknx, "TestCover")
+        cover = Cover(xknx, "TestCover", group_address_long="2/4/5")
         with patch("xknx.devices.Cover.set_up") as mock:
             mock.return_value = asyncio.ensure_future(async_none())
             self.loop.run_until_complete(cover.do("up"))
@@ -1013,7 +1013,7 @@ class TestCover(unittest.TestCase):
     def test_wrong_do(self):
         """Test wrong do command."""
         xknx = XKNX()
-        cover = Cover(xknx, "TestCover")
+        cover = Cover(xknx, "TestCover", group_address_long="2/3/4")
         with patch("logging.Logger.warning") as mock_warn:
             self.loop.run_until_complete(cover.do("execute"))
             self.assertEqual(xknx.telegrams.qsize(), 0)
@@ -1045,3 +1045,18 @@ class TestCover(unittest.TestCase):
         self.assertTrue(cover.has_group_address(GroupAddress("1/2/5")))
         self.assertTrue(cover.has_group_address(GroupAddress("1/2/6")))
         self.assertFalse(cover.has_group_address(GroupAddress("1/2/7")))
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        cover = Cover(
+            xknx,
+            "TestCover",
+            group_address_long="1/2/1",
+            group_address_short="1/2/2",
+            group_address_position="1/2/3",
+            group_address_position_state="1/2/4",
+            group_address_angle="1/2/5",
+            group_address_angle_state="1/2/6",
+        )
+        self.assertEqual(cover.unique_id, "1/2/1")

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -174,3 +174,9 @@ class TestDevice(unittest.TestCase):
             mock_info.assert_called_with(
                 "'do()' not implemented for action '%s' of %s", "xx", "Device"
             )
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        device = Device(xknx, "Test")
+        self.assertIsNone(device.unique_id)

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -224,6 +224,7 @@ class TestLight(unittest.TestCase):
         light = Light(
             xknx,
             name="TestLight",
+            group_address_switch="1/3/5",
             group_address_switch_state="1/2/3",
             group_address_brightness_state="1/2/5",
             group_address_color_state="1/2/6",
@@ -1394,3 +1395,16 @@ class TestLight(unittest.TestCase):
         self.assertTrue(light.has_group_address(GroupAddress("1/1/16")))
 
         self.assertFalse(light.has_group_address(GroupAddress("1/7/13")))
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        light = Light(
+            xknx,
+            name="TestLight",
+            group_address_switch="1/2/3",
+            group_address_brightness="1/2/5",
+            group_address_tunable_white="1/2/9",
+            group_address_color_temperature="1/2/11",
+        )
+        self.assertEqual(light.unique_id, "1/2/3")

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -1408,3 +1408,19 @@ class TestLight(unittest.TestCase):
             group_address_color_temperature="1/2/11",
         )
         self.assertEqual(light.unique_id, "1/2/3")
+
+    def test_unique_id_colors(self):
+        """Test unique id for colors functionality."""
+        xknx = XKNX()
+        light = Light(
+            xknx,
+            name="TestLight",
+            group_address_switch_green="1/2/3",
+            group_address_switch_blue="1/2/4",
+            group_address_switch_red="1/2/5",
+            group_address_switch_white="1/2/6",
+            group_address_brightness="1/2/5",
+            group_address_tunable_white="1/2/9",
+            group_address_color_temperature="1/2/11",
+        )
+        self.assertEqual(light.unique_id, "1/2/5_1/2/3_1/2/4_1/2/6")

--- a/test/devices_tests/scene_test.py
+++ b/test/devices_tests/scene_test.py
@@ -88,3 +88,9 @@ class TestScene(unittest.TestCase):
         scene = Scene(xknx, "TestScene", group_address="1/2/1", scene_number=23)
         self.assertTrue(scene.has_group_address(GroupAddress("1/2/1")))
         self.assertFalse(scene.has_group_address(GroupAddress("2/2/2")))
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        scene = Scene(xknx, "TestScene", group_address="1/2/1", scene_number=23)
+        self.assertEqual(scene.unique_id, "1/2/1")

--- a/test/devices_tests/scene_test.py
+++ b/test/devices_tests/scene_test.py
@@ -93,4 +93,4 @@ class TestScene(unittest.TestCase):
         """Test unique id functionality."""
         xknx = XKNX()
         scene = Scene(xknx, "TestScene", group_address="1/2/1", scene_number=23)
-        self.assertEqual(scene.unique_id, "1/2/1")
+        self.assertEqual(scene.unique_id, "1/2/1_23")

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -2700,3 +2700,11 @@ class TestSensor(unittest.TestCase):
         )
         self.loop.run_until_complete(sensor.process(telegram))
         after_update_callback.assert_called_with(sensor)
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        sensor = Sensor(
+            xknx, "TestSensor", group_address_state="1/2/3", value_type="temperature"
+        )
+        self.assertEqual(sensor.unique_id, "1/2/3")

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -36,7 +36,9 @@ class TestSwitch(unittest.TestCase):
     def test_sync(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX()
-        switch = Switch(xknx, "TestOutlet", group_address_state="1/2/3")
+        switch = Switch(
+            xknx, "TestOutlet", group_address_state="1/2/3", group_address="1/2/4"
+        )
         self.loop.run_until_complete(switch.sync())
 
         self.assertEqual(xknx.telegrams.qsize(), 1)
@@ -392,3 +394,9 @@ class TestSwitch(unittest.TestCase):
         self.assertEqual(switch1.state, False)
         callback_mock.assert_called_once()
         callback_mock.reset_mock()
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        switch = Switch(xknx, "TestOutlet", group_address="1/2/3")
+        self.assertEqual(switch.unique_id, "1/2/3")

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -43,6 +43,7 @@ class TestWeather(unittest.TestCase):
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
             group_address_brightness_north="1/3/8",
+            group_address_temperature="1/4/4",
         )
 
         weather._brightness_east.payload = DPTArray(
@@ -369,3 +370,9 @@ class TestWeather(unittest.TestCase):
         weather = Weather(name="weather", xknx=xknx, group_address_temperature="1/3/4")
         self.assertTrue(weather._temperature.has_group_address(GroupAddress("1/3/4")))
         self.assertFalse(weather._temperature.has_group_address(GroupAddress("1/2/4")))
+
+    def test_unique_id(self):
+        """Test unique id functionality."""
+        xknx = XKNX()
+        weather = Weather(name="weather", xknx=xknx, group_address_temperature="1/3/4")
+        self.assertEqual(weather.unique_id, "1/3/4")

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -75,6 +75,11 @@ class BinarySensor(Device):
         """Iterate the devices RemoteValue classes."""
         yield self.remote_value
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.remote_value.group_address_state}"
+
     def __del__(self) -> None:
         """Destructor. Cleaning up if this was not done before."""
         try:

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -162,6 +162,11 @@ class Climate(Device):
                     value_type=value_type,
                 )
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.temperature.group_address_state}"
+
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Climate":
         """Initialize object from configuration structure."""

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -138,6 +138,11 @@ class Cover(Device):
         yield self.position_target
         yield self.angle
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.updown.group_address}"
+
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Cover":
         """Initialize object from configuration structure."""

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -58,6 +58,11 @@ class Device(ABC):
         # yield from (<list all used RemoteValue instances>)
         yield from ()
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return local unique id of this device."""
+        return None
+
     def register_device_updated_cb(self, device_updated_cb: DeviceCallbackType) -> None:
         """Register device updated callback."""
         self.device_updated_cbs.append(device_updated_cb)

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -271,6 +271,11 @@ class Light(Device):
         yield from (self.red, self.green, self.blue, self.white)
 
     @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.switch.group_address}"
+
+    @property
     def supports_brightness(self) -> bool:
         """Return if light supports brightness."""
         return self.brightness.initialized

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -273,7 +273,13 @@ class Light(Device):
     @property
     def unique_id(self) -> Optional[str]:
         """Return unique id for this device."""
-        return f"{self.switch.group_address}"
+        if self.switch.group_address is not None:
+            return f"{self.switch.group_address}"
+        else:
+            return (
+                f"{self.red.switch.group_address}_{self.green.switch.group_address}_"
+                f"{self.blue.switch.group_address}_{self.white.switch.group_address}"
+            )
 
     @property
     def supports_brightness(self) -> bool:

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -275,11 +275,11 @@ class Light(Device):
         """Return unique id for this device."""
         if self.switch.group_address is not None:
             return f"{self.switch.group_address}"
-        else:
-            return (
-                f"{self.red.switch.group_address}_{self.green.switch.group_address}_"
-                f"{self.blue.switch.group_address}_{self.white.switch.group_address}"
-            )
+
+        return (
+            f"{self.red.switch.group_address}_{self.green.switch.group_address}_"
+            f"{self.blue.switch.group_address}_{self.white.switch.group_address}"
+        )
 
     @property
     def supports_brightness(self) -> bool:

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -41,6 +41,11 @@ class Scene(Device):
         """Iterate the devices RemoteValue classes."""
         yield self.scene_value
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.scene_value.group_address}"
+
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Scene":
         """Initialize object from configuration structure."""

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -44,7 +44,7 @@ class Scene(Device):
     @property
     def unique_id(self) -> Optional[str]:
         """Return unique id for this device."""
-        return f"{self.scene_value.group_address}"
+        return f"{self.scene_value.group_address}_{self.scene_number}"
 
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Scene":

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -71,6 +71,11 @@ class Sensor(Device):
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.sensor_value.group_address_state}"
+
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Sensor":
         """Initialize object from configuration structure."""

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -63,6 +63,11 @@ class Switch(Device):
                 pass
         super().__del__()
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self.switch.group_address}"
+
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Dict[str, Any]) -> "Switch":
         """Initialize object from configuration structure."""

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -247,6 +247,11 @@ class Weather(Device):
         yield self._air_pressure
         yield self._humidity
 
+    @property
+    def unique_id(self) -> Optional[str]:
+        """Return unique id for this device."""
+        return f"{self._temperature.group_address_state}"
+
     async def process_group_write(self, telegram: "Telegram") -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
         for remote_value in self._iter_remote_values():

--- a/xknx/dpt/dpt_4bit_control.py
+++ b/xknx/dpt/dpt_4bit_control.py
@@ -52,9 +52,9 @@ class DPTControlStepCode(DPTBase, ABC):
             return 0 <= raw <= cls.APCI_MAX_VALUE
 
     @classmethod
-    def _test_values(cls, control: bool, step_code: int) -> bool:
+    def _test_values(cls, step_code: int) -> bool:
         """Test if input values are valid."""
-        if isinstance(control, bool) and isinstance(step_code, int):
+        if isinstance(step_code, int):
             if 0 <= step_code <= cls.APCI_STEPCODEMASK:
                 return True
         return False
@@ -76,7 +76,7 @@ class DPTControlStepCode(DPTBase, ABC):
                 "Cant serialize %s; invalid keys" % cls.__name__, value=value
             )
 
-        if not cls._test_values(control, step_code):
+        if not cls._test_values(step_code):
             raise ConversionError(
                 "Cant serialize %s; invalid values" % cls.__name__, value=value
             )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR adds experimental (opt-in) support for unique ids within the KNX platform. Since XKNX natively does not have the ability to provide unique ids we created our own ones based on data that we think might be unique across an installation.

This PR is tested and working correctly on my local test setup:

![image](https://user-images.githubusercontent.com/708887/105774273-62de3f00-5f65-11eb-9739-3044f3f9905e.png)

You can see that with the unique_id feature turned on you can set customize the entity to your liking.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
