### PR TITLE
Type RemoteValue.value

### DIFF
--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -430,6 +430,10 @@ class TestLight(unittest.TestCase):
             group_address_brightness_white="1/1/15",
             group_address_brightness_white_state="1/1/16",
         )
+        self.assertEqual(light.state, None)
+        for color in light._iter_individual_colors():
+            self.assertEqual(color.is_on, None)
+
         self.loop.run_until_complete(light.set_on())
         self.assertEqual(xknx.telegrams.qsize(), 4)
 
@@ -455,6 +459,13 @@ class TestLight(unittest.TestCase):
         ]
         self.assertEqual(len(set(telegrams)), 4)
         self.assertEqual(set(telegrams), set(test_telegrams))
+
+        for telegram in telegrams:
+            self.loop.run_until_complete(light.process(telegram))
+
+        self.assertEqual(light.state, True)
+        for color in light._iter_individual_colors():
+            self.assertEqual(color.is_on, True)
 
     #
     # TEST SET OFF

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -42,6 +42,7 @@ class TestWeather(unittest.TestCase):
             group_address_brightness_east="1/3/5",
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
+            group_address_brightness_north="1/3/8",
         )
 
         weather._brightness_east.payload = DPTArray(
@@ -62,6 +63,12 @@ class TestWeather(unittest.TestCase):
                 0x5A,
             )
         )
+        weather._brightness_north.payload = DPTArray(
+            (
+                0x7C,
+                0x5A,
+            )
+        )
 
         self.assertEqual(weather.brightness_east, 366346.24)
         self.assertEqual(weather._brightness_east.unit_of_measurement, "lx")
@@ -74,6 +81,10 @@ class TestWeather(unittest.TestCase):
         self.assertEqual(weather.brightness_south, 365035.52)
         self.assertEqual(weather._brightness_south.unit_of_measurement, "lx")
         self.assertEqual(weather._brightness_south.ha_device_class, "illuminance")
+
+        self.assertEqual(weather.brightness_north, 365035.52)
+        self.assertEqual(weather._brightness_north.unit_of_measurement, "lx")
+        self.assertEqual(weather._brightness_north.ha_device_class, "illuminance")
 
     def test_pressure(self):
         """Test resolve state with pressure."""

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -28,7 +28,7 @@ class StateUpdater:
 
     def register_remote_value(
         self,
-        remote_value: RemoteValue[Any],
+        remote_value: RemoteValue[Any, Any],
         tracker_options: Union[bool, int, float, str] = True,
     ) -> None:
         """Register a RemoteValue to initialize its state and/or track for expiration."""
@@ -110,11 +110,11 @@ class StateUpdater:
         if self.started:
             tracker.start()
 
-    def unregister_remote_value(self, remote_value: RemoteValue[Any]) -> None:
+    def unregister_remote_value(self, remote_value: RemoteValue[Any, Any]) -> None:
         """Unregister a RemoteValue from StateUpdater."""
         self._workers.pop(id(remote_value)).stop()
 
-    def update_received(self, remote_value: RemoteValue[Any]) -> None:
+    def update_received(self, remote_value: RemoteValue[Any, Any]) -> None:
         """Reset the timer when a state update was received."""
         if self.started and id(remote_value) in self._workers:
             self._workers[id(remote_value)].update_received()

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -131,7 +131,7 @@ class Climate(Device):
         if create_temperature_sensors:
             self.create_temperature_sensors()
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield from (
             self.temperature,
@@ -277,13 +277,13 @@ class Climate(Device):
             self.target_temperature.value is not None
             and self._setpoint_shift.value is not None
         ):
-            return self.target_temperature.value - self._setpoint_shift.value  # type: ignore
+            return self.target_temperature.value - self._setpoint_shift.value
         return None
 
     @property
     def setpoint_shift(self) -> Optional[float]:
         """Return current offset from base temperature in Kelvin."""
