### PR TITLE
Tunneling: default `auto_reconnect`to True

### DIFF
--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -61,7 +61,7 @@ class ConnectionConfig:
         local_ip: Optional[str] = None,
         gateway_ip: Optional[str] = None,
         gateway_port: int = DEFAULT_MCAST_PORT,
-        auto_reconnect: bool = False,
+        auto_reconnect: bool = True,
         auto_reconnect_wait: int = 3,
         scan_filter: GatewayScanFilter = GatewayScanFilter(),
     ):

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -47,7 +47,7 @@ class Tunnel(Interface):
         gateway_ip: str,
         gateway_port: int,
         telegram_received_callback: Optional["TelegramCallbackType"] = None,
-        auto_reconnect: bool = False,
+        auto_reconnect: bool = True,
         auto_reconnect_wait: int = 3,
     ):
         """Initialize Tunnel class."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
So config_file users also get reconnected
Also I think its a good default.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
