### PR TITLE
DPTString: replace invalid characters with question marks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 ### Internals
 
+- DPTString: replace invalid characters with question marks in `to_knx`
 - GatewayScanFilter: Ignore non-gateway KNX/IP devices
 
 ## 0.18.9 HS-color 2021-07-26

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -95,6 +95,29 @@ class TestDPTString:
         assert DPTString.to_knx(string) == raw
         assert DPTString.from_knx(raw) == string
 
+    def test_to_knx_invalid_chars(self):
+        """Test streaming string with invalid chars."""
+        raw = (
+            0x4D,
+            0x61,
+            0x74,
+            0x6F,
+            0x75,
+            0x3F,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+        )
+        string = "Matouš"
+        knx_string = "Matou?"
+        assert DPTString.to_knx(string) == raw
+        assert DPTString.from_knx(raw) == knx_string
+
     def test_to_knx_too_long(self):
         """Test serializing DPTString to KNX with wrong value (to long)."""
         with pytest.raises(ConversionError):

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -36,11 +36,11 @@ class DPTString(DPTBase):
             knx_value = str(value)
             if not cls._test_boundaries(knx_value):
                 raise ValueError
-            raw = []
-            for character in knx_value:
-                raw.append(ord(character))
+            raw = [ord(character) for character in knx_value]
             raw.extend([0] * (cls.payload_length - len(raw)))
-            return tuple(raw)
+            # replace invalid characters with question marks
+            # bytes(knx_value, 'ascii') would raise UnicodeEncodeError
+            return tuple(map(lambda char: char if char <= 0xFF else ord("?"), raw))
         except ValueError:
             raise ConversionError("Could not serialize %s" % cls.__name__, value=value)
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
DPTString: replace invalid characters with question marks

When trying to send an invalid character (eg. "š") we would raise an error at https://github.com/XKNX/xknx/blob/c19ea3d4347513d6052f358ea98948e248a68e97/xknx/telegram/apci.py#L271 because
```python
>>> ord("š")
353
>>> bytes((353,))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: bytes must be in range(0, 256)
```
and this would crash our outgoing TelegramQueue.

see https://community.home-assistant.io/t/outgoing-knx-telegrams-are-not-send-after-ha-core-update/340444

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
