### PR TITLE
DPT update

### DIFF
--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -224,7 +224,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), 641157503)
         self.assertEqual(sensor.unit_of_measurement(), "Wh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_active_energy_kwh(self):
         """Test resolve state with active_energy_kwh sensor."""
@@ -246,7 +246,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), 923076074)
         self.assertEqual(sensor.unit_of_measurement(), "kWh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_activity(self):
         """Test resolve state with activity sensor."""
@@ -422,7 +422,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), -742580571)
         self.assertEqual(sensor.unit_of_measurement(), "VAh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_apparant_energy_kvah(self):
         """Test resolve state with apparant_energy_kvah sensor."""
@@ -444,7 +444,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), 1228982537)
         self.assertEqual(sensor.unit_of_measurement(), "kVAh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_area(self):
         """Test resolve state with area sensor."""
@@ -1794,7 +1794,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), -2898.508056640625)
         self.assertEqual(sensor.unit_of_measurement(), "cosΦ")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "power_factor")
 
     def test_str_ppm(self):
         """Test resolve state with ppm sensor."""
@@ -1917,7 +1917,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), 441019815)
         self.assertEqual(sensor.unit_of_measurement(), "VARh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_reactive_energy_kvarh(self):
         """Test resolve state with reactive_energy_kvarh sensor."""
@@ -1939,7 +1939,7 @@ class TestSensor(unittest.TestCase):
 
         self.assertEqual(sensor.resolve_state(), -865991375)
         self.assertEqual(sensor.unit_of_measurement(), "kVARh")
-        self.assertEqual(sensor.ha_device_class(), None)
+        self.assertEqual(sensor.ha_device_class(), "energy")
 
     def test_str_resistance(self):
         """Test resolve state with resistance sensor."""

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -131,7 +131,7 @@ class TestDPTFloat(unittest.TestCase):
         self.assertEqual(DPTTemperature().value_min, -273)
         self.assertEqual(DPTTemperature().value_max, 670760)
         self.assertEqual(DPTTemperature().unit, "°C")
-        self.assertEqual(DPTTemperature().resolution, 1)
+        self.assertEqual(DPTTemperature().resolution, 0.01)
 
     def test_temperature_assert_min_exceeded(self):
         """Testing parsing of DPTTemperature with wrong value."""
@@ -151,7 +151,7 @@ class TestDPTFloat(unittest.TestCase):
         self.assertEqual(DPTLux().value_min, 0)
         self.assertEqual(DPTLux().value_max, 670760)
         self.assertEqual(DPTLux().unit, "lx")
-        self.assertEqual(DPTLux().resolution, 1)
+        self.assertEqual(DPTLux().resolution, 0.01)
 
     def test_lux_assert_min_exceeded(self):
         """Test parsing of DPTLux with wrong value."""
@@ -166,7 +166,7 @@ class TestDPTFloat(unittest.TestCase):
         self.assertEqual(DPTHumidity().value_min, 0)
         self.assertEqual(DPTHumidity().value_max, 670760)
         self.assertEqual(DPTHumidity().unit, "%")
-        self.assertEqual(DPTHumidity().resolution, 1)
+        self.assertEqual(DPTHumidity().resolution, 0.01)
 
     def test_humidity_assert_min_exceeded(self):
         """Test parsing of DPTHumidity with wrong value."""

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -93,7 +93,7 @@ class DPTTemperature(DPT2ByteFloat):
     value_type = "temperature"
     unit = "°C"
     ha_device_class = "temperature"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTTemperatureDifference2Byte(DPT2ByteFloat):
@@ -106,7 +106,7 @@ class DPTTemperatureDifference2Byte(DPT2ByteFloat):
     value_type = "temperature_difference_2byte"
     unit = "K"
     ha_device_class = "temperature"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTTemperatureA(DPT2ByteFloat):
@@ -118,7 +118,7 @@ class DPTTemperatureA(DPT2ByteFloat):
     dpt_sub_number = 3
     value_type = "temperature_a"
     unit = "K/h"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTLux(DPT2ByteFloat):
@@ -131,7 +131,7 @@ class DPTLux(DPT2ByteFloat):
     value_type = "illuminance"
     unit = "lx"
     ha_device_class = "illuminance"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTWsp(DPT2ByteFloat):
@@ -143,7 +143,7 @@ class DPTWsp(DPT2ByteFloat):
     dpt_sub_number = 5
     value_type = "wind_speed_ms"
     unit = "m/s"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTPressure2Byte(DPT2ByteFloat):
@@ -156,7 +156,7 @@ class DPTPressure2Byte(DPT2ByteFloat):
     value_type = "pressure_2byte"
     unit = "Pa"
     ha_device_class = "pressure"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTHumidity(DPT2ByteFloat):
@@ -169,7 +169,7 @@ class DPTHumidity(DPT2ByteFloat):
     value_type = "humidity"
     unit = "%"
     ha_device_class = "humidity"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTPartsPerMillion(DPT2ByteFloat):
@@ -179,6 +179,7 @@ class DPTPartsPerMillion(DPT2ByteFloat):
     dpt_sub_number = 8
     value_type = "ppm"
     unit = "ppm"
+    resolution = 0.01
 
 
 class DPTTime1(DPT2ByteFloat):
@@ -190,7 +191,7 @@ class DPTTime1(DPT2ByteFloat):
     dpt_sub_number = 10
     value_type = "time_1"
     unit = "s"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTTime2(DPT2ByteFloat):
@@ -202,7 +203,7 @@ class DPTTime2(DPT2ByteFloat):
     dpt_sub_number = 11
     value_type = "time_2"
     unit = "ms"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTVoltage(DPT2ByteFloat):
@@ -212,6 +213,7 @@ class DPTVoltage(DPT2ByteFloat):
     dpt_sub_number = 20
     value_type = "voltage"
     unit = "mV"
+    resolution = 0.01
 
 
 class DPTCurrent(DPT2ByteFloat):
@@ -221,6 +223,7 @@ class DPTCurrent(DPT2ByteFloat):
     dpt_sub_number = 21
     value_type = "curr"
     unit = "mA"
+    resolution = 0.01
 
 
 class DPTPowerDensity(DPT2ByteFloat):
@@ -230,6 +233,7 @@ class DPTPowerDensity(DPT2ByteFloat):
     dpt_sub_number = 22
     value_type = "power_density"
     unit = "W/m²"
+    resolution = 0.01
 
 
 class DPTKelvinPerPercent(DPT2ByteFloat):
@@ -239,6 +243,7 @@ class DPTKelvinPerPercent(DPT2ByteFloat):
     dpt_sub_number = 23
     value_type = "kelvin_per_percent"
     unit = "K/%"
+    resolution = 0.01
 
 
 class DPTPower2Byte(DPT2ByteFloat):
@@ -249,6 +254,7 @@ class DPTPower2Byte(DPT2ByteFloat):
     value_type = "power_2byte"
     unit = "kW"
     ha_device_class = "power"
+    resolution = 0.01
 
 
 class DPTVolumeFlow(DPT2ByteFloat):
@@ -258,6 +264,7 @@ class DPTVolumeFlow(DPT2ByteFloat):
     dpt_sub_number = 25
     value_type = "volume_flow"
     unit = "l/h"
+    resolution = 0.01
 
 
 class DPTRainAmount(DPT2ByteFloat):
@@ -269,6 +276,7 @@ class DPTRainAmount(DPT2ByteFloat):
     dpt_sub_number = 26
     value_type = "rain_amount"
     unit = "l/m²"
+    resolution = 0.01
 
 
 class DPTTemperatureF(DPT2ByteFloat):
@@ -281,7 +289,7 @@ class DPTTemperatureF(DPT2ByteFloat):
     value_type = "temperature_f"
     unit = "°F"
     ha_device_class = "temperature"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTWspKmh(DPT2ByteFloat):
@@ -293,7 +301,7 @@ class DPTWspKmh(DPT2ByteFloat):
     dpt_sub_number = 28
     value_type = "wind_speed_kmh"
     unit = "km/h"
-    resolution = 1
+    resolution = 0.01
 
 
 class DPTEnthalpy(DPT2ByteFloat):
@@ -304,3 +312,4 @@ class DPTEnthalpy(DPT2ByteFloat):
     dpt_sub_number = 999
     value_type = "enthalpy"
     unit = "H"
+    resolution = 0.01

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -22,7 +22,7 @@ class DPT2ByteFloat(DPTBase):
     dpt_sub_number = None
     value_type = "2byte_float"
     unit = ""
-    resolution = 1
+    resolution = 0.01
     payload_length = 2
 
     @classmethod
@@ -93,7 +93,6 @@ class DPTTemperature(DPT2ByteFloat):
     value_type = "temperature"
     unit = "°C"
     ha_device_class = "temperature"
-    resolution = 0.01
 
 
 class DPTTemperatureDifference2Byte(DPT2ByteFloat):
@@ -106,7 +105,6 @@ class DPTTemperatureDifference2Byte(DPT2ByteFloat):
     value_type = "temperature_difference_2byte"
     unit = "K"
     ha_device_class = "temperature"
-    resolution = 0.01
 
 
 class DPTTemperatureA(DPT2ByteFloat):
@@ -118,7 +116,6 @@ class DPTTemperatureA(DPT2ByteFloat):
     dpt_sub_number = 3
     value_type = "temperature_a"
     unit = "K/h"
-    resolution = 0.01
 
 
 class DPTLux(DPT2ByteFloat):
@@ -131,7 +128,6 @@ class DPTLux(DPT2ByteFloat):
     value_type = "illuminance"
     unit = "lx"
     ha_device_class = "illuminance"
-    resolution = 0.01
 
 
 class DPTWsp(DPT2ByteFloat):
@@ -143,7 +139,6 @@ class DPTWsp(DPT2ByteFloat):
     dpt_sub_number = 5
     value_type = "wind_speed_ms"
     unit = "m/s"
-    resolution = 0.01
 
 
 class DPTPressure2Byte(DPT2ByteFloat):
@@ -156,7 +151,6 @@ class DPTPressure2Byte(DPT2ByteFloat):
     value_type = "pressure_2byte"
     unit = "Pa"
     ha_device_class = "pressure"
-    resolution = 0.01
 
 
 class DPTHumidity(DPT2ByteFloat):
@@ -169,7 +163,6 @@ class DPTHumidity(DPT2ByteFloat):
     value_type = "humidity"
     unit = "%"
     ha_device_class = "humidity"
-    resolution = 0.01
 
 
 class DPTPartsPerMillion(DPT2ByteFloat):
@@ -179,7 +172,6 @@ class DPTPartsPerMillion(DPT2ByteFloat):
     dpt_sub_number = 8
     value_type = "ppm"
     unit = "ppm"
-    resolution = 0.01
 
 
 class DPTTime1(DPT2ByteFloat):
@@ -191,7 +183,6 @@ class DPTTime1(DPT2ByteFloat):
     dpt_sub_number = 10
     value_type = "time_1"
     unit = "s"
-    resolution = 0.01
 
 
 class DPTTime2(DPT2ByteFloat):
@@ -203,7 +194,6 @@ class DPTTime2(DPT2ByteFloat):
     dpt_sub_number = 11
     value_type = "time_2"
     unit = "ms"
-    resolution = 0.01
 
 
 class DPTVoltage(DPT2ByteFloat):
@@ -213,7 +203,6 @@ class DPTVoltage(DPT2ByteFloat):
     dpt_sub_number = 20
     value_type = "voltage"
     unit = "mV"
-    resolution = 0.01
 
 
 class DPTCurrent(DPT2ByteFloat):
@@ -223,7 +212,6 @@ class DPTCurrent(DPT2ByteFloat):
     dpt_sub_number = 21
     value_type = "curr"
     unit = "mA"
-    resolution = 0.01
 
 
 class DPTPowerDensity(DPT2ByteFloat):
@@ -233,7 +221,6 @@ class DPTPowerDensity(DPT2ByteFloat):
     dpt_sub_number = 22
     value_type = "power_density"
     unit = "W/m²"
-    resolution = 0.01
 
 
 class DPTKelvinPerPercent(DPT2ByteFloat):
@@ -243,7 +230,6 @@ class DPTKelvinPerPercent(DPT2ByteFloat):
     dpt_sub_number = 23
     value_type = "kelvin_per_percent"
     unit = "K/%"
-    resolution = 0.01
 
 
 class DPTPower2Byte(DPT2ByteFloat):
@@ -254,7 +240,6 @@ class DPTPower2Byte(DPT2ByteFloat):
     value_type = "power_2byte"
     unit = "kW"
     ha_device_class = "power"
-    resolution = 0.01
 
 
 class DPTVolumeFlow(DPT2ByteFloat):
@@ -264,7 +249,6 @@ class DPTVolumeFlow(DPT2ByteFloat):
     dpt_sub_number = 25
     value_type = "volume_flow"
     unit = "l/h"
-    resolution = 0.01
 
 
 class DPTRainAmount(DPT2ByteFloat):
@@ -276,7 +260,6 @@ class DPTRainAmount(DPT2ByteFloat):
     dpt_sub_number = 26
     value_type = "rain_amount"
     unit = "l/m²"
-    resolution = 0.01
 
 
 class DPTTemperatureF(DPT2ByteFloat):
@@ -289,7 +272,6 @@ class DPTTemperatureF(DPT2ByteFloat):
     value_type = "temperature_f"
     unit = "°F"
     ha_device_class = "temperature"
-    resolution = 0.01
 
 
 class DPTWspKmh(DPT2ByteFloat):
@@ -301,7 +283,6 @@ class DPTWspKmh(DPT2ByteFloat):
     dpt_sub_number = 28
     value_type = "wind_speed_kmh"
     unit = "km/h"
-    resolution = 0.01
 
 
 class DPTEnthalpy(DPT2ByteFloat):
@@ -312,4 +293,3 @@ class DPTEnthalpy(DPT2ByteFloat):
     dpt_sub_number = 999
     value_type = "enthalpy"
     unit = "H"
-    resolution = 0.01

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -572,6 +572,7 @@ class DPTPowerFactor(DPT4ByteFloat):
     dpt_sub_number = 57
     value_type = "powerfactor"
     unit = "cosΦ"
+    ha_device_class = "power_factor"
 
 
 class DPTPressure(DPT4ByteFloat):

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -120,6 +120,7 @@ class DPTActiveEnergy(DPT4ByteSigned):
     dpt_sub_number = 10
     value_type = "active_energy"
     unit = "Wh"
+    ha_device_class = "energy"
 
 
 class DPTApparantEnergy(DPT4ByteSigned):
@@ -129,6 +130,7 @@ class DPTApparantEnergy(DPT4ByteSigned):
     dpt_sub_number = 11
     value_type = "apparant_energy"
     unit = "VAh"
+    ha_device_class = "energy"
 
 
 class DPTReactiveEnergy(DPT4ByteSigned):
@@ -138,6 +140,7 @@ class DPTReactiveEnergy(DPT4ByteSigned):
     dpt_sub_number = 12
     value_type = "reactive_energy"
     unit = "VARh"
+    ha_device_class = "energy"
 
 
 class DPTActiveEnergykWh(DPT4ByteSigned):
@@ -147,6 +150,7 @@ class DPTActiveEnergykWh(DPT4ByteSigned):
     dpt_sub_number = 13
     value_type = "active_energy_kwh"
     unit = "kWh"
+    ha_device_class = "energy"
 
 
 class DPTApparantEnergykVAh(DPT4ByteSigned):
@@ -156,6 +160,7 @@ class DPTApparantEnergykVAh(DPT4ByteSigned):
     dpt_sub_number = 14
     value_type = "apparant_energy_kvah"
     unit = "kVAh"
+    ha_device_class = "energy"
 
 
 class DPTReactiveEnergykVARh(DPT4ByteSigned):
@@ -165,6 +170,7 @@ class DPTReactiveEnergykVARh(DPT4ByteSigned):
     dpt_sub_number = 15
     value_type = "reactive_energy_kvarh"
     unit = "kVARh"
+    ha_device_class = "energy"
 
 
 class DPTLongDeltaTimeSec(DPT4ByteSigned):


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
This PR updates DPT definition as follows:
- Resolution of DPT9 had been changed from 1 to 0.01 according to the KNX specification. This should not break anything, as the parameter is not used for the time being.
- Some additional `HA_device_class`es had been added: `power_factor` for DPT14 and `energy` for DPT13.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
