### PR TITLE
Unwrap Optional RemoteValue.value

### DIFF
--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1067,6 +1067,21 @@ class TestClimate(unittest.TestCase):
             telegram1, Telegram(GroupAddress("1/2/15"), payload=GroupValueRead())
         )
 
+    def test_sync_mode_from_climate(self):
+        """Test sync function / propagating to mode."""
+        xknx = XKNX()
+        climate_mode = ClimateMode(
+            xknx, "TestClimateMode", group_address_operation_mode_state="1/2/4"
+        )
+        climate = Climate(xknx, "TestClimate", mode=climate_mode)
+
+        self.loop.run_until_complete(climate.sync())
+        self.assertEqual(xknx.telegrams.qsize(), 1)
+        telegram1 = xknx.telegrams.get_nowait()
+        self.assertEqual(
+            telegram1, Telegram(GroupAddress("1/2/4"), payload=GroupValueRead())
+        )
+
     #
     # TEST PROCESS
     #

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -119,7 +119,8 @@ class BinarySensor(Device):
 
     async def _state_from_remote_value(self) -> None:
         """Update the internal state from RemoteValue (Callback)."""
-        await self._set_internal_state(self.remote_value.value)
+        if self.remote_value.value is not None:
+            await self._set_internal_state(self.remote_value.value)
 
     async def _set_internal_state(self, state: bool) -> None:
         """Set the internal state of the device. If state was changed after_update hooks and connected Actions are executed."""

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -361,7 +361,8 @@ class ClimateMode(Device):
         if self.supports_controller_mode:
             for rv in self._iter_controller_remote_values():
                 if await rv.process(telegram):
-                    await self._set_internal_controller_mode(rv.value)
+                    if rv.value is not None:
+                        await self._set_internal_controller_mode(rv.value)
                     return
 
     def __str__(self) -> str:

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -266,18 +266,22 @@ class Cover(Device):
 
     async def _target_position_from_rv(self) -> None:
         """Update the target postion from RemoteValue (Callback)."""
-        self.travelcalculator.start_travel(self.position_target.value)
-        await self.after_update()
+        new_target = self.position_target.value
+        if new_target is not None:
+            self.travelcalculator.start_travel(new_target)
+            await self.after_update()
 
     async def _current_position_from_rv(self) -> None:
         """Update the current postion from RemoteValue (Callback)."""
         position_before_update = self.travelcalculator.current_position()
-        if self.is_traveling():
-            self.travelcalculator.update_position(self.position_current.value)
-        else:
-            self.travelcalculator.set_position(self.position_current.value)
-        if position_before_update != self.travelcalculator.current_position():
-            await self.after_update()
+        new_position = self.position_current.value
+        if new_position is not None:
+            if self.is_traveling():
+                self.travelcalculator.update_position(new_position)
+            else:
+                self.travelcalculator.set_position(new_position)
+            if position_before_update != self.travelcalculator.current_position():
+                await self.after_update()
 
     async def set_angle(self, angle: int) -> None:
         """Move cover to designated angle."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -21,6 +21,7 @@ from typing import (
     Iterator,
     Optional,
     Tuple,
+    cast,
 )
 
 from xknx.remote_value import (
@@ -549,7 +550,7 @@ class Light(Device):
         )
         if None in colors:
             return None, self.white.brightness.value
-        return colors, self.white.brightness.value
+        return cast(Tuple[int, int, int], colors), self.white.brightness.value
 
     async def set_color(
         self, color: Tuple[int, int, int], white: Optional[int] = None

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -36,7 +36,7 @@ class RemoteValueColorRGBW(RemoteValue[DPTArray]):
             feature_name=feature_name,
             after_update_cb=after_update_cb,
         )
-        self.previous_value: Tuple[int, ...] = (0, 0, 0, 0)
+        self.previous_value: Tuple[int, int, int, int] = (0, 0, 0, 0)
 
     def payload_valid(
         self, payload: Optional[Union[DPTArray, DPTBinary]]
@@ -101,17 +101,17 @@ class RemoteValueColorRGBW(RemoteValue[DPTArray]):
             return DPTArray(list(rgbw) + [0x00] + list(value[4:]))
         return DPTArray(value)
 
-    def from_knx(self, payload: DPTArray) -> Tuple[int, ...]:
+    def from_knx(self, payload: DPTArray) -> Tuple[int, int, int, int]:
         """
         Convert current payload to value. Always 4 byte (RGBW).
 
         If one element is invalid, use the previous value. All previous element
         values are initialized to 0.
         """
-        _result = []
+        _result = list(self.previous_value)
         for i in range(0, len(payload.value) - 2):
-            valid = (payload.value[5] & (0x08 >> i)) != 0  # R,G,B,W value valid?
-            _result.append(payload.value[i] if valid else self.previous_value[i])
-        result = tuple(_result)
+            if payload.value[5] & (0x08 >> i):  # R,G,B,W value valid?
+                _result[i] = payload.value[i]
+        result = (_result[0], _result[1], _result[2], _result[3])
         self.previous_value = result
         return result


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
The `RemoteValue.value` property actually retruns `Optional[Something]` but is annotated `-> Any`. This is ok for now since we `# type: ignore` when the value is used. 
This PR unwraps the Optional when .value is used in code. It is a preparation for annotating .value properly.

`Climate.initialized_for_setpoint_shift_calculations` is now only used in tests.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
