### PR TITLE
Ignore non-gateway KNX/IP devices in GatewayScanner

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 ### Internals
 
-- GatewayScanFilter: Treat `tunnelling` and `routing` attributes as OR when both are `True`.
+- GatewayScanFilter: Ignore non-gateway KNX/IP devices
 
 ## 0.18.9 HS-color 2021-07-26
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Internals
+
+- GatewayScanFilter: Treat `tunnelling` and `routing` attributes as OR when both are `True`.
+
 ## 0.18.9 HS-color 2021-07-26
 
 ### Devices

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -48,6 +48,15 @@ class TestGatewayScanner:
         supports_tunnelling=True,
         supports_routing=True,
     )
+    gateway_desc_neither = GatewayDescriptor(
+        name="AC/S 1.1.1 Application Control",
+        ip_addr="10.1.1.15",
+        port=3671,
+        local_interface="en1",
+        local_ip="192.168.42.50",
+        supports_tunnelling=False,
+        supports_routing=False,
+    )
 
     fake_interfaces = ["lo0", "en0", "en1"]
     fake_ifaddresses = {
@@ -93,22 +102,38 @@ class TestGatewayScanner:
         filter_router = GatewayScanFilter(routing=True)
         filter_name = GatewayScanFilter(name="KNX-Router")
         filter_no_tunnel = GatewayScanFilter(tunnelling=False)
+        filter_no_router = GatewayScanFilter(routing=False)
+        filter_tunnel_or_router = GatewayScanFilter(tunnelling=True, routing=True)
 
         assert filter_tunnel.match(self.gateway_desc_interface)
         assert not filter_tunnel.match(self.gateway_desc_router)
         assert filter_tunnel.match(self.gateway_desc_both)
+        assert not filter_tunnel.match(self.gateway_desc_neither)
 
         assert not filter_router.match(self.gateway_desc_interface)
         assert filter_router.match(self.gateway_desc_router)
         assert filter_router.match(self.gateway_desc_both)
+        assert not filter_router.match(self.gateway_desc_neither)
 
         assert not filter_name.match(self.gateway_desc_interface)
         assert filter_name.match(self.gateway_desc_router)
         assert not filter_name.match(self.gateway_desc_both)
+        assert not filter_name.match(self.gateway_desc_neither)
 
         assert not filter_no_tunnel.match(self.gateway_desc_interface)
         assert filter_no_tunnel.match(self.gateway_desc_router)
         assert not filter_no_tunnel.match(self.gateway_desc_both)
+        assert filter_no_tunnel.match(self.gateway_desc_neither)
+
+        assert filter_no_router.match(self.gateway_desc_interface)
+        assert not filter_no_router.match(self.gateway_desc_router)
+        assert not filter_no_router.match(self.gateway_desc_both)
+        assert filter_no_router.match(self.gateway_desc_neither)
+
+        assert filter_tunnel_or_router.match(self.gateway_desc_interface)
+        assert filter_tunnel_or_router.match(self.gateway_desc_router)
+        assert filter_tunnel_or_router.match(self.gateway_desc_both)
+        assert not filter_tunnel_or_router.match(self.gateway_desc_neither)
 
     def test_search_response_reception(self):
         """Test function of gateway scanner."""

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -98,12 +98,18 @@ class TestGatewayScanner:
 
     def test_gateway_scan_filter_match(self):
         """Test match function of gateway filter."""
+        filter_default = GatewayScanFilter()
         filter_tunnel = GatewayScanFilter(tunnelling=True)
         filter_router = GatewayScanFilter(routing=True)
         filter_name = GatewayScanFilter(name="KNX-Router")
         filter_no_tunnel = GatewayScanFilter(tunnelling=False)
         filter_no_router = GatewayScanFilter(routing=False)
-        filter_tunnel_or_router = GatewayScanFilter(tunnelling=True, routing=True)
+        filter_tunnel_and_router = GatewayScanFilter(tunnelling=True, routing=True)
+
+        assert filter_default.match(self.gateway_desc_interface)
+        assert filter_default.match(self.gateway_desc_router)
+        assert filter_default.match(self.gateway_desc_both)
+        assert not filter_default.match(self.gateway_desc_neither)
 
         assert filter_tunnel.match(self.gateway_desc_interface)
         assert not filter_tunnel.match(self.gateway_desc_router)
@@ -123,17 +129,17 @@ class TestGatewayScanner:
         assert not filter_no_tunnel.match(self.gateway_desc_interface)
         assert filter_no_tunnel.match(self.gateway_desc_router)
         assert not filter_no_tunnel.match(self.gateway_desc_both)
-        assert filter_no_tunnel.match(self.gateway_desc_neither)
+        assert not filter_no_tunnel.match(self.gateway_desc_neither)
 
         assert filter_no_router.match(self.gateway_desc_interface)
         assert not filter_no_router.match(self.gateway_desc_router)
         assert not filter_no_router.match(self.gateway_desc_both)
-        assert filter_no_router.match(self.gateway_desc_neither)
+        assert not filter_no_router.match(self.gateway_desc_neither)
 
-        assert filter_tunnel_or_router.match(self.gateway_desc_interface)
-        assert filter_tunnel_or_router.match(self.gateway_desc_router)
-        assert filter_tunnel_or_router.match(self.gateway_desc_both)
-        assert not filter_tunnel_or_router.match(self.gateway_desc_neither)
+        assert not filter_tunnel_and_router.match(self.gateway_desc_interface)
+        assert not filter_tunnel_and_router.match(self.gateway_desc_router)
+        assert filter_tunnel_and_router.match(self.gateway_desc_both)
+        assert not filter_tunnel_and_router.match(self.gateway_desc_neither)
 
     def test_search_response_reception(self):
         """Test function of gateway scanner."""

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -67,7 +67,10 @@ class GatewayDescriptor:
 
 
 class GatewayScanFilter:
-    """Filter to limit gateway scan attempts."""
+    """Filter to limit gateway scan attempts.
+
+    If `tunnelling` and `routing` are True it is treated as OR.
+    """
 
     def __init__(
         self,
@@ -84,14 +87,13 @@ class GatewayScanFilter:
         """Check whether the given GatewayDescriptor matches the filter."""
         if self.name is not None and self.name != gateway.name:
             return False
-        if (
-            self.tunnelling is not None
-            and self.tunnelling != gateway.supports_tunnelling
-        ):
-            return False
-        if self.routing is not None and self.routing != gateway.supports_routing:
-            return False
-        return True
+        if self.tunnelling is None and self.routing is None:
+            return True
+        if self.tunnelling is gateway.supports_tunnelling:
+            return True
+        if self.routing is gateway.supports_routing:
+            return True
+        return False
 
 
 class GatewayScanner:

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -69,7 +69,8 @@ class GatewayDescriptor:
 class GatewayScanFilter:
     """Filter to limit gateway scan attempts.
 
-    If `tunnelling` and `routing` are True it is treated as OR.
+    If `tunnelling` and `routing` are set it is treated as AND.
+    KNX/IP devices that don't support `tunnelling` or `routing` aren't matched.
     """
 
     def __init__(
@@ -84,16 +85,17 @@ class GatewayScanFilter:
         self.routing = routing
 
     def match(self, gateway: GatewayDescriptor) -> bool:
-        """Check whether the given GatewayDescriptor matches the filter."""
+        """Check whether the device is a gateway and given GatewayDescriptor matches the filter."""
         if self.name is not None and self.name != gateway.name:
             return False
-        if self.tunnelling is None and self.routing is None:
-            return True
-        if self.tunnelling is gateway.supports_tunnelling:
-            return True
-        if self.routing is gateway.supports_routing:
-            return True
-        return False
+        if (
+            self.tunnelling is not None
+            and self.tunnelling != gateway.supports_tunnelling
+        ):
+            return False
+        if self.routing is not None and self.routing != gateway.supports_routing:
+            return False
+        return gateway.supports_tunnelling or gateway.supports_routing
 
 
 class GatewayScanner:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Ignore non-gateway KNX/IP devices in GatewayScanner.
`GatewayScanFilter()` matches Rotuers, Tunnel servers and both. When `tunnelling` or `routing` attributes are set they are treated as AND. `None` ignores. Non-gateway KNX/IP devices are never matched by GatewayScanner.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