-        return self._setpoint_shift.value  # type: ignore
+        return self._setpoint_shift.value
 
     def validate_value(
         self, value: float, min_value: Optional[float], max_value: Optional[float]

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -227,7 +227,7 @@ class ClimateMode(Device):
 
     def _iter_remote_values(
         self,
-    ) -> Iterator[RemoteValue[Any]]:
+    ) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate climate mode RemoteValue classes."""
         return chain(
             self._iter_byte_operation_modes(),

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -129,7 +129,7 @@ class Cover(Device):
 
         self.device_class = device_class
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.updown
         yield self.step
@@ -367,7 +367,7 @@ class Cover(Device):
 
     def current_angle(self) -> Optional[int]:
         """Return current tilt angle of cover."""
-        return self.angle.value  # type: ignore
+        return self.angle.value
 
     def is_traveling(self) -> bool:
         """Return if cover is traveling at the moment."""

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -52,7 +52,7 @@ class Device(ABC):
             remote_value.__del__()
 
     @abstractmethod
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         # yield self.remote_value
         # yield from (<list all used RemoteValue instances>)

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -61,7 +61,7 @@ class ExposeSensor(Device):
                 value_type=value_type,
             )
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -89,7 +89,7 @@ class Fan(Device):
             after_update_cb=self.after_update,
         )
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield from (self.speed, self.oscillation)
 
@@ -159,9 +159,9 @@ class Fan(Device):
     @property
     def current_speed(self) -> Optional[int]:
         """Return current speed of fan."""
-        return self.speed.value  # type: ignore
+        return self.speed.value
 
     @property
     def current_oscillation(self) -> Optional[bool]:
         """Return true if the fan is oscillating."""
-        return self.oscillation.value  # type: ignore
+        return self.oscillation.value

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -86,7 +86,7 @@ class _SwitchAndBrightness:
     @property
     def is_on(self) -> Optional[bool]:
         """Return if light is on."""
-        return self.switch.value  # type: ignore
+        return self.switch.value
 
     async def set_on(self) -> None:
         """Switch light on."""
@@ -254,7 +254,7 @@ class Light(Device):
         self.min_kelvin = min_kelvin
         self.max_kelvin = max_kelvin
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.switch
         yield self.brightness
@@ -497,7 +497,7 @@ class Light(Device):
     def state(self) -> Optional[bool]:
         """Return the current switch state of the device."""
         if self.switch.value is not None:
-            return self.switch.value  # type: ignore
+            return self.switch.value
         if any(c.switch.value is not None for c in self._iter_individual_colors()):
             return any(c.switch.value for c in self._iter_individual_colors())
         return None
@@ -519,7 +519,7 @@ class Light(Device):
     @property
     def current_brightness(self) -> Optional[int]:
         """Return current brightness of light."""
-        return self.brightness.value  # type: ignore
+        return self.brightness.value
 
     async def set_brightness(self, brightness: int) -> None:
         """Set brightness of light."""
@@ -592,7 +592,7 @@ class Light(Device):
     @property
     def current_tunable_white(self) -> Optional[int]:
         """Return current relative color temperature of light."""
-        return self.tunable_white.value  # type: ignore
+        return self.tunable_white.value
 
     async def set_tunable_white(self, tunable_white: int) -> None:
         """Set relative color temperature of light."""
@@ -604,7 +604,7 @@ class Light(Device):
     @property
     def current_color_temperature(self) -> Optional[int]:
         """Return current absolute color temperature of light."""
-        return self.color_temperature.value  # type: ignore
+        return self.color_temperature.value
 
     async def set_color_temperature(self, color_temperature: int) -> None:
         """Set absolute color temperature of light."""

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -59,7 +59,7 @@ class Notification(Device):
     @property
     def message(self) -> Optional[str]:
         """Return the current message."""
-        return self._message.value  # type: ignore
+        return self._message.value
 
     async def set(self, message: str) -> None:
         """Set message."""

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -67,7 +67,7 @@ class Sensor(Device):
         self.always_callback = always_callback
         self.ha_value_template = ha_value_template
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -83,7 +83,7 @@ class Switch(Device):
     @property
     def state(self) -> Optional[bool]:
         """Return the current switch state of the device."""
-        return self.switch.value  # type: ignore
+        return self.switch.value
 
     async def set_on(self) -> None:
         """Switch on switch."""

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -231,7 +231,7 @@ class Weather(Device):
         if create_sensors:
             self.create_sensors()
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices remote values."""
         yield self._temperature
         yield self._brightness_south
@@ -260,34 +260,30 @@ class Weather(Device):
     @property
     def brightness_south(self) -> float:
         """Return brightness south."""
-        return (  # type: ignore
-            0.0
-            if self._brightness_south.value is None
-            else self._brightness_south.value
-        )
+        if self._brightness_south.value is not None:
+            return self._brightness_south.value  # type: ignore
+        return 0.0
 
     @property
     def brightness_north(self) -> float:
         """Return brightness north."""
