### PR TITLE
Catch and log exceptions from processed Telegrams

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 ### Internals
 
+- Catch and log exceptions raised in callbacks to not stall the TelegramQueue
+- Handle callbacks in separate asyncio Tasks
 - GatewayScanFilter: Ignore non-gateway KNX/IP devices
 
 ## 0.18.9 HS-color 2021-07-26

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -238,7 +238,7 @@ class TestTelegramQueue:
 
         async def process_exception():
             raise CouldNotParseTelegram(
-                "Something went wrong when receiving the telegram." ""
+                "Something went wrong when receiving the telegram."
             )
 
         process_tg_in_mock.return_value = asyncio.ensure_future(process_exception())
@@ -254,9 +254,7 @@ class TestTelegramQueue:
 
         logging_error_mock.assert_called_once_with(
             "Error while processing telegram %s",
-            CouldNotParseTelegram(
-                "Something went wrong when receiving the telegram." ""
-            ),
+            CouldNotParseTelegram("Something went wrong when receiving the telegram."),
         )
 
     @patch("xknx.core.TelegramQueue.process_telegram_outgoing", new_callable=AsyncMock)
@@ -385,3 +383,34 @@ class TestTelegramQueue:
         await xknx.telegram_queue.process_telegram_incoming(telegram)
         async_telegram_received_cb_one.assert_not_called()
         async_telegram_received_cb_two.assert_called_once_with(telegram)
+
+    #
+    # TEST BAD CALLBACKS
+    #
+    @patch("logging.Logger.exception")
+    async def test_callback_raising(self, logging_exception_mock):
+        """Test telegram_received_callback raising an exception."""
+        xknx = XKNX()
+        good_callback_1 = AsyncMock()
+        bad_callback = AsyncMock(side_effect=Exception("Boom"))
+        good_callback_2 = AsyncMock()
+
+        xknx.telegram_queue.register_telegram_received_cb(good_callback_1)
+        xknx.telegram_queue.register_telegram_received_cb(bad_callback)
+        xknx.telegram_queue.register_telegram_received_cb(good_callback_2)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            direction=TelegramDirection.INCOMING,
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        await xknx.telegram_queue.process_telegram_incoming(telegram)
+
+        good_callback_1.assert_called_once_with(telegram)
+        bad_callback.assert_called_once_with(telegram)
+        good_callback_2.assert_called_once_with(telegram)
+
+        logging_exception_mock.assert_called_once_with(
+            "Unexpected error while processing telegram_received_cb for %s",
+            telegram,
+        )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
When handling a Telegram (received or sent) raises an Exception - from a Callback or an Error in xknx -  it should not cancel the TelegramQueue.
These unexpected errors will now be logged and the TelegramQueue keeps processing telegrams.

Callbacks for devices and telegrams are now handled in separate asyncio Tasks (through `asyncio.gather()`) which may enable some async concurrency but also adds a little overhead 🙃 (in my local tests - with `timeit` not real-world - it was a little bit slower than the previous loop-await implementation - but nothing significant).


## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
