### PR TITLE
Fix light with global switch and brightness address

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Devices
+
+- Light: Only send to global switch or brightness address if individual colors are also configured
+
 ## 0.18.12 Add always callback to NumericValue and RawValue 2021-11-01
 
 ### Internals

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -684,6 +684,52 @@ class TestLight:
                 "Dimming not supported for device %s", "TestLight"
             )
 
+    async def test_set_individual_color_with_gloabl_switch(self):
+        """Test switching on and dimming a Light with global addresses."""
+        xknx = XKNX()
+        light = Light(
+            xknx,
+            "Diningroom.Light_1",
+            group_address_switch="1/0/0",
+            group_address_brightness="1/0/1",
+            group_address_switch_red="1/1/1",
+            group_address_switch_red_state="1/1/2",
+            group_address_brightness_red="1/1/3",
+            group_address_brightness_red_state="1/1/4",
+            group_address_switch_green="1/1/5",
+            group_address_switch_green_state="1/1/6",
+            group_address_brightness_green="1/1/7",
+            group_address_brightness_green_state="1/1/8",
+            group_address_switch_blue="1/1/9",
+            group_address_switch_blue_state="1/1/10",
+            group_address_brightness_blue="1/1/11",
+            group_address_brightness_blue_state="1/1/12",
+            group_address_switch_white="1/1/13",
+            group_address_switch_white_state="1/1/14",
+            group_address_brightness_white="1/1/15",
+            group_address_brightness_white_state="1/1/16",
+        )
+        assert light.state is None
+        for color in light._iter_individual_colors():
+            assert color.is_on is None
+        # turn on
+        await light.set_on()
+        assert xknx.telegrams.qsize() == 1
+
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/0/0"),
+            payload=GroupValueWrite(DPTBinary(True)),
+        )
+        # brightness
+        await light.set_brightness(23)
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/0/1"),
+            payload=GroupValueWrite(DPTArray(23)),
+        )
+
     #
     # TEST SET COLOR
     #

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -92,16 +92,18 @@ class _SwitchAndBrightness:
 
     async def set_on(self) -> None:
         """Switch light on."""
-        if self.switch.initialized:
+        if self.switch.writable:
             await self.switch.on()
-        elif self.brightness.initialized:
+            return
+        if self.brightness.writable:
             await self.brightness.set(self.brightness.range_to)
 
     async def set_off(self) -> None:
         """Switch light off."""
-        if self.switch.initialized:
+        if self.switch.writable:
             await self.switch.off()
-        elif self.brightness.initialized:
+            return
+        if self.brightness.writable:
             await self.brightness.set(0)
 
     def __eq__(self, other: object) -> bool:
@@ -375,15 +377,17 @@ class Light(Device):
 
     async def set_on(self) -> None:
         """Switch light on."""
-        if self.switch.initialized:
+        if self.switch.writable:
             await self.switch.on()
+            return
         for color in self._iter_individual_colors():
             await color.set_on()
 
     async def set_off(self) -> None:
         """Switch light off."""
-        if self.switch.initialized:
+        if self.switch.writable:
             await self.switch.off()
+            return
         for color in self._iter_individual_colors():
             await color.set_off()
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Only send to global switch or brightness address, not individual colors, for turning on/off or changing brightness when all are configured.
See https://community.home-assistant.io/t/knx-dali-controller-last-set-color-always-overwritten/354163

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