-        return (  # type: ignore
-            0.0
-            if self._brightness_north.value is None
-            else self._brightness_north.value
-        )
+        if self._brightness_north.value is not None:
+            return self._brightness_north.value  # type: ignore
+        return 0.0
 
     @property
     def brightness_east(self) -> float:
         """Return brightness east."""
-        return (  # type: ignore
-            0.0 if self._brightness_east.value is None else self._brightness_east.value
-        )
+        if self._brightness_east.value is not None:
+            return self._brightness_east.value  # type: ignore
+        return 0.0
 
     @property
     def brightness_west(self) -> float:
         """Return brightness west."""
-        return (  # type: ignore
-            0.0 if self._brightness_west.value is None else self._brightness_west.value
-        )
+        if self._brightness_west.value is not None:
+            return self._brightness_west.value  # type: ignore
+        return 0.0
 
     @property
     def wind_speed(self) -> Optional[float]:
@@ -302,22 +298,22 @@ class Weather(Device):
     @property
     def rain_alarm(self) -> Optional[bool]:
         """Return True if rain alarm False if not."""
-        return self._rain_alarm.value  # type: ignore
+        return self._rain_alarm.value
 
     @property
     def wind_alarm(self) -> Optional[bool]:
         """Return True if wind alarm False if not."""
-        return self._wind_alarm.value  # type: ignore
+        return self._wind_alarm.value
 
     @property
     def frost_alarm(self) -> Optional[bool]:
         """Return True if frost alarm False if not."""
-        return self._frost_alarm.value  # type: ignore
+        return self._frost_alarm.value
 
     @property
     def day_night(self) -> Optional[bool]:
         """Return day or night."""
-        return self._day_night.value  # type: ignore
+        return self._day_night.value
 
     @property
     def air_pressure(self) -> Optional[float]:

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -17,6 +17,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    TypeVar,
     Union,
 )
 
@@ -33,9 +34,10 @@ logger = logging.getLogger("xknx.log")
 
 AsyncCallbackType = Callable[[], Awaitable[None]]
 GroupAddressesType = Union["GroupAddressableType", List["GroupAddressableType"]]
+ValueType = TypeVar("ValueType")
 
 
-class RemoteValue(ABC, Generic[DPTPayloadType]):
+class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
     """Class for managing remote knx value."""
 
     # pylint: disable=too-many-instance-attributes
@@ -126,7 +128,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType]):
         """Return payload if telegram payload may be parsed - to be implemented in derived class."""
 
     @abstractmethod
-    def from_knx(self, payload: DPTPayloadType) -> Any:
+    def from_knx(self, payload: DPTPayloadType) -> ValueType:
         """Convert current payload to value - to be implemented in derived class."""
 
     @abstractmethod
@@ -172,7 +174,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType]):
         return True
 
     @property
-    def value(self) -> Any:
+    def value(self) -> Optional[ValueType]:
         """Return current value."""
         if self.payload is None:
             return None

--- a/xknx/remote_value/remote_value_1count.py
+++ b/xknx/remote_value/remote_value_1count.py
@@ -10,7 +10,7 @@ from xknx.dpt import DPTArray, DPTBinary, DPTValue1Count
 from .remote_value import RemoteValue
 
 
