### PR TITLE
ClimateMode: fix telegram processing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Bugfix
+
+- ClimateMode: fix telegram processing operation mode and controller mode (heat/cool) are both used
+
 ## 0.18.3 XYY colors 2021-05-30
 
 ### Devices

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1163,6 +1163,7 @@ class TestClimate:
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
+            group_address_operation_mode="i-op-mode",
             group_address_heat_cool="1/2/14",
             group_address_heat_cool_state="1/2/15",
         )

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -159,16 +159,12 @@ class ClimateMode(Device):
 
         self.supports_operation_mode = any(
             operation_mode.initialized
-            for operation_mode in self._iter_byte_operation_modes()
-        ) or any(
-            operation_mode.initialized
-            for operation_mode in self._iter_binary_operation_modes()
+            for operation_mode in self._iter_operation_remote_values()
         )
         self.supports_controller_mode = any(
-            operation_mode.initialized
-            for operation_mode in self._iter_controller_remote_values()
+            controller_mode.initialized
+            for controller_mode in self._iter_controller_remote_values()
         )
-
         self._use_binary_operation_modes = any(
             operation_mode.initialized
             for operation_mode in self._iter_binary_operation_modes()
@@ -245,9 +241,7 @@ class ClimateMode(Device):
             )
 
         rv_operation: RemoteValueClimateModeBase[Any, HVACOperationMode]
-        for rv_operation in chain(
-            self._iter_byte_operation_modes(), self._iter_binary_operation_modes()
-        ):
+        for rv_operation in self._iter_operation_remote_values():
             if (
                 rv_operation.writable
                 and operation_mode in rv_operation.supported_operation_modes()
@@ -293,9 +287,7 @@ class ClimateMode(Device):
     def gather_operation_modes(self) -> list[HVACOperationMode]:
         """Gather operation modes from RemoteValues."""
         operation_modes: list[HVACOperationMode] = []
-        for rv_operation in chain(
-            self._iter_binary_operation_modes(), self._iter_byte_operation_modes()
-        ):
+        for rv_operation in self._iter_operation_remote_values():
             if rv_operation.writable:
                 operation_modes.extend(rv_operation.supported_operation_modes())
         # remove duplicates


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
ClimateMode: fix telegram processing operation mode and controller mode (heat/cool) are both used

Previously a telegram to a controller mode would return `ClimateMode.process()` wthout awaiting `self._set_internal_controller_mode()`

Fixes https://github.com/home-assistant/core/issues/44502

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
