### PR TITLE
DPTNumeric

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased changes
+
+### Internals
+
+- `DPTBase.parse_transcoder` is now a classmethod to allow parsing only subclasses.
+- Add `DPTNumeric` as base class for DPTs representing numeric values.
+
 ## 0.18.4 ClimateMode bugfix 2021-06-04
 
 ### Bugfix

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -5,7 +5,7 @@ Module for encoding and decoding KNX datatypes.
 * Derived KNX Values like Scaling, Temperature
 """
 # flake8: noqa
-from .dpt import DPTArray, DPTBase, DPTBinary
+from .dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric
 from .dpt_1byte_signed import DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count
 from .dpt_1byte_uint import (
     DPTDecimalFactor,
@@ -268,6 +268,7 @@ __all__ = [
     "DPTMassFlux",
     "DPTMol",
     "DPTMomentum",
+    "DPTNumeric",
     "DPTPartsPerMillion",
     "DPTPercentU8",
     "DPTPercentV16",

--- a/xknx/dpt/dpt_1byte_signed.py
+++ b/xknx/dpt/dpt_1byte_signed.py
@@ -3,23 +3,25 @@ from __future__ import annotations
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPTSignedRelativeValue(DPTBase):
+class DPTSignedRelativeValue(DPTNumeric):
     """
     Abstraction for KNX 1 Byte "1-octet Signed Relative Value".
 
     DPT 6.***
     """
 
-    value_min = -128
-    value_max = 127
     dpt_main_number = 6
     dpt_sub_number: int | None = None
     value_type = "1byte_signed"
     unit = ""
     payload_length = 1
+
+    value_min = -128
+    value_max = 127
+    resolution = 1
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -30,7 +32,7 @@ class DPTSignedRelativeValue(DPTBase):
         return raw[0]
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)

--- a/xknx/dpt/dpt_1byte_uint.py
+++ b/xknx/dpt/dpt_1byte_uint.py
@@ -3,24 +3,25 @@ from __future__ import annotations
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPTValue1ByteUnsigned(DPTBase):
+class DPTValue1ByteUnsigned(DPTNumeric):
     """
     Abstraction for KNX 1 Octet.
 
     DPT 5.***
     """
 
-    value_min = 0
-    value_max = 255
     dpt_main_number = 5
     dpt_sub_number: int | None = None
     value_type = "1byte_unsigned"
     unit = ""
-    resolution = 1
     payload_length = 1
+
+    value_min = 0
+    value_max = 255
+    resolution = 1
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -37,7 +38,7 @@ class DPTValue1ByteUnsigned(DPTBase):
         return value
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -111,12 +112,13 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
     DPT 17.001
     """
 
-    value_min = 1
-    value_max = 64
     dpt_main_number = 17
     dpt_sub_number = 1
     value_type = "scene_number"
     unit = ""
+
+    value_min = 1
+    value_max = 64
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -133,7 +135,7 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
         return value
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> tuple[int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value) - 1

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -7,24 +7,25 @@ from __future__ import annotations
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPT2ByteFloat(DPTBase):
+class DPT2ByteFloat(DPTNumeric):
     """
     Abstraction for KNX 2 Octet Floating Point Numbers.
 
     DPT 9.***
     """
 
-    value_min = -671088.64
-    value_max = 670760.96
     dpt_main_number = 9
     dpt_sub_number: int | None = None
     value_type = "2byte_float"
     unit = ""
-    resolution = 0.01
     payload_length = 2
+
+    value_min = -671088.64
+    value_max = 670760.96
+    resolution = 0.01
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> float:
@@ -87,83 +88,90 @@ class DPT2ByteFloat(DPTBase):
 class DPTTemperature(DPT2ByteFloat):
     """DPT 9.001 DPT_Value_Temp."""
 
-    value_min = -273
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 1
     value_type = "temperature"
     unit = "°C"
     ha_device_class = "temperature"
 
+    value_min = -273
+    value_max = 670760
+
 
 class DPTTemperatureDifference2Byte(DPT2ByteFloat):
     """DPT 9.002 DPT_Value_Tempd."""
 
-    value_min = -670760
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 2
     value_type = "temperature_difference_2byte"
     unit = "K"
     ha_device_class = "temperature"
 
+    value_min = -670760
+    value_max = 670760
+
 
 class DPTTemperatureA(DPT2ByteFloat):
     """DPT 9.003 DPT_Value_Tempa."""
 
-    value_min = -670760
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 3
     value_type = "temperature_a"
     unit = "K/h"
 
+    value_min = -670760
+    value_max = 670760
+
 
 class DPTLux(DPT2ByteFloat):
     """DPT 9.004 DPT_Value_Lux."""
 
-    value_min = 0
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 4
     value_type = "illuminance"
     unit = "lx"
     ha_device_class = "illuminance"
 
+    value_min = 0
+    value_max = 670760
+
 
 class DPTWsp(DPT2ByteFloat):
     """DPT 9.005 DPT_Value_Ws Speed (m/s)."""
 
-    value_min = 0
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 5
     value_type = "wind_speed_ms"
     unit = "m/s"
 
