### PR TITLE
New option for climate device to expose temperture sensors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,12 +5,13 @@
 ### Devices
 
 - Fan: Add `max_step` attribute which defines the maximum amount of steps. If set, the fan is controlled by steps instead of percentage.
+- Climate: Add option to create dedicated sensors for current and target temperature.
 
-## 0.16.2 Bugfix for yaml loader 2021-01-24
+## 0.16.2 Bugfix for YAML loader 2021-01-24
 
 ### Internals
 
-- fix conflict with HA Yaml loader
+- fix conflict with HA YAML loader
 
 ## 0.16.1 HA register services 2021-01-16
 
@@ -162,7 +163,7 @@
 - Reset binary sensor counters after the context has been timed out in order to be able to use state change events within HA
 - Code cleanups
 
-## 0.14.0 New sensor types and refacoring of binary sensor automations
+## 0.14.0 New sensor types and refactoring of binary sensor automations
 
 ### Breaking changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 
 ### Devices
 
-- Climate: Add option to create dedicated sensors for current and target temperature.
+- Climate: Add `create_temperature_sensors` option to create dedicated sensors for current and target temperature.
+- Weather (breaking change!): Renamed `expose_sensors` to `create_sensors` to prevent confusion with the XKNX `expose_sensor` device type.
 
 ## 0.16.3 Fan contributions 2021-02-06
 

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -51,7 +51,7 @@ groups:
             group_address_day_night: "7/0/8",
             group_address_air_pressure: "7/0/9",
             group_address_humidity: "7/0/10",