-class RemoteValue1Count(RemoteValue[DPTArray]):
+class RemoteValue1Count(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX 6.010 (DPT_Value_1_Count)."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -5,7 +5,7 @@ DPT .
 """
 from abc import abstractmethod
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Generic, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from xknx.dpt import (
     DPTArray,
@@ -24,9 +24,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueClimateModeBase(
-    RemoteValue[DPTPayloadType], Generic[DPTPayloadType, HVACModeType]
-):
+class RemoteValueClimateModeBase(RemoteValue[DPTPayloadType, Optional[HVACModeType]]):
     """Base class for binary climate mode remote values."""
 
     @abstractmethod

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueColorRGB(RemoteValue[DPTArray]):
+class RemoteValueColorRGB(RemoteValue[DPTArray, Tuple[int, int, int]]):
     """Abstraction for remote value of KNX DPT 232.600 (DPT_Color_RGB)."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueColorRGBW(RemoteValue[DPTArray]):
+class RemoteValueColorRGBW(RemoteValue[DPTArray, Tuple[int, int, int, int]]):
     """Abstraction for remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueControl(RemoteValue[DPTBinary]):
+class RemoteValueControl(RemoteValue[DPTBinary, Any]):
     """Abstraction for remote value used for controling."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -24,7 +24,7 @@ class DateTimeType(Enum):
     TIME = DPTTime
 
 
-class RemoteValueDateTime(RemoteValue[DPTArray]):
+class RemoteValueDateTime(RemoteValue[DPTArray, time.struct_time]):
     """Abstraction for remote value of KNX 10.001, 11.001 and 19.001 time and date objects."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray]):
+class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 7.001."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_dpt_value_1_ucount.py
+++ b/xknx/remote_value/remote_value_dpt_value_1_ucount.py
@@ -10,7 +10,7 @@ from xknx.dpt import DPTArray, DPTBinary, DPTValue1Ucount
 from .remote_value import RemoteValue
 
 
-class RemoteValueDptValue1Ucount(RemoteValue[DPTArray]):
+class RemoteValueDptValue1Ucount(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 5.010."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueScaling(RemoteValue[DPTArray]):
+class RemoteValueScaling(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 5.001 (DPT_Scaling)."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_scene_number.py
+++ b/xknx/remote_value/remote_value_scene_number.py
@@ -10,7 +10,7 @@ from xknx.dpt import DPTArray, DPTBinary, DPTSceneNumber
 from .remote_value import RemoteValue
 
 
-class RemoteValueSceneNumber(RemoteValue[DPTArray]):
+class RemoteValueSceneNumber(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 17.001 (DPT_Scene_Number)."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueSensor(RemoteValue[DPTArray]):
+class RemoteValueSensor(RemoteValue[DPTArray, Union[int, float, str]]):
     """Abstraction for many different sensor DPT types."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueSetpointShift(RemoteValue[DPTArray]):
+class RemoteValueSetpointShift(RemoteValue[DPTArray, float]):
     """Abstraction for remote value of KNX DPT 6.010."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueStep(RemoteValue[DPTBinary]):
+class RemoteValueStep(RemoteValue[DPTBinary, "RemoteValueStep.Direction"]):
     """Abstraction for remote value of KNX DPT 1.007 / DPT_Step."""
 
     class Direction(Enum):

--- a/xknx/remote_value/remote_value_string.py
+++ b/xknx/remote_value/remote_value_string.py
@@ -10,7 +10,7 @@ from xknx.dpt import DPTArray, DPTBinary, DPTString
 from .remote_value import RemoteValue
 
 
-class RemoteValueString(RemoteValue[DPTArray]):
+class RemoteValueString(RemoteValue[DPTArray, str]):
     """Abstraction for remote value of KNX 16.000 (DPT_String_ASCII)."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueSwitch(RemoteValue[DPTBinary]):
+class RemoteValueSwitch(RemoteValue[DPTBinary, bool]):
     """Abstraction for remote value of KNX DPT 1.001 / DPT_Switch."""
 
     def __init__(

--- a/xknx/remote_value/remote_value_temp.py
+++ b/xknx/remote_value/remote_value_temp.py
@@ -10,7 +10,7 @@ from xknx.dpt import DPTArray, DPTBinary, DPTTemperature
 from .remote_value import RemoteValue
 
 
-class RemoteValueTemp(RemoteValue[DPTArray]):
+class RemoteValueTemp(RemoteValue[DPTArray, float]):
     """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
 
     # pylint: disable=no-self-use

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueUpDown(RemoteValue[DPTBinary]):
+class RemoteValueUpDown(RemoteValue[DPTBinary, "RemoteValueUpDown.Direction"]):
     """Abstraction for remote value of KNX DPT 1.008 / DPT_UpDown."""
 
     class Direction(Enum):


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Add value type to RemoteValue Generic parameters
so `RemoteValue[DPTArray, float]` would process `DPTArray` and return values of `Optional[float]` (None on init).
see remote_value.py https://github.com/XKNX/xknx/pull/641/files#diff-c1cc580570df2a483ee5154e69d92c7034820c4ec58e3722e2eb49556ec4d7a3

One thing that is not covered is RemoteValueSensor. This is returning a casted `Union[int, float, str]` right now because we can't know the dpt_class.


I have a second idea on how to do this by eager decoding of the payload and storing in an instance variable instead of using the `.value` property. Let's see which one looks better in the end.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
