### PR TITLE
Description of platform dependend xknx pip path

### DIFF
--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -44,7 +44,7 @@ Delete the automatically installed version:
 rm [hass-directory]/lib/python[python-version]/site-packages/xknx*
 ```
 
-Note: `[hass-directory]` is platform dependend (e.g. `~/.homeassistant` for MacOS or `/srv/homeassistant` for LINUX).
+Note: `[hass-directory]` is platform dependend (e.g. `.homeassistant/deps` for MacOS or `/srv/homeassistant` for LINUX).
 
 Ideally start HA from command line. Export the environment variable PYTHONPATH to your local `xknx` checkout:
 

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -36,12 +36,12 @@ Run HA as usual either via service or by directly typing in `hass`.
 Running HA with local XKNX library
 ------------------------------------
 
-Even when running HA with the XKNX custom component, HA will automatically install a `xknx` library version within `.homeassistant/deps/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
+Even when running HA with the XKNX custom component, HA will automatically install a `xknx` library version within `/srv/homeassistant/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
 
 Delete the automatically installed version:
 
 ```bash
-rm .homeassistant/deps/lib/python[python-version]/site-packages/xknx*
+rm /srv/homeassistant/lib/python[python-version]/site-packages/xknx*
 ```
 
 Ideally start HA from command line. Export the environment variable PYTHONPATH to your local `xknx` checkout:

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -36,15 +36,15 @@ Run HA as usual either via service or by directly typing in `hass`.
 Running HA with local XKNX library
 ------------------------------------
 
-Even when running HA with the XKNX custom component, HA will automatically install a `xknx` library version within `[hass-directory]/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
+When running HA with the KNX integrated component once, HA will automatically install a `xknx` library version within `[hass-dependency-directory]/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
 
 Delete the automatically installed version:
 
 ```bash
-rm [hass-directory]/lib/python[python-version]/site-packages/xknx*
+rm [hass-dependency-directory]/lib/python[python-version]/site-packages/xknx*
 ```
 
-Note: `[hass-directory]` is platform dependend (e.g. `/usr/local/` for MacOS or `/srv/homeassistant` for LINUX).
+Note: `[hass-dependency-directory]` is platform dependend (e.g. `/usr/local` for Docker image, `~/.homeassistant/deps` for macOS or `/srv/homeassistant` for Debian).
 
 Ideally start HA from command line. Export the environment variable PYTHONPATH to your local `xknx` checkout:
 
@@ -81,5 +81,4 @@ Help
 ----
 
 If you have problems, join the [XKNX chat on Discord](https://discord.gg/EuAQDXU). We are happy to help :-)
-
 

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -36,13 +36,15 @@ Run HA as usual either via service or by directly typing in `hass`.
 Running HA with local XKNX library
 ------------------------------------
 
-Even when running HA with the XKNX custom component, HA will automatically install a `xknx` library version within `/srv/homeassistant/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
+Even when running HA with the XKNX custom component, HA will automatically install a `xknx` library version within `[hass-directory]/lib/python[python-version]/site-packages` via pip. This very often causes the problem, that the manually checked out `xknx` library is not in sync with the `xknx` library version HA already contains and uses by default. But getting both in sync is easy:
 
 Delete the automatically installed version:
 
 ```bash
-rm /srv/homeassistant/lib/python[python-version]/site-packages/xknx*
+rm [hass-directory]/lib/python[python-version]/site-packages/xknx*
 ```
+
+Note: `[hass-directory]` is platform dependend (e.g. `~/.homeassistant` for MacOS or `/srv/homeassistant` for LINUX).
 
 Ideally start HA from command line. Export the environment variable PYTHONPATH to your local `xknx` checkout:
 

--- a/docs/home_assistant.md
+++ b/docs/home_assistant.md
@@ -44,7 +44,7 @@ Delete the automatically installed version:
 rm [hass-directory]/lib/python[python-version]/site-packages/xknx*
 ```
 
-Note: `[hass-directory]` is platform dependend (e.g. `.homeassistant/deps` for MacOS or `/srv/homeassistant` for LINUX).
+Note: `[hass-directory]` is platform dependend (e.g. `/usr/local/` for MacOS or `/srv/homeassistant` for LINUX).
 
 Ideally start HA from command line. Export the environment variable PYTHONPATH to your local `xknx` checkout:
 


### PR DESCRIPTION
xknx pip path has changed, libary is no longer stored in home directory

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
I did a new xknx setup today and have noticed, that the xknx libary is no longer stored in the home folder. It's stored under `/srv/homeassistant/`. I have adapted the docu. 

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