+    value_min = 0
+    value_max = 670760
+
 
 class DPTPressure2Byte(DPT2ByteFloat):
     """DPT 9.006 DPT_Value_Pres (Pa)."""
 
-    value_min = 0
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 6
     value_type = "pressure_2byte"
     unit = "Pa"
     ha_device_class = "pressure"
 
+    value_min = 0
+    value_max = 670760
+
 
 class DPTHumidity(DPT2ByteFloat):
     """DPT 9.007 DPT_Value_Humidity."""
 
-    value_min = 0
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 7
     value_type = "humidity"
     unit = "%"
     ha_device_class = "humidity"
+
+    value_min = 0
+    value_max = 670760
 
 
 class DPTPartsPerMillion(DPT2ByteFloat):
@@ -178,23 +186,25 @@ class DPTPartsPerMillion(DPT2ByteFloat):
 class DPTTime1(DPT2ByteFloat):
     """DPT 9.010 DPT_Value_Time1 (s)."""
 
-    value_min = -670760
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 10
     value_type = "time_1"
     unit = "s"
 
+    value_min = -670760
+    value_max = 670760
+
 
 class DPTTime2(DPT2ByteFloat):
     """DPT 9.011 DPT_Value_Time2 (ms)."""
 
-    value_min = -670760
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 11
     value_type = "time_2"
     unit = "ms"
+
+    value_min = -670760
+    value_max = 670760
 
 
 class DPTVoltage(DPT2ByteFloat):
@@ -255,35 +265,38 @@ class DPTVolumeFlow(DPT2ByteFloat):
 class DPTRainAmount(DPT2ByteFloat):
     """DPT 9.026 DPT_Rain_Amount (l/m²)."""
 
-    value_min = -671088.64
-    value_max = 670760.96
     dpt_main_number = 9
     dpt_sub_number = 26
     value_type = "rain_amount"
     unit = "l/m²"
 
+    value_min = -671088.64
+    value_max = 670760.96
+
 
 class DPTTemperatureF(DPT2ByteFloat):
     """DPT 9.027 DPT_Value_Temp_F."""
 
-    value_min = -459.6
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 27
     value_type = "temperature_f"
     unit = "°F"
     ha_device_class = "temperature"
 
+    value_min = -459.6
+    value_max = 670760
+
 
 class DPTWspKmh(DPT2ByteFloat):
     """DPT 9.028 DPT_Value_Wsp_kmh Speed (km/h)."""
 
-    value_min = 0
-    value_max = 670760
     dpt_main_number = 9
     dpt_sub_number = 28
     value_type = "wind_speed_kmh"
     unit = "km/h"
+
+    value_min = 0
+    value_max = 670760
 
 
 class DPTEnthalpy(DPT2ByteFloat):

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -10,24 +10,25 @@ import struct
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPT2ByteSigned(DPTBase):
+class DPT2ByteSigned(DPTNumeric):
     """
     Abstraction for KNX 2 Byte signed values.
 
     DPT 8.***
     """
 
-    value_min = -32768
-    value_max = 32767
     dpt_main_number = 8
     dpt_sub_number: int | None = None
     value_type = "2byte_signed"
     unit = ""
-    resolution: float = 1
     payload_length = 2
+
+    value_min = -32768
+    value_max = 32767
+    resolution = 1
 
     _struct_format = ">h"
 
@@ -42,7 +43,7 @@ class DPT2ByteSigned(DPTBase):
             raise ConversionError("Could not parse %s" % cls.__name__, raw=raw)
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int, ...]:
+    def to_knx(cls, value: int | float) -> tuple[int, ...]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -83,7 +84,6 @@ class DPTDeltaTime10Msec(DPT2ByteSigned):
     dpt_sub_number = 3
     value_type = "delta_time_10ms"
     unit = "ms"
-    resolution = 10
 
 
 class DPTDeltaTime100Msec(DPT2ByteSigned):
@@ -93,7 +93,6 @@ class DPTDeltaTime100Msec(DPT2ByteSigned):
     dpt_sub_number = 4
     value_type = "delta_time_100ms"
     unit = "ms"
-    resolution = 100
 
 
 class DPTDeltaTimeSec(DPT2ByteSigned):
@@ -130,7 +129,6 @@ class DPTPercentV16(DPT2ByteSigned):
     dpt_sub_number = 10
     value_type = "percentV16"
     unit = "%"
-    resolution = 0.01
 
 
 class DPTRotationAngle(DPT2ByteSigned):

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPT2ByteUnsigned(DPTBase):
+class DPT2ByteUnsigned(DPTNumeric):
     """
     Abstraction for KNX 2 Byte "2-octet unsigned value".
 
@@ -15,14 +15,15 @@ class DPT2ByteUnsigned(DPTBase):
     DPT 7.***
     """
 
-    value_min = 0
-    value_max = 65535
     dpt_main_number = 7
     dpt_sub_number: int | None = None
     value_type = "2byte_unsigned"
     unit = ""
-    resolution = 1
     payload_length = 2
