### PR TITLE
HA integration: local_ip for routing optional

### DIFF
--- a/home-assistant-plugin/custom_components/xknx/__init__.py
+++ b/home-assistant-plugin/custom_components/xknx/__init__.py
@@ -318,9 +318,12 @@ class KNXModule:
 
     def connection_config_routing(self):
         """Return the connection_config if routing is configured."""
-        local_ip = self.config[DOMAIN][CONF_XKNX_ROUTING].get(
-            ConnectionSchema.CONF_XKNX_LOCAL_IP
-        )
+        local_ip = None
+        # all configuration variables for routing are optional
+        if self.config[DOMAIN][CONF_XKNX_ROUTING] is not None:
+            local_ip = self.config[DOMAIN][CONF_XKNX_ROUTING].get(
+                ConnectionSchema.CONF_XKNX_LOCAL_IP
+            )
         return ConnectionConfig(
             connection_type=ConnectionType.ROUTING, local_ip=local_ip
         )

--- a/home-assistant-plugin/custom_components/xknx/schema.py
+++ b/home-assistant-plugin/custom_components/xknx/schema.py
@@ -38,7 +38,9 @@ class ConnectionSchema:
         }
     )
 
-    ROUTING_SCHEMA = vol.Schema({vol.Optional(CONF_XKNX_LOCAL_IP): cv.string})
+    ROUTING_SCHEMA = vol.Maybe(
+        vol.Schema({vol.Optional(CONF_XKNX_LOCAL_IP): cv.string})
+    )
 
 
 class CoverSchema:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
The local IP address for a routing connection is optional, not required. This enables routing to be used from a host with dynamic IP .
(It was always possible, I just didn't know how to write the Schema until I found vol.Maybe).

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
