### PR TITLE
Cover: set_up / set_down with position GA only

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Devices
+
+- Cover: enable `set_up` and `set_down` with `group_address_position` only (without `group_address_long`).
+
 ## 0.18.7 RawValue 2021-06-18
 
 ### Devices

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -432,13 +432,11 @@ class TestCover:
         await cover_short_stop.stop()
         assert xknx.telegrams.qsize() == 2
         telegram = xknx.telegrams.get_nowait()
-        print(telegram)
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray(0xFF)),
         )
         telegram = xknx.telegrams.get_nowait()
-        print(telegram)
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTBinary(1)),
@@ -449,13 +447,11 @@ class TestCover:
         await cover_short_stop.stop()
         assert xknx.telegrams.qsize() == 2
         telegram = xknx.telegrams.get_nowait()
-        print(telegram)
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray(0x00)),
         )
         telegram = xknx.telegrams.get_nowait()
-        print(telegram)
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTBinary(0)),
@@ -481,6 +477,36 @@ class TestCover:
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray(0x80)),
+        )
+
+    async def test_position_without_binary(self):
+        """Test moving cover - with no binary positioning supported."""
+        xknx = XKNX()
+        cover = Cover(
+            xknx,
+            "TestCover",
+            group_address_position="1/2/3",
+        )
+        await cover.set_down()
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0xFF)),
+        )
+        await cover.set_position(50)
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x80)),
+        )
+        await cover.set_up()
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x00)),
         )
 
     async def test_position_without_position_address_up(self):

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -174,17 +174,23 @@ class Cover(Device):
 
     async def set_down(self) -> None:
         """Move cover down."""
-        await self.updown.down()
-        self.travelcalculator.start_travel_down()
-        self.travel_direction_tilt = None
-        await self.after_update()
+        if self.updown.writable:
+            await self.updown.down()
+            self.travelcalculator.start_travel_down()
+            self.travel_direction_tilt = None
+            await self.after_update()
+        elif self.position_target.writable:
+            await self.position_target.set(self.travelcalculator.position_closed)
 
     async def set_up(self) -> None:
         """Move cover up."""
-        await self.updown.up()
-        self.travelcalculator.start_travel_up()
-        self.travel_direction_tilt = None
-        await self.after_update()
+        if self.updown.writable:
+            await self.updown.up()
+            self.travelcalculator.start_travel_up()
+            self.travel_direction_tilt = None
+            await self.after_update()
+        elif self.position_target.writable:
+            await self.position_target.set(self.travelcalculator.position_open)
 
     async def set_short_down(self) -> None:
         """Move cover short down."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Enables cover to set_up / set_down with `group_address_position` only. The cover device maintains same functionality regardless if `group_address_long` is set.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [x] The Homeassistant plugin has been adjusted in case of new config options
it already assumes this is possible 🙃