+
+    value_min = 0
+    value_max = 65535
+    resolution = 1
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -31,7 +32,7 @@ class DPT2ByteUnsigned(DPTBase):
         return (raw[0] * 256) + raw[1]
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int, int]:
+    def to_knx(cls, value: int | float) -> tuple[int, int]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -72,7 +73,6 @@ class DPTTimePeriod10Msec(DPT2ByteUnsigned):
     dpt_sub_number = 3
     value_type = "time_period_10msec"
     unit = "ms"
-    resolution = 10
 
 
 class DPTTimePeriod100Msec(DPT2ByteUnsigned):
@@ -82,7 +82,6 @@ class DPTTimePeriod100Msec(DPT2ByteUnsigned):
     dpt_sub_number = 4
     value_type = "time_period_100msec"
     unit = "ms"
-    resolution = 100
 
 
 class DPTTimePeriodSec(DPT2ByteUnsigned):

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -11,10 +11,10 @@ from typing import cast
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPT4ByteFloat(DPTBase):
+class DPT4ByteFloat(DPTNumeric):
     """
     Abstraction for KNX 4 Octet Floating Point Numbers, with a maximum usable range as specified in IEEE 754.
 
@@ -31,6 +31,10 @@ class DPT4ByteFloat(DPTBase):
     value_type = "4byte_float"
     unit = ""
     payload_length = 4
+
+    value_min = float("-inf")
+    value_max = float("inf")
+    resolution = 0.0000001
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> float:

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -11,24 +11,25 @@ import struct
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPT4ByteUnsigned(DPTBase):
+class DPT4ByteUnsigned(DPTNumeric):
     """
     Abstraction for KNX 4 Byte "32-bit unsigned".
 
     DPT 12.***
     """
 
-    value_min = 0
-    value_max = 4294967295
     dpt_main_number = 12
     dpt_sub_number: int | None = None
     value_type = "4byte_unsigned"
     unit = ""
-    resolution: float = 1
     payload_length = 4
+
+    value_min = 0
+    value_max = 4294967295
+    resolution = 1
 
     _struct_format = ">I"
 
@@ -43,7 +44,7 @@ class DPT4ByteUnsigned(DPTBase):
             raise ConversionError("Could not parse %s" % cls.__name__, raw=raw)
 
     @classmethod
-    def to_knx(cls, value: int) -> tuple[int, ...]:
+    def to_knx(cls, value: int | float) -> tuple[int, ...]:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -66,13 +67,14 @@ class DPT4ByteSigned(DPT4ByteUnsigned):
     DPT 13.***
     """
 
-    value_min = -2147483648
-    value_max = 2147483647
     dpt_main_number = 13
     dpt_sub_number: int | None = None
     value_type = "4byte_signed"
     unit = ""
-    resolution: float = 1
+
+    value_min = -2147483648
+    value_max = 2147483647
+    resolution = 1
 
     _struct_format = ">i"
 
@@ -111,7 +113,6 @@ class DPTFlowRateM3H(DPT4ByteSigned):
     dpt_sub_number = 2
     value_type = "flow_rate_m3h"
     unit = "m³/h"
-    resolution = 0.0001
 
 
 class DPTActiveEnergy(DPT4ByteSigned):

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -21,7 +21,7 @@ class DPTScaling(DPTNumeric):
 
     value_min = 0
     value_max = 100
-    resolution = 100 / 255
+    resolution = 1
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -73,4 +73,4 @@ class DPTAngle(DPTScaling):
 
     value_min = 0
     value_max = 360
-    resolution = 360 / 255
+    resolution = 1

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -3,24 +3,25 @@ from __future__ import annotations
 
 from xknx.exceptions import ConversionError
 
-from .dpt import DPTBase
+from .dpt import DPTNumeric
 
 
-class DPTScaling(DPTBase):
+class DPTScaling(DPTNumeric):
     """
     Abstraction for KNX 1 Octet Percent.
 
     DPT 5.001
     """
 
-    value_min = 0
-    value_max = 100
-    resolution = 100 / 255
     dpt_main_number = 5
     dpt_sub_number = 1
     value_type = "percent"
     unit = "%"
     payload_length = 1
+
+    value_min = 0
+    value_max = 100
+    resolution = 100 / 255
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> int:
@@ -65,10 +66,11 @@ class DPTAngle(DPTScaling):
     DPT 5.003
     """
 
-    value_min = 0
-    value_max = 360
-    resolution = 360 / 255
     dpt_main_number = 5
     dpt_sub_number = 3
     value_type = "angle"
     unit = "°"
+
+    value_min = 0
+    value_max = 360
+    resolution = 360 / 255


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Add a common base class for all numeric DPT definitions. 

- `DPTBase.parse_transcoder` is now a classmethod to allow parsing only subclasses.
- Add `DPTNumeric` as base class for DPTs representing numeric values.

This allows to check for DPTNumeric e.g. in ReomteValueSensor by `issubclass(dpt_class, DPTNumeric)` and parsing value_types that guarantee to accept and return `int | float` by `DPTNumeric.parse_transcoder(value_type)`

I want to use this for HAs expose values and for a number entity.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