-            expose_sensors: True,
+            create_sensors: True,
             sync_state: True,
           }
 ```
@@ -71,7 +71,7 @@ groups:
 - **group_address_day_night** KNX address for reading a day/night object.
 - **group_address_air_pressure** KNX address reading current air pressure. **DPT 9.006**
 - **group_address_humidity** KNX address for reading current humidity. **DPT 9.007**
-- **expose_sensors** If true, also exposes all values as sensors to the xknx device list (useful for home assistant). Default: False
+- **create_sensors** If true, also adds sensors for all values to the xknx device list (useful for Home Assistant). Default: False
 - **sync_state** Periodically sync the state.
 - **device_updated_cb** awaitable callback for each update.
 

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -195,6 +195,7 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
     climate_mode = XknxClimateMode(
         knx_module,
         name=f"{config[CONF_NAME]} Mode",
+        expose_temperature_sensors=config[ClimateSchema.CONF_EXPOSE_TEMPERATURE_SENSORS],
         group_address_operation_mode=config.get(
             ClimateSchema.CONF_OPERATION_MODE_ADDRESS
         ),

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -195,7 +195,6 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
     climate_mode = XknxClimateMode(
         knx_module,
         name=f"{config[CONF_NAME]} Mode",
-        expose_temperature_sensors=config[ClimateSchema.CONF_EXPOSE_TEMPERATURE_SENSORS],
         group_address_operation_mode=config.get(
             ClimateSchema.CONF_OPERATION_MODE_ADDRESS
         ),
@@ -260,6 +259,9 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
         max_temp=config.get(ClimateSchema.CONF_MAX_TEMP),
         mode=climate_mode,
         on_off_invert=config[ClimateSchema.CONF_ON_OFF_INVERT],
+        expose_temperature_sensors=config.get(
+            ClimateSchema.CONF_EXPOSE_TEMPERATURE_SENSORS
+        ),
     )
 
 

--- a/home-assistant-plugin/custom_components/xknx/factory.py
+++ b/home-assistant-plugin/custom_components/xknx/factory.py
@@ -259,8 +259,8 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
         max_temp=config.get(ClimateSchema.CONF_MAX_TEMP),
         mode=climate_mode,
         on_off_invert=config[ClimateSchema.CONF_ON_OFF_INVERT],
-        expose_temperature_sensors=config.get(
-            ClimateSchema.CONF_EXPOSE_TEMPERATURE_SENSORS
+        create_temperature_sensors=config.get(
+            ClimateSchema.CONF_CREATE_TEMPERATURE_SENSORS
         ),
     )
 
@@ -330,7 +330,7 @@ def _create_weather(knx_module: XKNX, config: ConfigType) -> XknxWeather:
         knx_module,
         name=config[CONF_NAME],
         sync_state=config[WeatherSchema.CONF_SYNC_STATE],
-        expose_sensors=config[WeatherSchema.CONF_XKNX_EXPOSE_SENSORS],
+        create_sensors=config[WeatherSchema.CONF_XKNX_CREATE_SENSORS],
         group_address_temperature=config[WeatherSchema.CONF_XKNX_TEMPERATURE_ADDRESS],
         group_address_brightness_south=config.get(
             WeatherSchema.CONF_XKNX_BRIGHTNESS_SOUTH_ADDRESS

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -240,7 +240,7 @@ class ClimateSchema:
     CONF_ON_OFF_INVERT = "on_off_invert"
     CONF_MIN_TEMP = "min_temp"
     CONF_MAX_TEMP = "max_temp"
-    CONF_EXPOSE_TEMPERATURE_SENSORS = "expose_temperature_sensors"
+    CONF_CREATE_TEMPERATURE_SENSORS = "create_temperature_sensors"
 
     DEFAULT_NAME = "KNX Climate"
     DEFAULT_SETPOINT_SHIFT_MODE = "DPT6010"
@@ -297,7 +297,7 @@ class ClimateSchema:
                 vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
                 vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
                 vol.Optional(
-                    CONF_EXPOSE_TEMPERATURE_SENSORS, default=False
+                    CONF_CREATE_TEMPERATURE_SENSORS, default=False
                 ): cv.boolean,
             }
         ),
@@ -407,7 +407,7 @@ class WeatherSchema:
     CONF_XKNX_DAY_NIGHT_ADDRESS = "address_day_night"
     CONF_XKNX_AIR_PRESSURE_ADDRESS = "address_air_pressure"
     CONF_XKNX_HUMIDITY_ADDRESS = "address_humidity"
-    CONF_XKNX_EXPOSE_SENSORS = "expose_sensors"
+    CONF_XKNX_CREATE_SENSORS = "create_sensors"
 
     DEFAULT_NAME = "KNX Weather Station"
 
@@ -419,7 +419,7 @@ class WeatherSchema:
                 cv.boolean,
                 cv.string,
             ),
-            vol.Optional(CONF_XKNX_EXPOSE_SENSORS, default=False): cv.boolean,
+            vol.Optional(CONF_XKNX_CREATE_SENSORS, default=False): cv.boolean,
             vol.Required(CONF_XKNX_TEMPERATURE_ADDRESS): cv.string,
             vol.Optional(CONF_XKNX_BRIGHTNESS_SOUTH_ADDRESS): cv.string,
             vol.Optional(CONF_XKNX_BRIGHTNESS_EAST_ADDRESS): cv.string,

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -240,6 +240,7 @@ class ClimateSchema:
     CONF_ON_OFF_INVERT = "on_off_invert"
     CONF_MIN_TEMP = "min_temp"
     CONF_MAX_TEMP = "max_temp"
+    CONF_EXPOSE_TEMPERATURE_SENSORS = "expose_temperature_sensors"
 
     DEFAULT_NAME = "KNX Climate"
     DEFAULT_SETPOINT_SHIFT_MODE = "DPT6010"
@@ -295,6 +296,9 @@ class ClimateSchema:
                 ),
                 vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
                 vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
+                vol.Optional(
+                    CONF_EXPOSE_TEMPERATURE_SENSORS, default=False
+                ): cv.boolean,
             }
         ),
     )

--- a/test/config_tests/config_v1_test.py
+++ b/test/config_tests/config_v1_test.py
@@ -587,12 +587,12 @@ class TestConfig(unittest.TestCase):
                 group_address_day_night="7/0/8",
                 group_address_air_pressure="7/0/9",
                 group_address_humidity="7/0/10",
-                expose_sensors=False,
+                create_sensors=False,
                 sync_state=True,
             ),
         )
 
-    def test_config_weather_expose_sensor(self):
+    def test_config_weather_create_sensor(self):
         """Test reading weather from config file."""
         self.assertTrue(isinstance(TestConfig.xknx.devices["Home_temperature"], Sensor))
         self.assertTrue(

--- a/test/config_tests/resources/weather/invalid_1.yaml
+++ b/test/config_tests/resources/weather/invalid_1.yaml
@@ -33,4 +33,4 @@ air_pressure:
 humidity:
   state_address: "7/0/10"
   state_update: "expire 60"
-expose_sensors: True
+create_sensors: True

--- a/test/config_tests/resources/weather/invalid_2.yaml
+++ b/test/config_tests/resources/weather/invalid_2.yaml
@@ -34,4 +34,4 @@ air_pressure:
 humidity:
   state_address: "7/0/10"
   state_update: "expire 60"
-expose_sensors: True
+create_sensors: True

--- a/test/config_tests/resources/weather/valid_1.yaml
+++ b/test/config_tests/resources/weather/valid_1.yaml
@@ -36,4 +36,4 @@ air_pressure:
 humidity:
   state_address: "7/0/10"
   state_update: "expire 60"
-expose_sensors: True
+create_sensors: True

--- a/test/config_tests/resources/weather/valid_2.yaml
+++ b/test/config_tests/resources/weather/valid_2.yaml
@@ -3,4 +3,4 @@ friendly_name: "Home"
 temperature:
   state_address: "7/0/0"
   state_update: "expire 60"
-expose_sensors: "off"
+create_sensors: "off"

--- a/test/config_tests/resources/xknx/invalid_1.yaml
+++ b/test/config_tests/resources/xknx/invalid_1.yaml
@@ -157,7 +157,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/config_tests/resources/xknx/invalid_2.yaml
+++ b/test/config_tests/resources/xknx/invalid_2.yaml
@@ -155,7 +155,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/config_tests/resources/xknx/invalid_3.yaml
+++ b/test/config_tests/resources/xknx/invalid_3.yaml
@@ -154,7 +154,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/config_tests/resources/xknx/valid_1.yaml
+++ b/test/config_tests/resources/xknx/valid_1.yaml
@@ -160,7 +160,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/config_tests/resources/xknx/valid_2.yaml
+++ b/test/config_tests/resources/xknx/valid_2.yaml
@@ -157,7 +157,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/config_tests/resources/xknx/valid_3.yaml
+++ b/test/config_tests/resources/xknx/valid_3.yaml
@@ -162,7 +162,7 @@ weather:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1456,3 +1456,28 @@ class TestClimate(unittest.TestCase):
                 payload=GroupValueWrite(DPTBinary(True)),
             ),
         )
+
+    #
+    # Expose temperature sensor tests
+    #
+    def test_expose_sensor(self):
+        """Test default state mapping."""
+        xknx = XKNX()
+        Climate(
+            name="climate",
+            xknx=xknx,
+            group_address_temperature="5/1/1",
+            group_address_target_temperature="5/1/4",
+        )
+
+        self.assertEqual(len(xknx.devices), 1)
+
+        Climate(
+            name="climate",
+            xknx=xknx,
+            group_address_temperature="5/1/1",
+            group_address_target_temperature="5/1/4",
+            expose_temperature_sensors=True,
+        )
+
+        self.assertEqual(len(xknx.devices), 3)

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1458,9 +1458,9 @@ class TestClimate(unittest.TestCase):
         )
 
     #
-    # Expose temperature sensor tests
+    # Create temperature sensor tests
     #
-    def test_expose_sensor(self):
+    def test_create_sensor(self):
         """Test default state mapping."""
         xknx = XKNX()
         Climate(
@@ -1477,7 +1477,7 @@ class TestClimate(unittest.TestCase):
             xknx=xknx,
             group_address_temperature="5/1/1",
             group_address_target_temperature="5/1/4",
-            expose_temperature_sensors=True,
+            create_temperature_sensors=True,
         )
 
         self.assertEqual(len(xknx.devices), 3)

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -291,9 +291,9 @@ class TestWeather(unittest.TestCase):
         self.assertEqual(weather.ha_current_state(), WeatherCondition.exceptional)
 
     #
-    # Expose Sensor tests
+    # Create sensor tests
     #
-    def test_expose_sensor(self):
+    def test_create_sensor(self):
         """Test default state mapping."""
         xknx = XKNX()
         Weather(
@@ -313,7 +313,7 @@ class TestWeather(unittest.TestCase):
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
             group_address_wind_alarm="1/5/4",
-            expose_sensors=True,
+            create_sensors=True,
         )
 
         self.assertEqual(len(xknx.devices), 6)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -339,7 +339,7 @@ class TestStringRepresentations(unittest.TestCase):
             group_address_day_night="7/0/7",
             group_address_rain_alarm="7/0/0",
             group_address_frost_alarm="7/0/8",
-            expose_sensors=True,
+            create_sensors=True,
             group_address_air_pressure="7/0/9",
             group_address_humidity="7/0/9",
             group_address_wind_alarm="7/0/10",

--- a/xknx.yaml
+++ b/xknx.yaml
@@ -288,7 +288,7 @@ groups:
             group_address_day_night: "7/0/8",
             group_address_air_pressure: "7/0/9",
             group_address_humidity: "7/0/10",
-            expose_sensors: True,
+            create_sensors: True,
             sync_state: True,
           }
         Remote:
@@ -304,6 +304,6 @@ groups:
             group_address_day_night: "7/0/8",
             group_address_air_pressure: "7/0/9",
             group_address_humidity: "7/0/10",
-            expose_sensors: False,
+            create_sensors: False,
             sync_state: True,
           }

--- a/xknx/config/schema.py
+++ b/xknx/config/schema.py
@@ -323,6 +323,7 @@ class ClimateSchema:
     CONF_HEAT_COOL = "heat_cool"
     CONF_OPERATION_MODES = "operation_modes"
     CONF_ON_OFF = "on_off"
+    CONF_EXPOSE_TEMPERATURE_SENSORS = "expose_temperature_sensors"
 
     CONF_FROST_PROTECTION_ADDRESS = "frost_protection_address"
     CONF_NIGHT_ADDRESS = "night_address"
@@ -416,6 +417,7 @@ class ClimateSchema:
             vol.Optional(CONF_OPERATION_MODES): vol.All(
                 ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
             ),
+            vol.Optional(CONF_EXPOSE_SENSORS, default=False): boolean,
         }
     )
 

--- a/xknx/config/schema.py
+++ b/xknx/config/schema.py
@@ -417,7 +417,7 @@ class ClimateSchema:
             vol.Optional(CONF_OPERATION_MODES): vol.All(
                 ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
             ),
-            vol.Optional(CONF_EXPOSE_SENSORS, default=False): boolean,
+            vol.Optional(CONF_EXPOSE_TEMPERATURE_SENSORS, default=False): boolean,
         }
     )
 

--- a/xknx/config/schema.py
+++ b/xknx/config/schema.py
@@ -323,7 +323,7 @@ class ClimateSchema:
     CONF_HEAT_COOL = "heat_cool"
     CONF_OPERATION_MODES = "operation_modes"
     CONF_ON_OFF = "on_off"
-    CONF_EXPOSE_TEMPERATURE_SENSORS = "expose_temperature_sensors"
+    CONF_CREATE_TEMPERATURE_SENSORS = "create_temperature_sensors"
 
     CONF_FROST_PROTECTION_ADDRESS = "frost_protection_address"
     CONF_NIGHT_ADDRESS = "night_address"
@@ -417,7 +417,7 @@ class ClimateSchema:
             vol.Optional(CONF_OPERATION_MODES): vol.All(
                 ensure_list, [vol.In({**OPERATION_MODES, **PRESET_MODES})]
             ),
-            vol.Optional(CONF_EXPOSE_TEMPERATURE_SENSORS, default=False): boolean,
+            vol.Optional(CONF_CREATE_TEMPERATURE_SENSORS, default=False): boolean,
         }
     )
 
@@ -437,7 +437,7 @@ class WeatherSchema:
     CONF_DAY_NIGHT = "day_night"
     CONF_AIR_PRESSURE = "air_pressure"
     CONF_HUMIDITY = "humidity"
-    CONF_EXPOSE_SENSORS = "expose_sensors"
+    CONF_CREATE_SENSORS = "create_sensors"
 
     SCHEMA = BaseDeviceSchema.SCHEMA.extend(
         {
@@ -513,7 +513,7 @@ class WeatherSchema:
                     vol.Required(CONF_STATE_ADDRESS): ensure_group_address,
                 }
             ),
-            vol.Optional(CONF_EXPOSE_SENSORS, default=False): boolean,
+            vol.Optional(CONF_CREATE_SENSORS, default=False): boolean,
         }
     )
 

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -2,8 +2,6 @@
 # flake8: noqa
 from .action import Action, ActionBase, ActionCallback
 from .binary_sensor import BinarySensor
-from .climate import Climate
-from .climate_mode import ClimateMode
 from .cover import Cover
 from .datetime import DateTime
 from .device import Device
@@ -16,6 +14,10 @@ from .scene import Scene
 from .sensor import Sensor
 from .switch import Switch
 from .travelcalculator import TravelCalculator, TravelStatus
+
+# Those depend on e.g. sensor having been imported already
+from .climate import Climate
+from .climate_mode import ClimateMode
 from .weather import Weather
 
 __all__ = [

--- a/xknx/devices/__init__.py
+++ b/xknx/devices/__init__.py
@@ -2,6 +2,8 @@
 # flake8: noqa
 from .action import Action, ActionBase, ActionCallback
 from .binary_sensor import BinarySensor
+from .climate import Climate
+from .climate_mode import ClimateMode
 from .cover import Cover
 from .datetime import DateTime
 from .device import Device
@@ -14,10 +16,6 @@ from .scene import Scene
 from .sensor import Sensor
 from .switch import Switch
 from .travelcalculator import TravelCalculator, TravelStatus
-
-# Those depend on e.g. sensor having been imported already
-from .climate import Climate
-from .climate_mode import ClimateMode
 from .weather import Weather
 
 __all__ = [

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -14,6 +14,7 @@ from xknx.remote_value import (
     RemoteValueTemp,
 )
 
+from . import Sensor
 from .climate_mode import ClimateMode
 from .device import Device, DeviceCallbackType
 
@@ -143,12 +144,12 @@ class Climate(Device):
         for suffix, group_address, value_type in (
             (
                 "_temperature",
-                self.group_address_temperature,
+                self.temperature.group_address_state,
                 "temperature",
             ),
             (
                 "_target_temperature",
-                self.group_address_target_temperature,
+                self.target_temperature.group_address_state,
                 "temperature",
             ),
         ):
@@ -158,7 +159,7 @@ class Climate(Device):
                     name=self.name + suffix,
                     group_address_state=group_address,
                     value_type=value_type,
-                )    
+                )
 
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Any) -> "Climate":

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -80,7 +80,7 @@ class Climate(Device):
             xknx,
             group_address_state=group_address_temperature,
             device_name=self.name,
-            feature_name="Current Temperature",
+            feature_name="Current temperature",
             after_update_cb=self.after_update,
         )
 
@@ -143,12 +143,12 @@ class Climate(Device):
         """Expose temperature sensors to xknx."""
         for suffix, group_address, value_type in (
             (
-                "_temperature",
+                "temperature",
                 self.temperature.group_address_state,
                 "temperature",
             ),
             (
-                "_target_temperature",
+                "target temperature",
                 self.target_temperature.group_address_state,
                 "temperature",
             ),
@@ -156,7 +156,7 @@ class Climate(Device):
             if group_address is not None:
                 Sensor(
                     self.xknx,
-                    name=self.name + suffix,
+                    name=self.name + " " + suffix,
                     group_address_state=group_address,
                     value_type=value_type,
                 )

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -14,7 +14,7 @@ from xknx.remote_value import (
     RemoteValueTemp,
 )
 
-from . import Sensor
+from .sensor import Sensor
 from .climate_mode import ClimateMode
 from .device import Device, DeviceCallbackType
 

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -14,9 +14,9 @@ from xknx.remote_value import (
     RemoteValueTemp,
 )
 
-from .sensor import Sensor
 from .climate_mode import ClimateMode
 from .device import Device, DeviceCallbackType
+from .sensor import Sensor
 
 if TYPE_CHECKING:
     from xknx.remote_value import RemoteValue
@@ -63,7 +63,7 @@ class Climate(Device):
         min_temp: Optional[float] = None,
         max_temp: Optional[float] = None,
         mode: Optional[ClimateMode] = None,
-        expose_temperature_sensors: bool = False,
+        create_temperature_sensors: bool = False,
         device_updated_cb: Optional[DeviceCallbackType] = None,
     ):
         """Initialize Climate class."""
@@ -127,8 +127,8 @@ class Climate(Device):
 
         self.mode = mode
 
-        if expose_temperature_sensors:
-            self.expose_temperature_sensors()
+        if create_temperature_sensors:
+            self.create_temperature_sensors()
 
     def _iter_remote_values(self) -> Iterator["RemoteValue"]:
         """Iterate the devices RemoteValue classes."""
@@ -139,8 +139,8 @@ class Climate(Device):
             self.on,
         )
 
-    def expose_temperature_sensors(self) -> None:
-        """Expose temperature sensors to xknx."""
+    def create_temperature_sensors(self) -> None:
+        """Create temperature sensors."""
         for suffix, group_address, value_type in (
             (
                 "temperature",

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -62,6 +62,7 @@ class Climate(Device):
         min_temp: Optional[float] = None,
         max_temp: Optional[float] = None,
         mode: Optional[ClimateMode] = None,
+        expose_temperature_sensors: bool = False,
         device_updated_cb: Optional[DeviceCallbackType] = None,
     ):
         """Initialize Climate class."""
@@ -125,6 +126,9 @@ class Climate(Device):
 
         self.mode = mode
 
+        if expose_temperature_sensors:
+            self.expose_temperature_sensors()
+
     def _iter_remote_values(self) -> Iterator["RemoteValue"]:
         """Iterate the devices RemoteValue classes."""
         yield from (
@@ -133,6 +137,28 @@ class Climate(Device):
             self._setpoint_shift,
             self.on,
         )
+
+    def expose_temperature_sensors(self) -> None:
+        """Expose temperature sensors to xknx."""
+        for suffix, group_address, value_type in (
+            (
+                "_temperature",
+                self.group_address_temperature,
+                "temperature",
+            ),
+            (
+                "_target_temperature",
+                self.group_address_target_temperature,
+                "temperature",
+            ),
+        ):
+            if group_address is not None:
+                Sensor(
+                    self.xknx,
+                    name=self.name + suffix,
+                    group_address_state=group_address,
+                    value_type=value_type,
+                )    
 
     @classmethod
     def from_config(cls, xknx: "XKNX", name: str, config: Any) -> "Climate":

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -92,7 +92,7 @@ class Weather(Device):
         group_address_day_night: Optional["GroupAddressableType"] = None,
         group_address_air_pressure: Optional["GroupAddressableType"] = None,
         group_address_humidity: Optional["GroupAddressableType"] = None,
-        expose_sensors: bool = False,
+        create_sensors: bool = False,
         sync_state: bool = True,
         device_updated_cb: Optional[DeviceCallbackType] = None,
     ) -> None:
@@ -212,8 +212,8 @@ class Weather(Device):
             after_update_cb=self.after_update,
         )
 
-        if expose_sensors:
-            self.expose_sensors()
+        if create_sensors:
+            self.create_sensors()
 
     def _iter_remote_values(self) -> Iterator[RemoteValue]:
         """Iterate the devices remote values."""
@@ -319,7 +319,7 @@ class Weather(Device):
             self.brightness_east,
         )
 
-    def expose_sensors(self) -> None:
+    def create_sensors(self) -> None:
         """Expose sensors to xknx."""
         for suffix, group_address in (
             ("_rain_alarm", self._rain_alarm.group_address_state),
@@ -437,7 +437,7 @@ class Weather(Device):
         group_address_day_night = config.get("group_address_day_night")
         group_address_air_pressure = config.get("group_address_air_pressure")
         group_address_humidity = config.get("group_address_humidity")
-        expose_sensors = config.get("expose_sensors", False)
+        create_sensors = config.get("create_sensors", False)
         sync_state = config.get("sync_state", True)
 
         return cls(
@@ -455,7 +455,7 @@ class Weather(Device):
             group_address_day_night=group_address_day_night,
             group_address_air_pressure=group_address_air_pressure,
             group_address_humidity=group_address_humidity,
-            expose_sensors=expose_sensors,
+            create_sensors=create_sensors,
             sync_state=sync_state,
         )
 

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -67,7 +67,7 @@ class RemoteValueClimateMode(RemoteValueClimateModeBase[HVACModeType]):
         group_address_state: Optional["GroupAddressableType"] = None,
         sync_state: bool = True,
         device_name: Optional[str] = None,
-        feature_name: str = "Climate Mode",
+        feature_name: str = "Climate mode",
         climate_mode_type: Optional[ClimateModeType] = None,
         after_update_cb: Optional["AsyncCallback"] = None,
         passive_group_addresses: Optional[List["GroupAddressableType"]] = None,
@@ -125,7 +125,7 @@ class RemoteValueBinaryOperationMode(RemoteValueClimateModeBase[HVACOperationMod
         group_address_state: Optional["GroupAddressableType"] = None,
         sync_state: bool = True,
         device_name: Optional[str] = None,
-        feature_name: str = "Climate Mode Binary",
+        feature_name: str = "Climate mode binary",
         after_update_cb: Optional["AsyncCallback"] = None,
         operation_mode: Optional[HVACOperationMode] = None,
     ):
@@ -207,7 +207,7 @@ class RemoteValueBinaryHeatCool(RemoteValueClimateModeBase[HVACControllerMode]):
         group_address_state: Optional["GroupAddressableType"] = None,
         sync_state: bool = True,
         device_name: Optional[str] = None,
-        feature_name: str = "Controller Mode Heat/Cool",
+        feature_name: str = "Controller mode Heat/Cool",
         after_update_cb: Optional["AsyncCallback"] = None,
         controller_mode: Optional[HVACControllerMode] = None,
     ):

--- a/xknx_v2.yaml
+++ b/xknx_v2.yaml
@@ -163,7 +163,7 @@ climate:
     humidity:
       state_address: "7/0/10"
       state_update: "expire 60"
-    expose_sensors: True
+    create_sensors: True
 datetime:
   - name: "Generaltime"
     time:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

Add support for exposing the current and target temperature as sensors from a climate device.

In regards to the sensor naming: The weather device uses underscores to add the suffix, but in HA that looks bad, so I instead went with spaces. Ideally we would use one approach consistently in the library.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [X] The Homeassistant plugin has been adjusted in case of new config options
