### PR TITLE
return `None` for `BinarySensor.counter` when context timeout is not used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 
 ### Devices
 
+- BinarySensor: return `None` for `BinarySensor.counter` when context timeout is not used (and don't calculate it)
 - Fan: Add `max_step` attribute which defines the maximum amount of steps. If set, the fan is controlled by steps instead of percentage.
 - Fan: Add `group_address_oscillation` and `group_address_oscillation_state` attributes to control the oscillation of a fan.
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Devices
+
+- BinarySensor: return `None` for `BinarySensor.counter` when context timeout is not used (and don't calculate it)
+
 ### Internals
 
 - RemoteValue is Generic now accepting DPTArray or DPTBinary
@@ -14,7 +18,6 @@
 
 ### Devices
 
-- BinarySensor: return `None` for `BinarySensor.counter` when context timeout is not used (and don't calculate it)
 - Fan: Add `max_step` attribute which defines the maximum amount of steps. If set, the fan is controlled by steps instead of percentage.
 - Fan: Add `group_address_oscillation` and `group_address_oscillation_state` attributes to control the oscillation of a fan.
 

--- a/home-assistant-plugin/custom_components/xknx/binary_sensor.py
+++ b/home-assistant-plugin/custom_components/xknx/binary_sensor.py
@@ -40,7 +40,9 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity):
     @property
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return device specific state attributes."""
-        return {ATTR_COUNTER: self._device.counter}
+        if self._device.counter is not None:
+            return {ATTR_COUNTER: self._device.counter}
+        return None
 
     @property
     def force_update(self) -> bool:

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -122,9 +122,9 @@ class BinarySensor(Device):
         """Set the internal state of the device. If state was changed after_update hooks and connected Actions are executed."""
         if state != self.state or self.ignore_internal_state:
             self.state = state
-            self.bump_and_get_counter(state)
 
             if self.ignore_internal_state and self._context_timeout:
+                self.bump_and_get_counter(state)
                 if self._context_task:
                     self._context_task.cancel()
                 self._context_task = asyncio.create_task(
@@ -152,9 +152,11 @@ class BinarySensor(Device):
                 await action.execute()
 
     @property
-    def counter(self) -> int:
+    def counter(self) -> Optional[int]:
         """Return current counter for sensor."""
-        return self._count_set_on if self.state else self._count_set_off
+        if self._context_timeout:
+            return self._count_set_on if self.state else self._count_set_off
+        return None
 
     def bump_and_get_counter(self, state: bool) -> int:
         """Bump counter and return the number of times a state was set to the same value within CONTEXT_TIMEOUT."""
@@ -169,7 +171,7 @@ class BinarySensor(Device):
             self._last_set = new_set_time
             return time_diff < cast(float, self._context_timeout)
 
-        if self._context_timeout and within_same_context():
+        if within_same_context():
             if state:
                 self._count_set_on = self._count_set_on + 1
                 return self._count_set_on


### PR DESCRIPTION
…used

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
return `None` for `BinarySensor.counter` when context timeout is not used (and don't calculate it).

This prevents "counter: 1" to be displayed in HA binary sensor cards even when the counter function is not used at all.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
