### PR TITLE
Add oscillation to fan

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Devices
 
 - Fan: Add `max_step` attribute which defines the maximum amount of steps. If set, the fan is controlled by steps instead of percentage.
+- Fan: Add `group_address_oscillation` and `group_address_oscillation_state` attributes to control the oscillation of a fan.
 
 ## 0.16.2 Bugfix for yaml loader 2021-01-24
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -15,12 +15,12 @@ Fans are simple representations of KNX controlled fans. They support setting the
 
 - `xknx` XKNX object.
 - `name` name of the device.
-- `group_address` is the KNX group address of the fan speed. Used for sending.
-- `group_address_state` is the KNX group address of the fan speed state. Used for updating and reading state.
+- `group_address` is the KNX group address of the fan speed. Used for sending. *DPT 5.001 / 5.010*
+- `group_address_state` is the KNX group address of the fan speed state. Used for updating and reading state. *DPT 5.001 / 5.010*
 - `group_address_oscillation` is the KNX group address of the oscillation. Used for sending. *DPT 1.001*
 - `group_address_oscillation_state` is the KNX group address of the fan oscillation state. Used for updating and reading state. *DPT 1.001*
 - `device_updated_cb` awaitable callback for each update.
-- `max_step` Maximum step amount for fans which are controlled with steps and not percentage.
+- `max_step` Maximum step amount for fans which are controlled with steps and not percentage. If this attribute is set, the fan is controlled by sending the step value in the range `0` and `max_step`. In that case, the group address DPT changes from *DPT 5.001* to *DPT 5.010*. Default: None
 
 ## [](#header-2)Example
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -9,7 +9,7 @@ nav_order: 4
 
 ## [](#header-2)Overview
 
-Fans are simple representations of KNX controlled fans. They support setting the speed.
+Fans are simple representations of KNX controlled fans. They support setting the speed and the oscillation.
 
 ## [](#header-2)Interface
 
@@ -17,6 +17,8 @@ Fans are simple representations of KNX controlled fans. They support setting the
 - `name` name of the device.
 - `group_address` is the KNX group address of the fan speed. Used for sending.
 - `group_address_state` is the KNX group address of the fan speed state. Used for updating and reading state.
+- `group_address_oscillation` is the KNX group address of the oscillation. Used for sending. *DPT 1.001*
+- `group_address_oscillation_state` is the KNX group address of the fan oscillation state. Used for updating and reading state. *DPT 1.001*
 - `device_updated_cb` awaitable callback for each update.
 - `max_step` Maximum step amount for fans which are controlled with steps and not percentage.
 
@@ -26,13 +28,21 @@ Fans are simple representations of KNX controlled fans. They support setting the
 fan = Fan(xknx,
               'TestFan',
               group_address='1/2/1',
-              group_address_state='1/2/2')
+              group_address_state='1/2/2',
+              group_address_oscillation='1/2/3',
+              group_address_oscillation_state='1/2/4')
 
 # Set the fan speed
 await fan.set_speed(50)
 
 # Accessing speed
 print(fan.current_speed)
+
+# Set the oscillation
+await fan.set_oscillation(True)
+
+# Accessing speed
+print(fan.current_oscillation)
 
 # Requesting state via KNX GroupValueRead
 await fan.sync()
@@ -45,5 +55,5 @@ Fans are usually configured via [`xknx.yaml`](/configuration):
 ```yaml
 groups:
     fan:
-        Livingroom.Fan_1: {group_address: '1/4/1', group_address_state: '1/4/2' }
+        Livingroom.Fan_1: { group_address: '1/4/1', group_address_state: '1/4/2', group_address_oscillation: '1/4/3', group_address_oscillation_state: '1/4/4' }
 ```

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -15,8 +15,8 @@ Fans are simple representations of KNX controlled fans. They support setting the
 
 - `xknx` XKNX object.
 - `name` name of the device.
-- `group_address` is the KNX group address of the fan device. Used for sending.
-- `group_address_state` is the KNX group address of the fan state. Used for updating and reading state.
+- `group_address` is the KNX group address of the fan speed. Used for sending.
+- `group_address_state` is the KNX group address of the fan speed state. Used for updating and reading state.
 - `device_updated_cb` awaitable callback for each update.
 - `max_step` Maximum step amount for fans which are controlled with steps and not percentage.
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -188,10 +188,12 @@ class TestStringRepresentations(unittest.TestCase):
             name="Dunstabzug",
             group_address_speed="1/2/3",
             group_address_speed_state="1/2/4",
+            group_address_oscillation="1/2/5",
+            group_address_oscillation_state="1/2/6",
         )
         self.assertEqual(
             str(fan),
-            '<Fan name="Dunstabzug" speed="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" />',
+            '<Fan name="Dunstabzug" speed="GroupAddress("1/2/3")/GroupAddress("1/2/4")/None/None" oscillation="GroupAddress("1/2/5")/GroupAddress("1/2/6")/None/None" />',
         )
 
     def test_light(self):

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -163,5 +163,5 @@ class Fan(Device):
 
     @property
     def current_oscillation(self) -> Optional[bool]:
-        """Return current oscillation state."""
+        """Return true if the fan is oscillating."""
         return self.oscillation.value  # type: ignore

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -95,7 +95,7 @@ class Fan(Device):
 
     @property
     def supports_oscillation(self) -> bool:
-        """Return if light supports brightness."""
+        """Return if fan supports oscillation."""
         return self.oscillation.initialized
 
     @classmethod

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -103,6 +103,8 @@ class Fan(Device):
         """Initialize object from configuration structure."""
         group_address_speed = config.get("group_address_speed")
         group_address_speed_state = config.get("group_address_speed_state")
+        group_address_oscillation = config.get("group_address_oscillation")
+        group_address_oscillation_state = config.get("group_address_oscillation_state")
         max_step = config.get("max_step")
 
         return cls(
@@ -110,20 +112,22 @@ class Fan(Device):
             name,
             group_address_speed=group_address_speed,
             group_address_speed_state=group_address_speed_state,
+            group_address_oscillation=group_address_oscillation,
+            group_address_oscillation_state=group_address_oscillation_state,
             max_step=max_step,
         )
 
     def __str__(self) -> str:
         """Return object as readable string."""
 
-        # str_oscillation = (
-        #     ""
-        #     if not self.supports_oscillation
-        #     else f' oscillation="{self.oscillation.group_addr_str()}"'
-        # )
+        str_oscillation = (
+            ""
+            if not self.supports_oscillation
+            else f' oscillation="{self.oscillation.group_addr_str()}"'
+        )
 
-        return '<Fan name="{}" ' 'speed="{}" />'.format(
-            self.name, self.speed.group_addr_str()
+        return '<Fan name="{}" ' 'speed="{}"{} />'.format(
+            self.name, self.speed.group_addr_str(), str_oscillation
         )
 
     async def set_speed(self, speed: int) -> None:
@@ -138,8 +142,10 @@ class Fan(Device):
         """Execute 'do' commands."""
         if action.startswith("speed:"):
             await self.set_speed(int(action[6:]))
-        elif action.startswith("oscillation:"):
-            await self.set_oscillation(bool(action[12:]))
+        elif action == "oscillation:True":
+            await self.set_oscillation(True)
+        elif action == "oscillation:False":
+            await self.set_oscillation(False)
         else:
             logger.warning(
                 "Could not understand action %s for device %s", action, self.get_name()


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
HA supports turning the oscillation of the fan on or off. https://developers.home-assistant.io/docs/core/entity/fan/
Furthermore in #466 there was the request to control the oscillation via switch DPT 1.001

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
