### PR TITLE
Prevent dumps for climate entity

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/knx_entity.py
+++ b/home-assistant-plugin/custom_components/xknx/knx_entity.py
@@ -40,12 +40,12 @@ class KnxEntity(Entity):
         """Store register state change callback."""
         self._device.register_device_updated_cb(self.after_update_callback)
 
-        if isinstance(self._device, XknxClimate):
+        if isinstance(self._device, XknxClimate) and self._device.mode is not None:
             self._device.mode.register_device_updated_cb(self.after_update_callback)
 
     async def async_will_remove_from_hass(self) -> None:
         """Disconnect device object when removed."""
         self._device.unregister_device_updated_cb(self.after_update_callback)
 
-        if isinstance(self._device, XknxClimate):
+        if isinstance(self._device, XknxClimate) and self._device.mode is not None:
             self._device.mode.unregister_device_updated_cb(self.after_update_callback)


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
 The following config results in dumps:

```
Bath:
      {
        group_address_temperature: "3/1/7",
        group_address_target_temperature: "3/2/7",
        group_address_target_temperature_state: "3/6/7",
        min_temp: 15.0,
        max_temp: 25.0,   
        operation_modes:
          {
            "Off",
            "Heat",
            "Cool",
          },
        controller_modes:
          {  
            "Comfort",
            "Standby",
            "Night",
            "Frost Protection",
          }        
      }
```

```
2021-01-30 18:00:43 ERROR (MainThread) [homeassistant.components.climate] Error while setting up knx platform for climate
Traceback (most recent call last):
  File "/home/philip/git/core/homeassistant/helpers/entity_platform.py", line 206, in _async_setup_platform
    await asyncio.gather(*pending)
  File "/home/philip/git/core/homeassistant/helpers/entity_platform.py", line 315, in async_add_entities
    await asyncio.gather(*tasks)
  File "/home/philip/git/core/homeassistant/helpers/entity_platform.py", line 506, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/home/philip/git/core/homeassistant/helpers/entity.py", line 530, in add_to_platform_finish
    await self.async_added_to_hass()
  File "/home/philip/git/core/homeassistant/components/knx/knx_entity.py", line 44, in async_added_to_hass
    self._device.mode.register_device_updated_cb(self.after_update_callback)
AttributeError: 'NoneType' object has no attribute 'register_device_updated_cb'
```

This should fix it, but currently untested since I don't have the custom component set up.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
