### PR TITLE
Use correct move_short direction when cover stopping

### DIFF
--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -125,7 +125,7 @@ class Cover(Device):
         self.travel_time_up = travel_time_up
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
-        self.travel_direction_tilt = None
+        self.travel_direction_tilt = Optional[TravelStatus]
 
         self.device_class = device_class
 
@@ -222,11 +222,15 @@ class Cover(Device):
         if self.stop_.writable:
             await self.stop_.on()
         elif self.step.writable:
-            if (self.travel_direction_tilt == TravelStatus.DIRECTION_UP or 
-                self.travelcalculator.travel_direction == TravelStatus.DIRECTION_UP):
+            if (
+                self.travel_direction_tilt == TravelStatus.DIRECTION_UP
+                or self.travelcalculator.travel_direction == TravelStatus.DIRECTION_UP
+            ):
                 await self.step.decrease()
-            elif (self.travel_direction_tilt == TravelStatus.DIRECTION_DOWN or 
-                self.travelcalculator.travel_direction == TravelStatus.DIRECTION_DOWN):
+            elif (
+                self.travel_direction_tilt == TravelStatus.DIRECTION_DOWN
+                or self.travelcalculator.travel_direction == TravelStatus.DIRECTION_DOWN
+            ):
                 await self.step.increase()
         else:
             logger.warning("Stop not supported for device %s", self.get_name())
@@ -283,7 +287,7 @@ class Cover(Device):
 
         self.travel_direction_tilt = (
             TravelStatus.DIRECTION_DOWN
-            if angle > self.current_angle()
+            if self.current_angle() is not None and angle > int(self.angle.value)
             else TravelStatus.DIRECTION_UP
         )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -217,10 +217,7 @@ class Cover(Device):
     async def stop(self) -> None:
         """Stop cover."""
         if self.stop_.writable:
-            if self.travelcalculator.travel_direction == TravelStatus.DIRECTION_UP:
-                await self.stop_.off()
-            elif self.travelcalculator.travel_direction == TravelStatus.DIRECTION_DOWN:
-                await self.stop_.on()
+            await self.stop_.on()
         elif self.step.writable:
             if self.travelcalculator.travel_direction == TravelStatus.DIRECTION_UP:
                 await self.step.decrease()

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -285,9 +285,10 @@ class Cover(Device):
             logger.warning("Angle not supported for device %s", self.get_name())
             return
 
+        current_angle = self.current_angle()
         self.travel_direction_tilt = (
             TravelStatus.DIRECTION_DOWN
-            if self.current_angle() and angle > int(self.angle.value)
+            if current_angle and angle > current_angle
             else TravelStatus.DIRECTION_UP
         )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -125,7 +125,7 @@ class Cover(Device):
         self.travel_time_up = travel_time_up
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
-        self.travel_direction_tilt = Optional[TravelStatus]
+        self.travel_direction_tilt: Optional[TravelStatus] = None
 
         self.device_class = device_class
 
@@ -288,7 +288,7 @@ class Cover(Device):
         current_angle = self.current_angle()
         self.travel_direction_tilt = (
             TravelStatus.DIRECTION_DOWN
-            if current_angle and angle >= current_angle
+            if current_angle is not None and angle >= current_angle
             else TravelStatus.DIRECTION_UP
         )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -287,7 +287,7 @@ class Cover(Device):
 
         self.travel_direction_tilt = (
             TravelStatus.DIRECTION_DOWN
-            if self.current_angle() is not None and angle > int(self.angle.value)
+            if self.current_angle() and angle > int(self.angle.value)
             else TravelStatus.DIRECTION_UP
         )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -288,7 +288,7 @@ class Cover(Device):
         current_angle = self.current_angle()
         self.travel_direction_tilt = (
             TravelStatus.DIRECTION_DOWN
-            if current_angle and angle > current_angle
+            if current_angle and angle >= current_angle
             else TravelStatus.DIRECTION_UP
         )
 

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -218,7 +218,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType]):
         """Send GroupValueRead telegram for state address to KNX bus."""
         if self.group_address_state is not None:
             # pylint: disable=import-outside-toplevel
-            # TODO: send a ReadRequset and start a timeout from here instead of ValueReader
+            # TODO: send a ReadRequest and start a timeout from here instead of ValueReader
             #       cancel timeout form process(); delete ValueReader
             from xknx.core import ValueReader
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

So far when stopping a cover, xknx always triggered a move_short in a fixed direction, regardless of whether we are moving up or down. Same for stopping a cover tilt.

Now the cover travel direction is taken into account.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [X] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
