### PR TITLE
add `respond_to_read` option to Switch

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Devices
+
+- Add `respond` option to Switch. If `True` GroupValueRead telegrams to the `group_address` are answered.
+
 ### Internals
 
 - fix DPTBase classmethod return types

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -17,6 +17,7 @@ Switches are simple representations of binary actors. They mainly support switch
 - `name` is the name of the object.
 - `group_address` is the KNX group address of the switch device. Used for sending.
 - `group_address_state` is the KNX group address of the switch state. Used for updating and reading state.
+- `respond` if `True` GroupValueRead requests to the `group_address` are answered. Defaults to `False`
 - `invert` inverts the payload so state "on" is represented by 0 on bus and "off" by 1. Defaults to `False`
 - `reset_after` may be used to reset the switch to `OFF` again after given time in sec. Defaults to `None`
 - `device_updated_cb` awaitable callback for each update.

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -17,7 +17,7 @@ Switches are simple representations of binary actors. They mainly support switch
 - `name` is the name of the object.
 - `group_address` is the KNX group address of the switch device. Used for sending.
 - `group_address_state` is the KNX group address of the switch state. Used for updating and reading state.
-- `respond` if `True` GroupValueRead requests to the `group_address` are answered. Defaults to `False`
+- `respond_to_read` if `True` GroupValueRead requests to the `group_address` are answered. Defaults to `False`
 - `invert` inverts the payload so state "on" is represented by 0 on bus and "off" by 1. Defaults to `False`
 - `reset_after` may be used to reset the switch to `OFF` again after given time in sec. Defaults to `None`
 - `device_updated_cb` awaitable callback for each update.

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -226,27 +226,27 @@ class TestSwitch:
     #
     # TEST RESPOND
     #
-    async def test_respond(self):
-        """Test respond function."""
+    async def test_respond_to_read(self):
+        """Test respond_to_read function."""
         xknx = XKNX()
         responding = Switch(
             xknx,
             "TestSensor1",
             group_address="1/1/1",
-            respond=True,
+            respond_to_read=True,
         )
         non_responding = Switch(
             xknx,
             "TestSensor2",
             group_address="1/1/1",
-            respond=False,
+            respond_to_read=False,
         )
         responding_multiple = Switch(
             xknx,
             "TestSensor3",
             group_address=["1/1/1", "3/3/3"],
             group_address_state="2/2/2",
-            respond=True,
+            respond_to_read=True,
         )
         #  set initial payload of Switch
         responding.switch.value = True

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -224,6 +224,71 @@ class TestSwitch:
         after_update_callback.assert_called_with(switch)
 
     #
+    # TEST RESPOND
+    #
+    async def test_respond(self):
+        """Test respond function."""
+        xknx = XKNX()
+        responding = Switch(
+            xknx,
+            "TestSensor1",
+            group_address="1/1/1",
+            respond=True,
+        )
+        non_responding = Switch(
+            xknx,
+            "TestSensor2",
+            group_address="1/1/1",
+            respond=False,
+        )
+        responding_multiple = Switch(
+            xknx,
+            "TestSensor3",
+            group_address=["1/1/1", "3/3/3"],
+            group_address_state="2/2/2",
+            respond=True,
+        )
+        #  set initial payload of Switch
+        responding.switch.value = True
+        non_responding.switch.value = True
+        responding_multiple.switch.value = True
+
+        read_telegram = Telegram(
+            destination_address=GroupAddress("1/1/1"), payload=GroupValueRead()
+        )
+        # verify no response when respond is False
+        await non_responding.process(read_telegram)
+        assert xknx.telegrams.qsize() == 0
+
+        # verify response when respond is True
+        await responding.process(read_telegram)
+        assert xknx.telegrams.qsize() == 1
+        response = xknx.telegrams.get_nowait()
+        assert response == Telegram(
+            destination_address=GroupAddress("1/1/1"),
+            payload=GroupValueResponse(DPTBinary(True)),
+        )
+        # verify no response when GroupValueRead request is not for group_address
+        await responding_multiple.process(read_telegram)
+        assert xknx.telegrams.qsize() == 1
+        response = xknx.telegrams.get_nowait()
+        assert response == Telegram(
+            destination_address=GroupAddress("1/1/1"),
+            payload=GroupValueResponse(DPTBinary(True)),
+        )
+        await responding_multiple.process(
+            Telegram(
+                destination_address=GroupAddress("2/2/2"), payload=GroupValueRead()
+            )
+        )
+        await responding_multiple.process(
+            Telegram(
+                destination_address=GroupAddress("3/3/3"), payload=GroupValueRead()
+            )
+        )
+        assert xknx.telegrams.qsize() == 0
+
+    #
     # TEST SET ON
     #
     async def test_set_on(self):

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -32,7 +32,7 @@ class Switch(Device):
         name: str,
         group_address: GroupAddressesType | None = None,
         group_address_state: GroupAddressesType | None = None,
-        respond: bool = False,
+        respond_to_read: bool = False,
         invert: bool = False,
         reset_after: float | None = None,
         device_updated_cb: DeviceCallbackType | None = None,
@@ -42,7 +42,7 @@ class Switch(Device):
 
         self.reset_after = reset_after
         self._reset_task: asyncio.Task[None] | None = None
-        self.respond = respond
+        self.respond_to_read = respond_to_read
         self.switch = RemoteValueSwitch(
             xknx,
             group_address,
@@ -95,7 +95,10 @@ class Switch(Device):
 
     async def process_group_read(self, telegram: "Telegram") -> None:
         """Process incoming GroupValueResponse telegrams."""
-        if self.respond and telegram.destination_address == self.switch.group_address:
+        if (
+            self.respond_to_read
+            and telegram.destination_address == self.switch.group_address
+        ):
             await self.switch.respond()
 
     async def _reset_state(self, wait_seconds: float) -> None:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Allows a Switch device to optionally respond to GroupValueRead requests.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
