### PR TITLE
Naming cleanup response_received_event

### DIFF
--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -123,16 +123,16 @@ class TestValueReader:
 
         await value_reader.telegram_received(telegram_wrong_address)
         assert value_reader.received_telegram is None
-        assert not value_reader.success
+        assert not value_reader.response_received_event.is_set()
 
         await value_reader.telegram_received(telegram_wrong_type)
         assert value_reader.received_telegram is None
-        assert not value_reader.success
+        assert not value_reader.response_received_event.is_set()
 
         await value_reader.telegram_received(expected_telegram_1)
         assert value_reader.received_telegram == expected_telegram_1
-        assert value_reader.success
+        assert value_reader.response_received_event.is_set()
 
         await value_reader.telegram_received(expected_telegram_2)
         assert value_reader.received_telegram == expected_telegram_2
-        assert value_reader.success
+        assert value_reader.response_received_event.is_set()

--- a/test/core_tests/value_reader_test.py
+++ b/test/core_tests/value_reader_test.py
@@ -44,7 +44,7 @@ class TestValueReader:
         """Test value reader: read timeout."""
         xknx = XKNX()
         value_reader = ValueReader(xknx, GroupAddress("0/0/0"))
-        value_reader.response_received_or_timeout.wait = MagicMock(
+        value_reader.response_received_event.wait = MagicMock(
             side_effect=asyncio.TimeoutError()
         )
 
@@ -69,7 +69,7 @@ class TestValueReader:
         """Test value reader: read cancelled."""
         xknx = XKNX()
         value_reader = ValueReader(xknx, GroupAddress("0/0/0"))
-        value_reader.response_received_or_timeout.wait = MagicMock(
+        value_reader.response_received_event.wait = MagicMock(
             side_effect=asyncio.CancelledError()
         )
         with pytest.raises(asyncio.CancelledError):

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -133,7 +133,7 @@ class TestGatewayScanner:
         netifaces_mock.interfaces.return_value = []
 
         gateway_scanner = GatewayScanner(xknx)
-        gateway_scanner._response_received_or_timeout.wait = MagicMock(
+        gateway_scanner._response_received_event.wait = MagicMock(
             side_effect=asyncio.TimeoutError()
         )
         timed_out_scan = await gateway_scanner.scan()

--- a/test/io_tests/request_response_test.py
+++ b/test/io_tests/request_response_test.py
@@ -34,7 +34,7 @@ class TestConnectResponse:
         xknx = XKNX()
         udp_client = UDPClient(xknx, ("192.168.1.1", 0), ("192.168.1.2", 1234))
         requ_resp = RequestResponse(xknx, udp_client, KNXIPBody)
-        requ_resp.response_received_or_timeout.wait = MagicMock(
+        requ_resp.response_received_event.wait = MagicMock(
             side_effect=asyncio.TimeoutError()
         )
         await requ_resp.start()
@@ -55,7 +55,7 @@ class TestConnectResponse:
         xknx = XKNX()
         udp_client = UDPClient(xknx, ("192.168.1.1", 0), ("192.168.1.2", 1234))
         requ_resp = RequestResponse(xknx, udp_client, KNXIPBody)
-        requ_resp.response_received_or_timeout.wait = MagicMock(
+        requ_resp.response_received_event.wait = MagicMock(
             side_effect=asyncio.CancelledError()
         )
         with pytest.raises(asyncio.CancelledError):

--- a/xknx/core/payload_reader.py
+++ b/xknx/core/payload_reader.py
@@ -34,14 +34,14 @@ class PayloadReader:
         """Initialize PayloadReader class."""
         self.xknx = xknx
         self.address = address
-        self.response_received_or_timeout = asyncio.Event()
+        self.response_received_event = asyncio.Event()
         self.success: bool = False
         self.timeout_in_seconds = timeout_in_seconds
         self.received_payload: APCI | None = None
 
     def reset(self) -> None:
         """Reset reader for next send."""
-        self.response_received_or_timeout = asyncio.Event()
+        self.response_received_event = asyncio.Event()
         self.success = False
         self.received_payload = None
 
@@ -63,7 +63,7 @@ class PayloadReader:
 
         try:
             await asyncio.wait_for(
-                self.response_received_or_timeout.wait(),
+                self.response_received_event.wait(),
                 timeout=self.timeout_in_seconds,
             )
         except asyncio.TimeoutError:
@@ -101,4 +101,4 @@ class PayloadReader:
                 return
         self.success = True
         self.received_payload = telegram.payload
-        self.response_received_or_timeout.set()
+        self.response_received_event.set()

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -32,7 +32,6 @@ class ValueReader:
         self.xknx = xknx
         self.group_address: GroupAddress = group_address
         self.response_received_event = asyncio.Event()
-        self.success: bool = False
         self.timeout_in_seconds: float = timeout_in_seconds
         self.received_telegram: Telegram | None = None
 
@@ -55,13 +54,13 @@ class ValueReader:
                 self.timeout_in_seconds,
                 self.group_address,
             )
+        else:
+            return self.received_telegram
         finally:
             # cleanup to not leave callbacks (for asyncio.CancelledError)
             self.xknx.telegram_queue.unregister_telegram_received_cb(cb_obj)
 
-        if not self.success:
-            return None
-        return self.received_telegram
+        return None
 
     async def send_group_read(self) -> None:
         """Send group read."""
@@ -75,6 +74,5 @@ class ValueReader:
         if telegram.destination_address == self.group_address and isinstance(
             telegram.payload, (GroupValueResponse, GroupValueWrite)
         ):
-            self.success = True
             self.received_telegram = telegram
             self.response_received_event.set()

--- a/xknx/core/value_reader.py
+++ b/xknx/core/value_reader.py
@@ -31,7 +31,7 @@ class ValueReader:
         """Initialize ValueReader class."""
         self.xknx = xknx
         self.group_address: GroupAddress = group_address
-        self.response_received_or_timeout = asyncio.Event()
+        self.response_received_event = asyncio.Event()
         self.success: bool = False
         self.timeout_in_seconds: float = timeout_in_seconds
         self.received_telegram: Telegram | None = None
@@ -46,7 +46,7 @@ class ValueReader:
 
         try:
             await asyncio.wait_for(
-                self.response_received_or_timeout.wait(),
+                self.response_received_event.wait(),
                 timeout=self.timeout_in_seconds,
             )
         except asyncio.TimeoutError:
@@ -77,4 +77,4 @@ class ValueReader:
         ):
             self.success = True
             self.received_telegram = telegram
-            self.response_received_or_timeout.set()
+            self.response_received_event.set()

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -111,7 +111,7 @@ class GatewayScanner:
         self.scan_filter = scan_filter
         self.found_gateways: list[GatewayDescriptor] = []
         self._udp_clients: list[UDPClient] = []
-        self._response_received_or_timeout = asyncio.Event()
+        self._response_received_event = asyncio.Event()
         self._count_upper_bound = 0
         """Clean value of self.stop_on_found, computed when ``scan`` is called."""
 
@@ -124,7 +124,7 @@ class GatewayScanner:
         await self._send_search_requests()
         try:
             await asyncio.wait_for(
-                self._response_received_or_timeout.wait(),
+                self._response_received_event.wait(),
                 timeout=self.timeout_in_seconds,
             )
         except asyncio.TimeoutError:
@@ -206,4 +206,4 @@ class GatewayScanner:
         if self.scan_filter.match(gateway):
             self.found_gateways.append(gateway)
             if 0 < self._count_upper_bound <= len(self.found_gateways):
-                self._response_received_or_timeout.set()
+                self._response_received_event.set()

--- a/xknx/io/request_response/request_response.py
+++ b/xknx/io/request_response/request_response.py
@@ -32,7 +32,7 @@ class RequestResponse:
         self.xknx = xknx
         self.udpclient = udp_client
         self.awaited_response_class: type[KNXIPBodyResponse] = awaited_response_class
-        self.response_received_or_timeout = asyncio.Event()
+        self.response_received_event = asyncio.Event()
         self.success = False
         self.timeout_in_seconds = timeout_in_seconds
 
@@ -51,7 +51,7 @@ class RequestResponse:
 
         try:
             await asyncio.wait_for(
-                self.response_received_or_timeout.wait(),
+                self.response_received_event.wait(),
                 timeout=self.timeout_in_seconds,
             )
         except asyncio.TimeoutError:
@@ -74,7 +74,7 @@ class RequestResponse:
             logger.warning("Could not understand knxipframe")
             return
         self.response_status_code = knxipframe.body.status_code
-        self.response_received_or_timeout.set()
+        self.response_received_event.set()
         if knxipframe.body.status_code == ErrorCode.E_NO_ERROR:
             self.success = True
             self.on_success_hook(knxipframe)


### PR DESCRIPTION
- rename `response_received_or_timeout` to `response_received_event`
The timeout does no longer trigger the event so the name is misleading.
The new name makes it more visible that is is an asyncio.Event.
- remove unnecessary `success` attribute 
`self.received_* is  not None` and the Event being set implies that `self.success is True` so we can assume success when the Event fires.
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
