### PR TITLE
Add Fan speed levels

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 ### Devices
 
-- Fan: Add "mode" parameter to control fans by steps instead of percentage.
+- Fan: Added "mode" parameter to control fans by steps instead of percentage.
+- Fan: Added 4 fixed levels ("off", "low", "medium", "high") with configurable speeds for each level.
 
 ## 0.16.2 Bugfix for yaml loader 2021-01-24
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -9,7 +9,7 @@ nav_order: 4
 
 ## [](#header-2)Overview
 
-Fans are simple representations of KNX controlled fans. They support setting the speed.
+Fans are simple representations of KNX controlled fans. They support setting the speed either directly or with four fixed levels. These levels are "off", "low", "medium", "high". The configured speed for each level can be adjusted.
 
 ## [](#header-2)Interface
 
@@ -19,6 +19,10 @@ Fans are simple representations of KNX controlled fans. They support setting the
 - `group_address_state` is the KNX group address of the fan state. Used for updating and reading state.
 - `device_updated_cb` awaitable callback for each update.
 - `mode` Enum for the type of the fan control. Can be *Percent* or *Step*. Default: FanSpeedMode.Percent
+- `fan_value_off` is the fan speed which represents the "off" setting of the fan. Default: 0
+- `fan_value_low` is the fan speed which represents the "low" setting of the fan. Default: 33
+- `fan_value_medium` is the fan speed which represents the "medium" setting of the fan. Default: 66
+- `fan_value_high` is the fan speed which represents the "high" setting of the fan. Default: 100
 
 ## [](#header-2)Example
 
@@ -33,6 +37,12 @@ await fan.set_speed(50)
 
 # Accessing speed
 print(fan.current_speed)
+
+# Set the fan speed level
+await fan.set_speed_level("medium")
+
+# Accessing speed level
+print(fan.current_speed_level)
 
 # Requesting state via KNX GroupValueRead
 await fan.sync()


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
To directly support HA the 4 predefined levels "off", "low", "medium" and "high" were added. Every level has it's own speed configured and can be called directly. When reading the speed back from the bus, the current level is determined by comparing the ranges of the levels. ie. 70 % would fall into the medium-level which starts at 66%.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
