### PR TITLE
Refactor state updater and handle initialization properly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased changes
+
+### Internals
+
+- The State Updater has been refactored and will be spawned per Remote Value.
+  The global `state_updater` option has been removed.
+
+### Home Assistant
+
+- Devices are now only set to available when the bus is connected and the state updater ran.
+
 ## 0.18.13 Hold your colour 2021-11-13
 
 ### Internals

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -29,7 +29,6 @@ xknx = XKNX(
     multicast_group=DEFAULT_MCAST_GRP,
     multicast_port=DEFAULT_MCAST_PORT,
     log_directory=None,
-    state_updater=False,
     daemon_mode=False,
     connection_config=ConnectionConfig()
 )
@@ -49,7 +48,6 @@ The constructor of the XKNX object takes several parameters:
 - `multicast_group` is the multicast IP address - can be used to override the default multicast address (`224.0.23.12`)
 - `multicast_port` is the multicast port - can be used to override the default multicast port (`3671`)
 - `log_directory` is the path to the log directory - when set to a valid directory we log to a dedicated file in this directory called `xknx.log`. The log files are rotated each night and will exist for 7 days. After that the oldest one will be deleted.
-- if `state_updater` is set, XKNX will start (once `start() is called) an asynchronous process for syncing the states of all connected devices every hour
 - if `daemon_mode` is set, start will only stop if Control-X is pressed. This function is useful for using XKNX as a daemon, e.g. for using the callback functions or using the internal action logic.
 - `connection_config` replaces a ConnectionConfig() that was read from a yaml config file.
 

--- a/home-assistant-plugin/custom_components/xknx/climate.py
+++ b/home-assistant-plugin/custom_components/xknx/climate.py
@@ -328,7 +328,7 @@ class KNXClimate(KnxEntity, ClimateEntity):
         """Return device specific state attributes."""
         attr: dict[str, Any] = {}
 
-        if self._device.command_value.initialized:
+        if self._device.command_value.has_any_group_address:
             attr[ATTR_COMMAND_VALUE] = self._device.command_value.value
         return attr
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 """Conftest for XKNX."""
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -55,4 +55,5 @@ def time_travel(event_loop: asyncio.AbstractEventLoop) -> EventLoopClockAdvancer
 def mock_state_updater_start(monkeypatch):
     """Mock state updater start as its part of all RemoteValues."""
     monkeypatch.setattr("xknx.core.StateUpdater.start", MagicMock())
+    monkeypatch.setattr("xknx.devices.Device._create_task", MagicMock())
     yield monkeypatch

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 """Conftest for XKNX."""
 import asyncio
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -48,3 +49,9 @@ class EventLoopClockAdvancer:
 def time_travel(event_loop: asyncio.AbstractEventLoop) -> EventLoopClockAdvancer:
     """Advance loop time and run callbacks."""
     return EventLoopClockAdvancer(event_loop)
+
+
+@pytest.fixture(autouse=True)
+def monkeypatch(monkeypatch):
+    monkeypatch.setattr("xknx.core.StateUpdater.start", MagicMock())
+    yield monkeypatch

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 """Conftest for XKNX."""
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -52,6 +52,7 @@ def time_travel(event_loop: asyncio.AbstractEventLoop) -> EventLoopClockAdvancer
 
 
 @pytest.fixture(autouse=True)
-def monkeypatch(monkeypatch):
+def mock_state_updater_start(monkeypatch):
+    """Mock state updater start as its part of all RemoteValues."""
     monkeypatch.setattr("xknx.core.StateUpdater.start", MagicMock())
     yield monkeypatch

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
 """Conftest for XKNX."""
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -55,5 +55,7 @@ def time_travel(event_loop: asyncio.AbstractEventLoop) -> EventLoopClockAdvancer
 def mock_state_updater_start(monkeypatch):
     """Mock state updater start as its part of all RemoteValues."""
     monkeypatch.setattr("xknx.core.StateUpdater.start", MagicMock())
-    monkeypatch.setattr("xknx.devices.Device._create_task", MagicMock())
+    monkeypatch.setattr(
+        "xknx.devices.Device._start_state_initialization_listener", MagicMock()
+    )
     yield monkeypatch

--- a/test/core_tests/state_updater_test.py
+++ b/test/core_tests/state_updater_test.py
@@ -236,23 +236,25 @@ class TestStateUpdater:
         remote_value.state_updater.start()
         assert not remote_value.state_updater.started
 
-        await xknx.connection_manager.connection_state_changed(
+        xknx.connection_manager._state = XknxConnectionState.CONNECTED
+
+        await remote_value.state_updater.connection_state_change_callback(
             XknxConnectionState.CONNECTED
         )
         assert remote_value.state_updater.started
 
         # process disconnect
-        await xknx.connection_manager.connection_state_changed(
+        await remote_value.state_updater.connection_state_change_callback(
             XknxConnectionState.DISCONNECTED
         )
         assert not remote_value.state_updater.started
 
-        await xknx.connection_manager.connection_state_changed(
+        await remote_value.state_updater.connection_state_change_callback(
             XknxConnectionState.CONNECTING
         )
         assert not remote_value.state_updater.started
 
-        await xknx.connection_manager.connection_state_changed(
+        await remote_value.state_updater.connection_state_change_callback(
             XknxConnectionState.CONNECTED
         )
         assert remote_value.state_updater.started

--- a/test/core_tests/state_updater_test.py
+++ b/test/core_tests/state_updater_test.py
@@ -98,10 +98,7 @@ class TestStateUpdater:
         read_state.assert_called_once()
         reset.assert_called_once()
 
-        assert remote_value.state_updater.initialized
-
-        remote_value.state_updater._worker = None
-        assert not remote_value.state_updater.initialized
+        assert remote_value.state_updater.initialized.is_set()
 
         remote_value.state_updater.stop()
 
@@ -143,7 +140,12 @@ class TestStateUpdater:
             """Fake read state mutex."""
             read_state_event.set()
 
-        state_tracker = _StateTracker(awaitable, StateTrackerType.EXPIRE, 0.00001)
+        def set_initialized_cb():
+            """Fake set in intialized."""
+
+        state_tracker = _StateTracker(
+            awaitable, set_initialized_cb, StateTrackerType.EXPIRE, 0.00002
+        )
         task = asyncio.create_task(state_tracker._update_loop())
         await read_state_event.wait()
         task.cancel()

--- a/test/core_tests/state_updater_test.py
+++ b/test/core_tests/state_updater_test.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from xknx import XKNX
 from xknx.core import XknxConnectionState
-from xknx.core.state_updater import StateTrackerType, StateUpdaterMixin, _StateTracker
+from xknx.core.state_updater import StateTrackerType, StateUpdater, _StateTracker
 from xknx.remote_value import RemoteValue
 from xknx.telegram import GroupAddress
 
@@ -60,7 +60,7 @@ class TestStateUpdater:
     ):
         """Test parsing tracker options."""
         xknx = XKNX()
-        tracker_type, update_interval = StateUpdaterMixin.parse_tracker_options(
+        tracker_type, update_interval = StateUpdater.parse_tracker_options(
             sync_state, RemoteValue(xknx)
         )
 
@@ -71,68 +71,69 @@ class TestStateUpdater:
     async def test_read_mutex(self, read_state):
         """Test read mutex."""
         xknx = XKNX()
-        state_updater = RemoteValue(
+        remote_value = RemoteValue(
             xknx, group_address_state=GroupAddress("1/1/1"), sync_state=False
         )
 
         xknx.connection_manager.connected.set()
 
-        await state_updater.read_state_mutex()
+        await remote_value.state_updater.read_state_mutex()
 
         read_state.assert_called_once()
 
     @patch("xknx.core.state_updater._StateTracker.reset")
     @patch("xknx.remote_value.RemoteValue.read_state")
-    async def test_state_tracker_worker(self, reset, read_state):
+    async def test_state_tracker_worker(self, reset, read_state, monkeypatch):
         """Test state tracker worker."""
+        monkeypatch.undo()
         xknx = XKNX()
-        state_updater = RemoteValue(xknx, group_address_state=GroupAddress("1/1/1"))
+        remote_value = RemoteValue(xknx, group_address_state=GroupAddress("1/1/1"))
 
         xknx.connection_manager.connected.set()
 
-        state_updater.start()
+        remote_value.state_updater.start()
 
-        await state_updater._worker._task
+        await remote_value.state_updater._worker._task
 
         read_state.assert_called_once()
         reset.assert_called_once()
 
-        assert state_updater.initialized
+        assert remote_value.state_updater.initialized
 
-        state_updater._worker = None
-        assert not state_updater.initialized
+        remote_value.state_updater._worker = None
+        assert not remote_value.state_updater.initialized
 
-        state_updater.stop()
+        remote_value.state_updater.stop()
 
     @patch("xknx.core.state_updater._StateTracker.reset")
     async def test_state_tracker_update_received(self, reset):
         """Test state tracker."""
         xknx = XKNX()
-        state_updater = RemoteValue(xknx, group_address_state=GroupAddress("1/1/1"))
+        remote_value = RemoteValue(xknx, group_address_state=GroupAddress("1/1/1"))
 
-        state_updater.started = True
-        state_updater.update_received()
+        remote_value.state_updater.started = True
+        remote_value.state_updater.update_received()
         reset.assert_called_once()
 
-        state_updater = RemoteValue(
+        remote_value = RemoteValue(
             xknx, sync_state="init", group_address_state=GroupAddress("1/1/1")
         )
-        state_updater.started = True
+        remote_value.state_updater.started = True
         reset.reset_mock()
 
-        state_updater.update_received()
+        remote_value.state_updater.update_received()
         reset.assert_not_called()
 
     @patch("xknx.core.state_updater._StateTracker._update_loop", new_callable=AsyncMock)
     async def test_state_updater_update_loop(self, _update_loop):
         """Test state tracker."""
         xknx = XKNX()
-        state_updater = RemoteValue(
-            xknx, sync_state="invalid", group_address_state=GroupAddress("1/1/1")
+        remote_value = RemoteValue(
+            xknx, sync_state=False, group_address_state=GroupAddress("1/1/1")
         )
-        state_updater._worker.reset()
+        remote_value.state_updater._worker.reset()
 
-        state_updater.stop()
+        remote_value.state_updater.stop()
 
     async def test_start_update_loop_and_stop_directly(self):
         """Test state tracker."""
@@ -147,68 +148,74 @@ class TestStateUpdater:
         await read_state_event.wait()
         task.cancel()
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
+    @patch("xknx.core.StateUpdater.start")
+    @patch("xknx.core.StateUpdater.stop")
     @patch("logging.Logger.warning")
     def test_tracker_parser_invalid_options(self, logging_warning_mock, stop, start):
         """Test parsing invalid tracker options."""
         xknx = XKNX()
-        state_updater = None
+        remote_value = None
 
         def _get_only_tracker() -> _StateTracker:
             # _workers is unordered so it just works with 1 item
-            assert state_updater._worker
-            return state_updater._worker
+            assert remote_value.state_updater._worker
+            return remote_value.state_updater._worker
 
         # INVALID string
-        state_updater = RemoteValue(
+        remote_value = RemoteValue(
             xknx, sync_state="invalid", group_address_state=GroupAddress("1/1/1")
         )
         logging_warning_mock.assert_called_once_with(
             'Could not parse StateUpdater tracker_options "%s" for %s. Using default %s %s minutes.',
             "invalid",
-            state_updater,
+            remote_value,
             StateTrackerType.EXPIRE,
             60,
         )
         assert _get_only_tracker().tracker_type == StateTrackerType.EXPIRE
         assert _get_only_tracker().update_interval == 60 * 60
-        state_updater.__del__()
+        remote_value.__del__()
         logging_warning_mock.reset_mock()
         # intervall too long
-        state_updater = RemoteValue(
+        remote_value = RemoteValue(
             xknx, sync_state=1441, group_address_state=GroupAddress("1/1/1")
         )
         logging_warning_mock.assert_called_once_with(
             "StateUpdater interval of %s to long for %s. Using maximum of %s minutes (1 day)",
             1441,
-            state_updater,
+            remote_value,
             1440,
         )
-        state_updater.__del__()
+        remote_value.__del__()
 
-    async def test_state_updater_start_update_stop(self):
+    async def test_state_updater_start_update_stop(self, monkeypatch):
         """Test start, update_received and stop of StateUpdater."""
+        monkeypatch.undo()
         xknx = XKNX()
 
-        state_updater = RemoteValue(
+        remote_value = RemoteValue(
             xknx, sync_state=True, group_address_state=GroupAddress("1/1/1")
         )
-        state_updater._worker = Mock()
+        remote_value.state_updater._worker = Mock()
 
-        assert state_updater.started
+        assert remote_value.state_updater.started
         xknx.connection_manager._state = XknxConnectionState.CONNECTED
-        state_updater.start()
-        assert state_updater.started
+        remote_value.state_updater.start()
+        assert remote_value.state_updater.started
         # start
-        state_updater._worker.start.assert_called_once_with()
+        remote_value.state_updater._worker.start.assert_called_once_with()
         # update
-        state_updater.update_received()
-        state_updater._worker.update_received.assert_called_once_with()
+        remote_value.state_updater.update_received()
+        remote_value.state_updater._worker.update_received.assert_called_once_with()
         # stop
-        state_updater.stop()
-        assert not state_updater.started
-        state_updater._worker.stop.assert_called_once_with()
+        remote_value.state_updater.stop()
+        assert not remote_value.state_updater.started
+        remote_value.state_updater._worker.stop.assert_called_once_with()
         # don't update when not started
-        state_updater.update_received()
-        state_updater._worker.update_received.assert_called_once_with()
+        remote_value.state_updater.update_received()
+        remote_value.state_updater._worker.update_received.assert_called_once_with()
+
+        remote_value = RemoteValue(xknx, sync_state=True)
+        remote_value.state_updater.start()
+
+        assert not remote_value.state_updater.started

--- a/test/core_tests/state_updater_test.py
+++ b/test/core_tests/state_updater_test.py
@@ -6,7 +6,6 @@ import pytest
 from xknx import XKNX
 from xknx.core import XknxConnectionState
 from xknx.core.state_updater import StateTrackerType, StateUpdaterMixin, _StateTracker
-import xknx.remote_value
 from xknx.remote_value import RemoteValue
 from xknx.telegram import GroupAddress
 

--- a/test/core_tests/task_registry_test.py
+++ b/test/core_tests/task_registry_test.py
@@ -13,9 +13,9 @@ class TestTaskRegistry:
     #
     # TEST REGISTER/UNREGISTER
     #
-    async def test_register(self):
+    async def test_register(self, monkeypatch):
         """Test register."""
-
+        monkeypatch.undo()
         xknx = XKNX()
 
         async def callback() -> None:
@@ -72,9 +72,9 @@ class TestTaskRegistry:
     #
     # TEST CONNECTION HANDLING
     #
-    async def test_reconnect_handling(self):
+    async def test_reconnect_handling(self, monkeypatch):
         """Test reconnect handling."""
-
+        monkeypatch.undo()
         xknx = XKNX()
         xknx.task_registry.start()
         assert len(xknx.connection_manager._connection_state_changed_cbs) == 1

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -233,11 +233,25 @@ class TestBinarySensor:
             XknxConnectionState.CONNECTED
         )
         assert sensor.remote_value.state_updater.started
-        assert not sensor.available
+        assert not sensor._available
 
         await xknx.task_registry.block_till_done()
 
-        assert sensor.available
+        assert sensor._available
+
+        await xknx.connection_manager.connection_state_changed(
+            XknxConnectionState.DISCONNECTED
+        )
+        assert not sensor.remote_value.state_updater.started
+        assert not sensor._available
+
+        await xknx.connection_manager.connection_state_changed(
+            XknxConnectionState.CONNECTED
+        )
+        assert sensor.remote_value.state_updater.started
+        assert not sensor._available
+
+        await xknx.task_registry.block_till_done()
 
     async def test_process_callback_ignore_internal_state_no_counter(self):
         """Test after_update_callback after state of switch was changed."""

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -290,7 +290,11 @@ class TestBinarySensor:
         """Test counter functionality."""
         xknx = XKNX()
         switch = BinarySensor(
-            xknx, "TestInput", group_address_state="1/2/3", context_timeout=1
+            xknx,
+            "TestInput",
+            group_address_state="1/2/3",
+            context_timeout=1,
+            sync_state=False,
         )
         with patch("time.time") as mock_time:
             mock_time.return_value = 1517000000.0

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -39,24 +39,31 @@ class TestClimate:
     def test_support_temperature(self):
         """Test supports_temperature flag."""
         xknx = XKNX()
-        climate = Climate(xknx, "TestClimate", group_address_temperature="1/2/3")
+        climate = Climate(
+            xknx, "TestClimate", group_address_temperature="1/2/3", sync_state=False
+        )
 
-        assert climate.temperature.initialized
-        assert not climate.target_temperature.initialized
+        assert climate.temperature.has_any_group_address
+        assert not climate.target_temperature.has_any_group_address
 
     def test_support_target_temperature(self):
         """Test supports_target__temperature flag."""
         xknx = XKNX()
-        climate = Climate(xknx, "TestClimate", group_address_target_temperature="1/2/3")
+        climate = Climate(
+            xknx,
+            "TestClimate",
+            group_address_target_temperature="1/2/3",
+            sync_state=False,
+        )
 
-        assert not climate.temperature.initialized
-        assert climate.target_temperature.initialized
+        assert not climate.temperature.has_any_group_address
+        assert climate.target_temperature.has_any_group_address
 
     def test_support_operation_mode(self):
         """Test supports_supports_operation_mode flag. One group address for all modes."""
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_operation_mode="1/2/4"
+            xknx, "TestClimate", group_address_operation_mode="1/2/4", sync_state=False
         )
         assert climate_mode.supports_operation_mode
 
@@ -64,7 +71,10 @@ class TestClimate:
         """Test supports_supports_operation_mode flag. Splitted group addresses for each mode."""
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_operation_mode_protection="1/2/4"
+            xknx,
+            "TestClimate",
+            group_address_operation_mode_protection="1/2/4",
+            sync_state=False,
         )
         assert climate_mode.supports_operation_mode
 
@@ -83,6 +93,7 @@ class TestClimate:
             group_address_setpoint_shift_state="1/2/4",
             group_address_on_off="1/2/11",
             group_address_on_off_state="1/2/12",
+            sync_state=False,
         )
 
         assert climate.has_group_address(GroupAddress("1/2/1"))
@@ -101,6 +112,7 @@ class TestClimate:
         climate_mode = ClimateMode(
             xknx,
             name=None,
+            sync_state=False,
             group_address_operation_mode="1/2/4",
             group_address_operation_mode_state="1/2/5",
             group_address_operation_mode_protection="1/2/6",
@@ -145,6 +157,7 @@ class TestClimate:
             group_address_setpoint_shift="1/2/3",
             group_address_setpoint_shift_state="1/2/4",
             setpoint_shift_mode=SetpointShiftMode.DPT6010,
+            sync_state=False,
         )
 
         after_update_callback = Mock()
@@ -170,7 +183,7 @@ class TestClimate:
 
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_operation_mode="1/2/5"
+            xknx, "TestClimate", group_address_operation_mode="1/2/5", sync_state=False
         )
 
         after_update_callback = Mock()
@@ -203,6 +216,7 @@ class TestClimate:
             group_address_temperature="1/2/1",
             group_address_target_temperature="1/2/2",
             group_address_setpoint_shift="1/2/3",
+            sync_state=False,
         )
 
         after_update_callback = Mock()
@@ -242,7 +256,10 @@ class TestClimate:
 
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimateMode", group_address_operation_mode="1/2/4"
+            xknx,
+            "TestClimateMode",
+            group_address_operation_mode="1/2/4",
+            sync_state=False,
         )
 
         after_update_callback = Mock()
@@ -272,7 +289,7 @@ class TestClimate:
         """Test set_operation_mode."""
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_operation_mode="1/2/4"
+            xknx, "TestClimate", group_address_operation_mode="1/2/4", sync_state=False
         )
 
         for operation_mode in DPT_20102_MODES:
@@ -288,7 +305,7 @@ class TestClimate:
         """Test set_operation_mode with DPT20.105 controller."""
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_controller_mode="1/2/4"
+            xknx, "TestClimate", group_address_controller_mode="1/2/4", sync_state=False
         )
 
         for _, controller_mode in DPTHVACContrMode.SUPPORTED_MODES.items():
@@ -1227,6 +1244,7 @@ class TestClimate:
             group_address_operation_mode_protection="1/2/5",
             group_address_operation_mode_night="1/2/6",
             group_address_operation_mode_comfort="1/2/7",
+            sync_state=False,
         )
 
         assert set(climate_mode.operation_modes) == {
@@ -1240,7 +1258,10 @@ class TestClimate:
         """Test get_supported_operation_modes with only night mode supported."""
         xknx = XKNX()
         climate_mode = ClimateMode(
-            xknx, "TestClimate", group_address_operation_mode_night="1/2/7"
+            xknx,
+            "TestClimate",
+            group_address_operation_mode_night="1/2/7",
+            sync_state=False,
         )
         # If one binary climate object is set, all 4 operation modes are supported.
         assert set(climate_mode.operation_modes) == {
@@ -1258,6 +1279,7 @@ class TestClimate:
             "TestClimate",
             group_address_heat_cool="1/2/14",
             group_address_heat_cool_state="1/2/15",
+            sync_state=False,
         )
         assert set(climate_mode.controller_modes) == {
             HVACControllerMode.HEAT,

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -930,7 +930,12 @@ class TestClimate:
     async def test_sync(self):
         """Test sync function / sending group reads to KNX bus."""
         xknx = XKNX()
-        climate = Climate(xknx, "TestClimate", group_address_temperature="1/2/3")
+        climate = Climate(
+            xknx,
+            "TestClimate",
+            group_address_temperature="1/2/3",
+            sync_state=False,
+        )
         await climate.sync()
         assert xknx.telegrams.qsize() == 1
         telegram1 = xknx.telegrams.get_nowait()
@@ -972,6 +977,7 @@ class TestClimate:
             "TestClimate",
             group_address_controller_mode="1/2/13",
             group_address_controller_mode_state="1/2/14",
+            sync_state=False,
         )
         await climate_mode.sync()
         assert xknx.telegrams.qsize() == 1
@@ -1295,6 +1301,7 @@ class TestClimate:
             "TestClimate",
             group_address_operation_mode="1/2/7",
             operation_modes=modes,
+            sync_state=False,
         )
         assert climate_mode.operation_modes == modes
 
@@ -1308,6 +1315,7 @@ class TestClimate:
             "TestClimate",
             group_address_operation_mode="1/2/7",
             operation_modes=str_modes,
+            sync_state=False,
         )
         assert climate_mode.operation_modes == modes
 
@@ -1325,6 +1333,7 @@ class TestClimate:
             "TestClimate",
             group_address_controller_mode="1/2/7",
             controller_modes=str_modes,
+            sync_state=False,
         )
         assert climate_mode.controller_modes == modes
 
@@ -1337,13 +1346,19 @@ class TestClimate:
             xknx,
             "TestClimate",
             controller_modes=str_modes,
+            sync_state=False,
         )
         assert climate_mode.controller_modes == modes
 
     async def test_process_power_status(self):
         """Test process / reading telegrams from telegram queue. Test if DPT20.105 controller mode is set correctly."""
         xknx = XKNX()
-        climate = Climate(xknx, "TestClimate", group_address_on_off="1/2/2")
+        climate = Climate(
+            xknx,
+            "TestClimate",
+            group_address_on_off="1/2/2",
+            sync_state=False,
+        )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTBinary(1)),
@@ -1364,7 +1379,12 @@ class TestClimate:
     async def test_power_on_off(self):
         """Test turn_on and turn_off functions."""
         xknx = XKNX()
-        climate = Climate(xknx, "TestClimate", group_address_on_off="1/2/2")
+        climate = Climate(
+            xknx,
+            "TestClimate",
+            group_address_on_off="1/2/2",
+            sync_state=False,
+        )
         await climate.turn_on()
         _telegram = xknx.telegrams.get_nowait()
         await xknx.devices.process(_telegram)
@@ -1406,10 +1426,16 @@ class TestClimate:
         """Test is_active property."""
         xknx = XKNX()
         climate_active = Climate(
-            xknx, "TestClimate1", group_address_active_state="1/1/1"
+            xknx,
+            "TestClimate1",
+            group_address_active_state="1/1/1",
+            sync_state=False,
         )
         climate_command = Climate(
-            xknx, "TestClimate2", group_address_command_value_state="2/2/2"
+            xknx,
+            "TestClimate2",
+            group_address_command_value_state="2/2/2",
+            sync_state=False,
         )
         climate_active_command = Climate(
             xknx,

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -349,6 +349,7 @@ class TestCover:
             group_address_short="1/2/2",
             group_address_position="1/2/3",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         # Attempt stopping while not actually moving
         await cover_short_stop.stop()
@@ -394,6 +395,7 @@ class TestCover:
             group_address_stop="1/2/0",
             group_address_position="1/2/3",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         await cover_manual_stop.stop()
         assert xknx.telegrams.qsize() == 1
@@ -413,6 +415,7 @@ class TestCover:
             group_address_short="1/2/2",
             group_address_angle="1/2/5",
             group_address_angle_state="1/2/6",
+            sync_state=False,
         )
         # Attempt stopping while not actually tilting
         await cover_short_stop.stop()
@@ -471,6 +474,7 @@ class TestCover:
             group_address_short="1/2/2",
             group_address_position="1/2/3",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         await cover.set_position(50)
         assert xknx.telegrams.qsize() == 1
@@ -487,6 +491,7 @@ class TestCover:
             xknx,
             "TestCover",
             group_address_position="1/2/3",
+            sync_state=False,
         )
         await cover.set_down()
         assert xknx.telegrams.qsize() == 1
@@ -519,6 +524,7 @@ class TestCover:
             group_address_long="1/2/1",
             group_address_short="1/2/2",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(60)
         await cover.set_position(50)
@@ -545,6 +551,7 @@ class TestCover:
             group_address_long="1/2/1",
             group_address_short="1/2/2",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(70)
         await cover.set_position(80)
@@ -569,6 +576,7 @@ class TestCover:
             group_address_long="1/2/1",
             group_address_short="1/2/2",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
 
         with patch("logging.Logger.warning") as mock_warn:
@@ -595,6 +603,7 @@ class TestCover:
             group_address_long="1/2/1",
             group_address_short="1/2/2",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
 
         with patch("logging.Logger.warning") as mock_warn:
@@ -624,6 +633,7 @@ class TestCover:
             group_address_position="1/4/16",
             group_address_angle="1/4/18",
             group_address_angle_state="1/4/19",
+            sync_state=False,
         )
         await cover.set_angle(50)
         assert xknx.telegrams.qsize() == 1
@@ -662,6 +672,7 @@ class TestCover:
             group_address_short="1/2/2",
             group_address_position="1/2/3",
             group_address_position_state="1/2/4",
+            sync_state=False,
         )
         # initial position process - position is unknown so this is the new state - not moving
         telegram = Telegram(
@@ -705,6 +716,7 @@ class TestCover:
             group_address_short="1/2/2",
             group_address_angle="1/2/3",
             group_address_angle_state="1/2/4",
+            sync_state=False,
         )
         telegram = Telegram(
             GroupAddress("1/2/4"), payload=GroupValueWrite(DPTArray(42))
@@ -720,6 +732,7 @@ class TestCover:
             "TestCover",
             group_address_long="1/2/1",
             group_address_locked_state="1/2/4",
+            sync_state=False,
         )
         telegram = Telegram(
             GroupAddress("1/2/4"), payload=GroupValueWrite(DPTBinary(1))
@@ -731,7 +744,11 @@ class TestCover:
         """Test process / reading telegrams from telegram queue. Test if up/down is processed correctly."""
         xknx = XKNX()
         cover = Cover(
-            xknx, "TestCover", group_address_long="1/2/1", group_address_short="1/2/2"
+            xknx,
+            "TestCover",
+            group_address_long="1/2/1",
+            group_address_short="1/2/2",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(50)
         assert not cover.is_traveling()
@@ -745,7 +762,11 @@ class TestCover:
         """Test process / reading telegrams from telegram queue. Test if up/down is processed correctly."""
         xknx = XKNX()
         cover = Cover(
-            xknx, "TestCover", group_address_long="1/2/1", group_address_short="1/2/2"
+            xknx,
+            "TestCover",
+            group_address_long="1/2/1",
+            group_address_short="1/2/2",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(50)
         assert not cover.is_traveling()
@@ -763,6 +784,7 @@ class TestCover:
             "TestCover",
             group_address_long="1/2/1",
             group_address_stop="1/2/2",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(50)
         await cover.set_down()
@@ -781,6 +803,7 @@ class TestCover:
             "TestCover",
             group_address_long="1/2/1",
             group_address_short="1/2/2",
+            sync_state=False,
         )
         cover.travelcalculator.set_position(50)
         await cover.set_down()
@@ -805,6 +828,7 @@ class TestCover:
             group_address_position_state="1/2/5",
             group_address_angle="1/2/6",
             group_address_angle_state="1/2/7",
+            sync_state=False,
         )
 
         after_update_callback = AsyncMock()
@@ -850,6 +874,7 @@ class TestCover:
             group_address_position_state="1/2/4",
             travel_time_down=10,
             travel_time_up=10,
+            sync_state=False,
         )
         with patch("time.time") as mock_time:
             mock_time.return_value = 1517000000.0
@@ -920,6 +945,7 @@ class TestCover:
             group_address_stop="1/2/2",
             travel_time_down=10,
             travel_time_up=10,
+            sync_state=False,
         )
         with patch(
             "xknx.devices.Cover.stop", new_callable=AsyncMock

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -109,6 +109,7 @@ class TestCover:
             xknx,
             "Children.Venetian",
             group_address_locked_state="1/4/14",
+            sync_state=False,
         )
         assert cover_locked.supports_locked
         cover_manual_stop = Cover(
@@ -953,6 +954,7 @@ class TestCover:
             group_address_position_state="1/2/4",
             group_address_angle="1/2/5",
             group_address_angle_state="1/2/6",
+            sync_state=False,
         )
 
         assert cover.has_group_address(GroupAddress("1/2/1"))

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -151,3 +151,16 @@ class TestDevice:
         xknx = XKNX()
         device = Device(xknx, "TestDevice")
         await device.process_group_read(Telegram())
+
+    async def test_device_state_initialization_listener(self, monkeypatch):
+        """Test state initialization listener for device."""
+        monkeypatch.undo()
+        xknx = XKNX()
+        after_update_callback = AsyncMock()
+        device = Device(xknx, "TestDevice", device_updated_cb=after_update_callback)
+        assert not device.available
+
+        device._start_state_initialization_listener()
+        await xknx.task_registry.block_till_done()
+        assert device.available
+        after_update_callback.assert_called_with(device)

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -152,15 +152,27 @@ class TestDevice:
         device = Device(xknx, "TestDevice")
         await device.process_group_read(Telegram())
 
+    async def test_available(self):
+        """Test available property."""
+        xknx = XKNX()
+        device = Device(xknx, "TestDevice")
+        device._connected = False
+        device._available = False
+        assert not device.available
+        device._connected = True
+        assert not device.available
+        device._available = True
+        assert device.available
+
     async def test_device_state_initialization_listener(self, monkeypatch):
         """Test state initialization listener for device."""
         monkeypatch.undo()
         xknx = XKNX()
         after_update_callback = AsyncMock()
         device = Device(xknx, "TestDevice", device_updated_cb=after_update_callback)
-        assert not device.available
+        assert not device._available
 
         device._start_state_initialization_listener()
         await xknx.task_registry.block_till_done()
-        assert device.available
+        assert device._available
         after_update_callback.assert_called_with(device)

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -43,10 +43,18 @@ class TestDevices:
         xknx = XKNX()
         devices = Devices()
 
-        light1 = Light(xknx, "Livingroom", group_address_switch="1/6/7")
-        sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
-        sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
-        light2 = Light(xknx, "Livingroom", group_address_switch="1/6/8")
+        light1 = Light(
+            xknx, "Livingroom", group_address_switch="1/6/7", sync_state=False
+        )
+        sensor1 = BinarySensor(
+            xknx, "Diningroom", group_address_state="3/0/1", sync_state=False
+        )
+        sensor2 = BinarySensor(
+            xknx, "Diningroom", group_address_state="3/0/1", sync_state=False
+        )
+        light2 = Light(
+            xknx, "Livingroom", group_address_switch="1/6/8", sync_state=False
+        )
         devices.add(light1)
         devices.add(sensor1)
         devices.add(sensor2)
@@ -68,10 +76,18 @@ class TestDevices:
         xknx = XKNX()
         devices = Devices()
 
-        light1 = Light(xknx, "Livingroom", group_address_switch="1/6/7")
-        sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
-        sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
-        light2 = Light(xknx, "Livingroom", group_address_switch="1/6/8")
+        light1 = Light(
+            xknx, "Livingroom", group_address_switch="1/6/7", sync_state=False
+        )
+        sensor1 = BinarySensor(
+            xknx, "Diningroom", group_address_state="3/0/1", sync_state=False
+        )
+        sensor2 = BinarySensor(
+            xknx, "Diningroom", group_address_state="3/0/1", sync_state=False
+        )
+        light2 = Light(
+            xknx, "Livingroom", group_address_switch="1/6/8", sync_state=False
+        )
         devices.add(light1)
         devices.add(sensor1)
         devices.add(sensor2)
@@ -84,16 +100,30 @@ class TestDevices:
         xknx = XKNX()
         assert len(xknx.devices) == 0
 
-        Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        Light(
+            xknx, "Living-Room.Light_1", group_address_switch="1/6/7", sync_state=False
+        )
         assert len(xknx.devices) == 1
 
-        BinarySensor(xknx, "DiningRoom.Motion.Sensor", group_address_state="3/0/1")
+        BinarySensor(
+            xknx,
+            "DiningRoom.Motion.Sensor",
+            group_address_state="3/0/1",
+            sync_state=False,
+        )
         assert len(xknx.devices) == 2
 
-        BinarySensor(xknx, "DiningRoom.Motion.Sensor", group_address_state="3/0/1")
+        BinarySensor(
+            xknx,
+            "DiningRoom.Motion.Sensor",
+            group_address_state="3/0/1",
+            sync_state=False,
+        )
         assert len(xknx.devices) == 3
 
-        Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
+        Light(
+            xknx, "Living-Room.Light_2", group_address_switch="1/6/8", sync_state=False
+        )
         assert len(xknx.devices) == 4
 
     def test_contains(self):

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -212,6 +212,7 @@ class TestFan:
             group_address_speed_state="1/7/2",
             group_address_oscillation="1/6/1",
             group_address_oscillation_state="1/6/2",
+            sync_state=False,
         )
         assert fan.has_group_address(GroupAddress("1/7/1"))
         assert fan.has_group_address(GroupAddress("1/7/2"))

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -72,6 +72,7 @@ class TestLight:
             group_address_switch_blue_state="1/1/10",
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
+            sync_state=False,
         )
         assert light.supports_color
 
@@ -101,6 +102,7 @@ class TestLight:
             group_address_switch_green_state="1/1/6",
             group_address_brightness_green="1/1/7",
             group_address_brightness_green_state="1/1/8",
+            sync_state=False,
         )
         assert not light.supports_color
 
@@ -116,6 +118,7 @@ class TestLight:
             group_address_switch="1/6/4",
             group_address_rgbw="1/6/5",
             group_address_color="1/6/6",
+            sync_state=False,
         )
         assert light.supports_rgbw
 
@@ -127,6 +130,7 @@ class TestLight:
             "Diningroom.Light_1",
             group_address_switch="1/6/4",
             group_address_color="1/6/6",
+            sync_state=False,
         )
         assert not light.supports_rgbw
 
@@ -152,6 +156,7 @@ class TestLight:
             group_address_switch_white_state="1/1/14",
             group_address_brightness_white="1/1/15",
             group_address_brightness_white_state="1/1/16",
+            sync_state=False,
         )
         assert light.supports_rgbw
 
@@ -186,6 +191,7 @@ class TestLight:
             group_address_switch_blue_state="1/1/10",
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
+            sync_state=False,
         )
         assert not light.supports_rgbw
 
@@ -1734,6 +1740,7 @@ class TestLight:
             group_address_switch_white_state="1/1/14",
             group_address_brightness_white="1/1/15",
             group_address_brightness_white_state="1/1/16",
+            sync_state=False,
         )
         assert light.has_group_address(GroupAddress("1/7/1"))
         assert light.has_group_address(GroupAddress("1/7/2"))

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -119,7 +119,11 @@ class TestNotification:
         """Test has_group_address."""
         xknx = XKNX()
         notification = Notification(
-            xknx, "Warning", group_address="1/2/3", group_address_state="1/2/4"
+            xknx,
+            "Warning",
+            group_address="1/2/3",
+            group_address_state="1/2/4",
+            sync_state=False,
         )
         assert notification.has_group_address(GroupAddress("1/2/3"))
         assert notification.has_group_address(GroupAddress("1/2/4"))

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -212,6 +212,7 @@ class TestSensorExposeLoop:
             "TestSensor",
             group_address_state="1/1/1",
             value_type=value_type,
+            sync_state=False,
         )
         assert sensor.resolve_state() is None
 

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -752,7 +752,11 @@ class TestSensor:
         """Test sensor has group address."""
         xknx = XKNX()
         sensor = Sensor(
-            xknx, "TestSensor", value_type="temperature", group_address_state="1/2/3"
+            xknx,
+            "TestSensor",
+            value_type="temperature",
+            group_address_state="1/2/3",
+            sync_state=False,
         )
         assert sensor.has_group_address(GroupAddress("1/2/3"))
         assert not sensor.has_group_address(GroupAddress("1/2/4"))

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -164,6 +164,7 @@ class TestWeather:
             xknx=xknx,
             group_address_rain_alarm="1/3/8",
             group_address_wind_alarm="1/3/9",
+            sync_state=False,
         )
 
         weather._rain_alarm.value = True
@@ -179,6 +180,7 @@ class TestWeather:
             xknx=xknx,
             group_address_rain_alarm="1/3/8",
             group_address_frost_alarm="1/3/10",
+            sync_state=False,
         )
 
         weather._rain_alarm.value = True
@@ -195,6 +197,7 @@ class TestWeather:
             group_address_rain_alarm="1/3/8",
             group_address_wind_alarm="1/3/9",
             group_address_frost_alarm="1/3/10",
+            sync_state=False,
         )
 
         weather._wind_alarm.value = True
@@ -210,6 +213,7 @@ class TestWeather:
             group_address_rain_alarm="1/3/8",
             group_address_wind_alarm="1/3/9",
             group_address_frost_alarm="1/3/10",
+            sync_state=False,
         )
 
         weather._rain_alarm.value = True
@@ -347,6 +351,7 @@ class TestWeather:
             group_address_temperature="1/3/4",
             group_address_rain_alarm="1/4/5",
             group_address_brightness_south="7/7/0",
+            sync_state=False,
         )
         assert weather.has_group_address(GroupAddress("1/3/4"))
         assert weather.has_group_address(GroupAddress("7/7/0"))
@@ -359,6 +364,11 @@ class TestWeather:
     def test_has_group_address(self):
         """Test sensor has group address."""
         xknx = XKNX()
-        weather = Weather(name="weather", xknx=xknx, group_address_temperature="1/3/4")
+        weather = Weather(
+            name="weather",
+            xknx=xknx,
+            group_address_temperature="1/3/4",
+            sync_state=False,
+        )
         assert weather._temperature.has_group_address(GroupAddress("1/3/4"))
         assert not weather._temperature.has_group_address(GroupAddress("1/2/4"))

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -17,7 +17,12 @@ class TestWeather:
     async def test_temperature(self):
         """Test resolve state with temperature."""
         xknx = XKNX()
-        weather = Weather(name="weather", xknx=xknx, group_address_temperature="1/3/4")
+        weather = Weather(
+            name="weather",
+            xknx=xknx,
+            group_address_temperature="1/3/4",
+            sync_state=False,
+        )
 
         await weather.process(
             Telegram(
@@ -42,6 +47,7 @@ class TestWeather:
             group_address_brightness_west="1/3/7",
             group_address_brightness_north="1/3/8",
             group_address_temperature="1/4/4",
+            sync_state=False,
         )
 
         await weather.process(
@@ -91,7 +97,12 @@ class TestWeather:
     async def test_pressure(self):
         """Test resolve state with pressure."""
         xknx = XKNX()
-        weather = Weather(name="weather", xknx=xknx, group_address_air_pressure="1/3/4")
+        weather = Weather(
+            name="weather",
+            xknx=xknx,
+            group_address_air_pressure="1/3/4",
+            sync_state=False,
+        )
 
         await weather.process(
             Telegram(
@@ -107,7 +118,9 @@ class TestWeather:
     async def test_humidity(self):
         """Test humidity."""
         xknx = XKNX()
-        weather = Weather(name="weather", xknx=xknx, group_address_humidity="1/2/4")
+        weather = Weather(
+            name="weather", xknx=xknx, group_address_humidity="1/2/4", sync_state=False
+        )
 
         await weather.process(
             Telegram(
@@ -124,7 +137,10 @@ class TestWeather:
         """Test wind speed received."""
         xknx = XKNX()
         weather: Weather = Weather(
-            name="weather", xknx=xknx, group_address_wind_speed="1/3/8"
+            name="weather",
+            xknx=xknx,
+            group_address_wind_speed="1/3/8",
+            sync_state=False,
         )
 
         await weather.process(
@@ -142,7 +158,10 @@ class TestWeather:
         """Test wind bearing received."""
         xknx = XKNX()
         weather: Weather = Weather(
-            name="weather", xknx=xknx, group_address_wind_bearing="1/3/8"
+            name="weather",
+            xknx=xknx,
+            group_address_wind_bearing="1/3/8",
+            sync_state=False,
         )
 
         await weather.process(
@@ -228,6 +247,7 @@ class TestWeather:
             xknx=xknx,
             group_address_brightness_east="1/3/5",
             group_address_brightness_south="1/3/6",
+            sync_state=False,
         )
 
         await weather.process(
@@ -253,6 +273,7 @@ class TestWeather:
             group_address_brightness_east="1/3/5",
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
+            sync_state=False,
         )
 
         await weather.process(
@@ -276,6 +297,7 @@ class TestWeather:
             xknx=xknx,
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
+            sync_state=False,
         )
 
         await weather.process(
@@ -300,6 +322,7 @@ class TestWeather:
             group_address_brightness_east="1/3/5",
             group_address_brightness_south="1/3/6",
             group_address_brightness_west="1/3/7",
+            sync_state=False,
         )
 
         await weather.process(
@@ -320,7 +343,10 @@ class TestWeather:
         """Test day night mapping."""
         xknx = XKNX()
         weather: Weather = Weather(
-            name="weather", xknx=xknx, group_address_day_night="1/3/20"
+            name="weather",
+            xknx=xknx,
+            group_address_day_night="1/3/20",
+            sync_state=False,
         )
 
         await weather.process(

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from xknx import XKNX
-import xknx.core
 from xknx.dpt import DPT2ByteFloat, DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValue, RemoteValueSwitch

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -125,7 +125,9 @@ class TestRemoteValue:
     async def test_read_state(self):
         """Test read state while waiting for the result."""
         xknx = XKNX()
-        remote_value = RemoteValueSwitch(xknx, group_address_state="1/2/3")
+        remote_value = RemoteValueSwitch(
+            xknx, group_address_state="1/2/3", sync_state=False
+        )
 
         with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid, patch(
             "xknx.core.ValueReader.read", new_callable=AsyncMock
@@ -161,8 +163,8 @@ class TestRemoteValue:
                 "State",
             )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
+    @patch("xknx.core.StateUpdater.start")
+    @patch("xknx.core.StateUpdater.stop")
     def test_unpacking_passive_address(self, start, stop):
         """Test if passive group addresses are properly unpacked."""
         xknx = XKNX()

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from xknx import XKNX
+import xknx.core
 from xknx.dpt import DPT2ByteFloat, DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValue, RemoteValueSwitch
@@ -161,7 +162,9 @@ class TestRemoteValue:
                 "State",
             )
 
-    def test_unpacking_passive_address(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_unpacking_passive_address(self, start, stop):
         """Test if passive group addresses are properly unpacked."""
         xknx = XKNX()
 
@@ -207,7 +210,7 @@ class TestRemoteValue:
         assert remote_value.writable
         assert not remote_value.readable
         # RemoteValue is initialized with only passive group address
-        assert remote_value.initialized
+        assert remote_value.has_any_group_address
         with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_always_valid:
             patch_always_valid.side_effect = lambda payload: payload
             test_payload = DPTArray((0x01, 0x02))

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -61,9 +61,7 @@ class TestStringRepresentations:
     """Test class for Configuration logic."""
 
     @patch.multiple(RemoteValue, __abstractmethods__=set())
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_remote_value(self, start, stop):
+    def test_remote_value(self):
         """Test string representation of remote value."""
         xknx = XKNX()
         remote_value = RemoteValue(
@@ -71,6 +69,7 @@ class TestStringRepresentations:
             group_address="1/2/3",
             device_name="MyDevice",
             group_address_state="1/2/4",
+            sync_state=False,
         )
         assert (
             str(remote_value)
@@ -94,20 +93,21 @@ class TestStringRepresentations:
             == "<RemoteValue device_name=\"MyDevice\" feature_name=\"Unknown\" <1/2/3, None, ['1/2/4', 'i-test'], None /> />"
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_binary_sensor(self, start, stop):
+    def test_binary_sensor(self):
         """Test string representation of binary sensor object."""
         xknx = XKNX()
-        binary_sensor = BinarySensor(xknx, name="Fnord", group_address_state="1/2/3")
+        binary_sensor = BinarySensor(
+            xknx,
+            name="Fnord",
+            group_address_state="1/2/3",
+            sync_state=False,
+        )
         assert (
             str(binary_sensor)
             == '<BinarySensor name="Fnord" remote_value=<None, 1/2/3, [], None /> state=None />'
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_climate(self, start, stop):
+    def test_climate(self):
         """Test string representation of climate object."""
         xknx = XKNX()
         climate = Climate(
@@ -122,6 +122,7 @@ class TestStringRepresentations:
             setpoint_shift_min=-20,
             group_address_on_off="1/2/14",
             group_address_on_off_state="1/2/15",
+            sync_state=False,
         )
         assert (
             str(climate) == '<Climate name="Wohnzimmer" '
@@ -133,9 +134,7 @@ class TestStringRepresentations:
             "group_address_on_off=<1/2/14, 1/2/15, [], None /> />"
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_climate_mode(self, start, stop):
+    def test_climate_mode(self):
         """Test string representation of climate mode object."""
         xknx = XKNX()
         climate_mode = ClimateMode(
@@ -150,6 +149,7 @@ class TestStringRepresentations:
             group_address_controller_status_state="1/2/11",
             group_address_controller_mode="1/2/12",
             group_address_controller_mode_state="1/2/13",
+            sync_state=False,
         )
         assert (
             str(climate_mode) == '<ClimateMode name="Wohnzimmer Mode" '
@@ -158,9 +158,7 @@ class TestStringRepresentations:
             "controller_status=<1/2/10, 1/2/11, [], None /> />"
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_cover(self, start, stop):
+    def test_cover(self):
         """Test string representation of cover object."""
         xknx = XKNX()
         cover = Cover(
@@ -176,6 +174,7 @@ class TestStringRepresentations:
             group_address_locked_state="1/2/9",
             travel_time_down=8,
             travel_time_up=10,
+            sync_state=False,
         )
         assert (
             str(cover) == '<Cover name="Rolladen" '
@@ -190,9 +189,7 @@ class TestStringRepresentations:
             'travel_time_up="10" />'
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_fan(self, start, stop):
+    def test_fan(self):
         """Test string representation of fan object."""
         xknx = XKNX()
         fan = Fan(
@@ -202,15 +199,14 @@ class TestStringRepresentations:
             group_address_speed_state="1/2/4",
             group_address_oscillation="1/2/5",
             group_address_oscillation_state="1/2/6",
+            sync_state=False,
         )
         assert (
             str(fan)
             == '<Fan name="Dunstabzug" speed=<1/2/3, 1/2/4, [], None /> oscillation=<1/2/5, 1/2/6, [], None /> />'
         )
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_light(self, start, stop):
+    def test_light(self):
         """Test string representation of non dimmable light object."""
         xknx = XKNX()
         light = Light(
@@ -218,12 +214,11 @@ class TestStringRepresentations:
             name="Licht",
             group_address_switch="1/2/3",
             group_address_switch_state="1/2/4",
+            sync_state=False,
         )
         assert str(light) == '<Light name="Licht" switch=<1/2/3, 1/2/4, [], None /> />'
 
-    @patch("xknx.core.StateUpdaterMixin.start")
-    @patch("xknx.core.StateUpdaterMixin.stop")
-    def test_light_dimmable(self, start, stop):
+    def test_light_dimmable(self):
         """Test string representation of dimmable light object."""
         xknx = XKNX()
         light = Light(
@@ -233,6 +228,7 @@ class TestStringRepresentations:
             group_address_switch_state="1/2/4",
             group_address_brightness="1/2/5",
             group_address_brightness_state="1/2/6",
+            sync_state=False,
         )
         assert (
             str(light) == '<Light name="Licht" '
@@ -288,7 +284,11 @@ class TestStringRepresentations:
         """Test string representation of sensor object."""
         xknx = XKNX()
         sensor = Sensor(
-            xknx, name="MeinSensor", group_address_state="1/2/3", value_type="percent"
+            xknx,
+            name="MeinSensor",
+            group_address_state="1/2/3",
+            value_type="percent",
+            sync_state=False,
         )
         assert (
             str(sensor)
@@ -356,6 +356,7 @@ class TestStringRepresentations:
             group_address_air_pressure="7/0/9",
             group_address_humidity="7/0/9",
             group_address_wind_alarm="7/0/10",
+            sync_state=False,
         )
         assert (
             str(weather)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -61,7 +61,9 @@ class TestStringRepresentations:
     """Test class for Configuration logic."""
 
     @patch.multiple(RemoteValue, __abstractmethods__=set())
-    def test_remote_value(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_remote_value(self, start, stop):
         """Test string representation of remote value."""
         xknx = XKNX()
         remote_value = RemoteValue(
@@ -92,7 +94,9 @@ class TestStringRepresentations:
             == "<RemoteValue device_name=\"MyDevice\" feature_name=\"Unknown\" <1/2/3, None, ['1/2/4', 'i-test'], None /> />"
         )
 
-    def test_binary_sensor(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_binary_sensor(self, start, stop):
         """Test string representation of binary sensor object."""
         xknx = XKNX()
         binary_sensor = BinarySensor(xknx, name="Fnord", group_address_state="1/2/3")
@@ -101,7 +105,9 @@ class TestStringRepresentations:
             == '<BinarySensor name="Fnord" remote_value=<None, 1/2/3, [], None /> state=None />'
         )
 
-    def test_climate(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_climate(self, start, stop):
         """Test string representation of climate object."""
         xknx = XKNX()
         climate = Climate(
@@ -127,7 +133,9 @@ class TestStringRepresentations:
             "group_address_on_off=<1/2/14, 1/2/15, [], None /> />"
         )
 
-    def test_climate_mode(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_climate_mode(self, start, stop):
         """Test string representation of climate mode object."""
         xknx = XKNX()
         climate_mode = ClimateMode(
@@ -150,7 +158,9 @@ class TestStringRepresentations:
             "controller_status=<1/2/10, 1/2/11, [], None /> />"
         )
 
-    def test_cover(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_cover(self, start, stop):
         """Test string representation of cover object."""
         xknx = XKNX()
         cover = Cover(
@@ -180,7 +190,9 @@ class TestStringRepresentations:
             'travel_time_up="10" />'
         )
 
-    def test_fan(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_fan(self, start, stop):
         """Test string representation of fan object."""
         xknx = XKNX()
         fan = Fan(
@@ -196,7 +208,9 @@ class TestStringRepresentations:
             == '<Fan name="Dunstabzug" speed=<1/2/3, 1/2/4, [], None /> oscillation=<1/2/5, 1/2/6, [], None /> />'
         )
 
-    def test_light(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_light(self, start, stop):
         """Test string representation of non dimmable light object."""
         xknx = XKNX()
         light = Light(
@@ -207,7 +221,9 @@ class TestStringRepresentations:
         )
         assert str(light) == '<Light name="Licht" switch=<1/2/3, 1/2/4, [], None /> />'
 
-    def test_light_dimmable(self):
+    @patch("xknx.core.StateUpdaterMixin.start")
+    @patch("xknx.core.StateUpdaterMixin.stop")
+    def test_light_dimmable(self, start, stop):
         """Test string representation of dimmable light object."""
         xknx = XKNX()
         light = Light(
@@ -229,6 +245,7 @@ class TestStringRepresentations:
         xknx = XKNX()
         light = Light(
             xknx,
+            sync_state=False,
             name="Licht",
             group_address_switch="1/2/3",
             group_address_switch_state="1/2/4",
@@ -310,7 +327,11 @@ class TestStringRepresentations:
         """Test string representation of switch object."""
         xknx = XKNX()
         switch = Switch(
-            xknx, name="Schalter", group_address="1/2/3", group_address_state="1/2/4"
+            xknx,
+            name="Schalter",
+            group_address="1/2/3",
+            group_address_state="1/2/4",
+            sync_state=False,
         )
         assert (
             str(switch)

--- a/test/xknx_test.py
+++ b/test/xknx_test.py
@@ -58,7 +58,7 @@ class TestXknxModule:
     @patch("xknx.io.KNXIPInterface.start", new_callable=AsyncMock)
     async def test_xknx_start(self, start_mock):
         """Test xknx start."""
-        xknx = XKNX(state_updater=True)
+        xknx = XKNX()
 
         await xknx.start()
         start_mock.assert_called_once()
@@ -69,7 +69,7 @@ class TestXknxModule:
         """Test xknx start."""
 
         async def run_in_contextmanager():
-            async with XKNX(state_updater=True) as xknx:
+            async with XKNX() as xknx:
                 assert xknx.started.is_set()
                 ipinterface_mock.assert_called_once()
 
@@ -93,4 +93,3 @@ class TestXknxModule:
         await xknx.stop()
         assert xknx.knxip_interface is None
         assert xknx.telegram_queue._consumer_task.done()
-        assert not xknx.state_updater.started

--- a/test/xknx_test.py
+++ b/test/xknx_test.py
@@ -56,12 +56,12 @@ class TestXknxModule:
         assert len(xknx.connection_manager._connection_state_changed_cbs) == 1
 
     @patch("xknx.io.KNXIPInterface.start", new_callable=AsyncMock)
-    async def test_xknx_start(self, start_mock):
+    async def test_xknx_start(self, monkeypatch):
         """Test xknx start."""
         xknx = XKNX()
 
         await xknx.start()
-        start_mock.assert_called_once()
+        monkeypatch.assert_called_once()
         await xknx.stop()
 
     @patch("xknx.io.KNXIPInterface.start", new_callable=AsyncMock)
@@ -77,7 +77,7 @@ class TestXknxModule:
 
     @patch("xknx.io.KNXIPInterface.start", new_callable=AsyncMock)
     async def test_xknx_start_and_stop_with_dedicated_connection_config(
-        self, start_mock
+        self, monkeypatch
     ):
         """Test xknx start and stop with connection config."""
         xknx = XKNX()
@@ -87,7 +87,7 @@ class TestXknxModule:
 
         await xknx.start()
 
-        start_mock.assert_called_once()
+        monkeypatch.assert_called_once()
         assert xknx.knxip_interface.connection_config == connection_config
 
         await xknx.stop()

--- a/xknx/core/__init__.py
+++ b/xknx/core/__init__.py
@@ -3,7 +3,7 @@
 from .connection_manager import ConnectionManager
 from .connection_state import XknxConnectionState
 from .payload_reader import PayloadReader
-from .state_updater import StateUpdater, _StateTracker
+from .state_updater import StateUpdaterMixin, _StateTracker
 from .task_registry import Task, TaskRegistry
 from .telegram_queue import TelegramQueue
 from .value_reader import ValueReader

--- a/xknx/core/__init__.py
+++ b/xknx/core/__init__.py
@@ -3,7 +3,7 @@
 from .connection_manager import ConnectionManager
 from .connection_state import XknxConnectionState
 from .payload_reader import PayloadReader
-from .state_updater import StateUpdaterMixin, _StateTracker
+from .state_updater import StateUpdater, _StateTracker
 from .task_registry import Task, TaskRegistry
 from .telegram_queue import TelegramQueue
 from .value_reader import ValueReader

--- a/xknx/core/__init__.py
+++ b/xknx/core/__init__.py
@@ -3,7 +3,7 @@
 from .connection_manager import ConnectionManager
 from .connection_state import XknxConnectionState
 from .payload_reader import PayloadReader
-from .state_updater import StateUpdater
+from .state_updater import StateUpdater, _StateTracker
 from .task_registry import Task, TaskRegistry
 from .telegram_queue import TelegramQueue
 from .value_reader import ValueReader

--- a/xknx/core/connection_manager.py
+++ b/xknx/core/connection_manager.py
@@ -21,8 +21,9 @@ class ConnectionManager:
     def register_connection_state_changed_cb(
         self, connection_state_changed_cb: AsyncConnectionStateCallback
     ) -> None:
-        """Register callback for connection state beeing updated."""
-        self._connection_state_changed_cbs.append(connection_state_changed_cb)
+        """Register callback for connection state being updated."""
+        if connection_state_changed_cb not in self._connection_state_changed_cbs:
+            self._connection_state_changed_cbs.append(connection_state_changed_cb)
 
     def unregister_connection_state_changed_cb(
         self, connection_state_changed_cb: AsyncConnectionStateCallback

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -123,11 +123,6 @@ class StateUpdater:
 
     def _start(self) -> None:
         """Start internal StateUpdater. Initialize states."""
-        #  dont start if we have no state address
-        if not self.remote_value.group_address_state or not self.sync_state:
-            self.initialized.set()
-            return
-
         self.started = True
         self._worker.start()
 
@@ -143,6 +138,11 @@ class StateUpdater:
 
     def start(self) -> None:
         """Start StateUpdater."""
+        #  dont start if we have no state address
+        if not self.remote_value.group_address_state or not self.sync_state:
+            self.initialized.set()
+            return
+
         self.xknx.connection_manager.register_connection_state_changed_cb(
             self.connection_state_change_callback
         )
@@ -221,6 +221,7 @@ class _StateTracker:
 
     def update_received(self) -> None:
         """Reset the timer if a telegram was received for a "expire" typed StateUpdater."""
+        self._mark_as_initialized()
         if self.tracker_type == StateTrackerType.EXPIRE:
             self.reset()
 

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -6,9 +6,8 @@ from enum import Enum
 import logging
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
-from xknx.remote_value import RemoteValue
-
 if TYPE_CHECKING:
+    from xknx.remote_value import RemoteValue
     from xknx.xknx import XKNX
 
 
@@ -18,7 +17,7 @@ DEFAULT_UPDATE_INTERVAL = 60
 MAX_UPDATE_INTERVAL = 1440
 
 
-class StateUpdater:
+class StateUpdaterMixin:
     """Class for keeping the state of a RemoteValue up to date."""
 
     state_updater_semaphore = asyncio.Semaphore(value=2)
@@ -87,7 +86,7 @@ class StateUpdater:
 
     async def read_state_mutex(self) -> None:
         """Schedule to read the state from the KNX bus - one at a time."""
-        async with StateUpdater.state_updater_semaphore:
+        async with StateUpdaterMixin.state_updater_semaphore:
             # wait until there is a bus connection
             await self.xknx.connection_manager.connected.wait()
             # wait until there is nothing else to send to the bus
@@ -106,7 +105,7 @@ class StateUpdater:
         self,
     ) -> None:
         """Register a RemoteValue to initialize its state and/or track for expiration."""
-        tracker_type, update_interval = StateUpdater.parse_tracker_options(
+        tracker_type, update_interval = StateUpdaterMixin.parse_tracker_options(
             self.sync_state, self.remote_value
         )
         tracker = _StateTracker(

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -17,7 +17,7 @@ DEFAULT_UPDATE_INTERVAL = 60
 MAX_UPDATE_INTERVAL = 1440
 
 
-class StateUpdaterMixin:
+class StateUpdater:
     """Class for keeping the state of a RemoteValue up to date."""
 
     state_updater_semaphore = asyncio.Semaphore(value=2)
@@ -86,7 +86,7 @@ class StateUpdaterMixin:
 
     async def read_state_mutex(self) -> None:
         """Schedule to read the state from the KNX bus - one at a time."""
-        async with StateUpdaterMixin.state_updater_semaphore:
+        async with StateUpdater.state_updater_semaphore:
             # wait until there is a bus connection
             await self.xknx.connection_manager.connected.wait()
             # wait until there is nothing else to send to the bus
@@ -105,7 +105,7 @@ class StateUpdaterMixin:
         self,
     ) -> None:
         """Register a RemoteValue to initialize its state and/or track for expiration."""
-        tracker_type, update_interval = StateUpdaterMixin.parse_tracker_options(
+        tracker_type, update_interval = StateUpdater.parse_tracker_options(
             self.sync_state, self.remote_value
         )
         tracker = _StateTracker(
@@ -129,6 +129,10 @@ class StateUpdaterMixin:
 
     def start(self) -> None:
         """Start internal StateUpdater. Initialize states."""
+        #  dont start if we have no state address
+        if not self.remote_value.group_address_state or not self.sync_state:
+            return
+
         self.started = True
         if self._worker:
             self._worker.start()

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -64,6 +64,7 @@ class BinarySensor(Device):
             # after_update called internally
             after_update_cb=self._state_from_remote_value,
         )
+        self._start_state_initialization_listener()
 
     def _iter_remote_values(self) -> Iterator[RemoteValueSwitch]:
         """Iterate the devices RemoteValue classes."""

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -40,7 +40,7 @@ class BinarySensor(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize BinarySensor class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.ignore_internal_state = ignore_internal_state or bool(context_timeout)
         self.reset_after = reset_after

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -134,6 +134,7 @@ class Climate(Device):
         )
 
         self.mode = mode
+        self._start_state_initialization_listener()
 
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -177,9 +177,9 @@ class Climate(Device):
     def initialized_for_setpoint_shift_calculations(self) -> bool:
         """Test if object is initialized for setpoint shift calculations."""
         if (
-            self._setpoint_shift.initialized
+            self._setpoint_shift.has_any_group_address
             and self._setpoint_shift.value is not None
-            and self.target_temperature.initialized
+            and self.target_temperature.has_any_group_address
             and self.target_temperature.value is not None
         ):
             return True

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -63,7 +63,7 @@ class Climate(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Climate class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.min_temp = min_temp
         self.max_temp = max_temp

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -52,7 +52,7 @@ class ClimateMode(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize ClimateMode class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.remote_value_operation_mode = RemoteValueOperationMode(
             xknx,

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -170,6 +170,7 @@ class ClimateMode(Device):
             operation_mode.has_any_group_address
             for operation_mode in self._iter_binary_operation_modes()
         )
+        self._start_state_initialization_listener()
 
     def _iter_remote_values(
         self,

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -159,15 +159,15 @@ class ClimateMode(Device):
                     self._controller_modes.append(ct_mode)
 
         self.supports_operation_mode = any(
-            operation_mode.initialized
+            operation_mode.has_any_group_address
             for operation_mode in self._iter_operation_remote_values()
         )
         self.supports_controller_mode = any(
-            controller_mode.initialized
+            controller_mode.has_any_group_address
             for controller_mode in self._iter_controller_remote_values()
         )
         self._use_binary_operation_modes = any(
-            operation_mode.initialized
+            operation_mode.has_any_group_address
             for operation_mode in self._iter_binary_operation_modes()
         )
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -135,6 +135,7 @@ class Cover(Device):
 
         self.travelcalculator = TravelCalculator(travel_time_down, travel_time_up)
         self.travel_direction_tilt: TravelStatus | None = None
+        self._start_state_initialization_listener()
 
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -57,7 +57,7 @@ class Cover(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Cover class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
         # self.after_update for position changes is called after updating the
         # travelcalculator (in process_group_write and set_*) - angle changes
         # are updated from RemoteValue objects

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -346,17 +346,17 @@ class Cover(Device):
     @property
     def supports_locked(self) -> bool:
         """Return if cover supports locking."""
-        return self.locked.initialized
+        return self.locked.has_any_group_address
 
     @property
     def supports_position(self) -> bool:
         """Return if cover supports direct positioning."""
-        return self.position_target.initialized
+        return self.position_target.has_any_group_address
 
     @property
     def supports_angle(self) -> bool:
         """Return if cover supports tilt angle."""
-        return self.angle.initialized
+        return self.angle.has_any_group_address
 
     def __str__(self) -> str:
         """Return object as readable string."""

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -33,7 +33,7 @@ class DateTime(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize DateTime class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, False)
         self.localtime = localtime
         self._broadcast_type = broadcast_type.upper()
         self._remote_value = RemoteValueDateTime(

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -46,6 +46,8 @@ class DateTime(Device):
         )
         self._broadcast_task: Task | None = self._create_broadcast_task(minutes=60)
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValueDateTime]:
         """Iterate the devices RemoteValue classes."""
         yield self._remote_value

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -32,17 +32,19 @@ class Device(ABC):
         xknx: XKNX,
         name: str,
         device_updated_cb: DeviceCallbackType | None = None,
+        sync_state: bool | int | float | str = True,
     ):
         """Initialize Device class."""
         self.xknx = xknx
         self.name = name
         self.available = False
+        self.sync_state = sync_state
         self.device_updated_cbs: list[DeviceCallbackType] = []
         if device_updated_cb is not None:
             self.register_device_updated_cb(device_updated_cb)
 
-        self.xknx.devices.add(self)
         self._task: Task | None = None
+        self.xknx.devices.add(self)
 
     def _start_state_initialization_listener(self) -> None:
         """Create task for state initialization."""

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -66,7 +66,7 @@ class Device(ABC):
             await remote_value.state_updater.initialized.wait()
 
         self.available = True
-        logger.info(
+        logger.debug(
             "Device state is now initialized for %s - marking as available",
             self,
         )

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -40,7 +40,7 @@ class ExposeSensor(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sensor class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, False)
 
         self.sensor_value: RemoteValueSensor | RemoteValueSwitch
         if value_type == "binary":

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -61,6 +61,8 @@ class ExposeSensor(Device):
                 value_type=value_type,
             )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -91,6 +91,8 @@ class Fan(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield from (self.speed, self.oscillation)

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -52,7 +52,7 @@ class Fan(Device):
         max_step: int | None = None,
     ):
         """Initialize fan class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.speed: RemoteValueDptValue1Ucount | RemoteValueScaling
         self.mode = FanSpeedMode.STEP if max_step else FanSpeedMode.PERCENT

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -98,7 +98,7 @@ class Fan(Device):
     @property
     def supports_oscillation(self) -> bool:
         """Return if fan supports oscillation."""
-        return self.oscillation.initialized
+        return self.oscillation.has_any_group_address
 
     async def set_speed(self, speed: int) -> None:
         """Set the fan to a desginated speed."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -316,6 +316,8 @@ class Light(Device):
         self._individual_color_debounce_telegram_counter: int
         self._reset_individual_color_debounce_telegrams()
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         return chain(

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -164,7 +164,7 @@ class Light(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Light class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.switch = RemoteValueSwitch(
             xknx,

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -28,7 +28,7 @@ class Notification(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize notification class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self._message = RemoteValueString(
             xknx,

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -40,6 +40,8 @@ class Notification(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValueString]:
         """Iterate the devices RemoteValue classes."""
         yield self._message

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -36,7 +36,7 @@ class NumericValue(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sensor class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
         self.always_callback = always_callback
         self.respond_to_read = respond_to_read
         self.sensor_value = RemoteValueNumeric(

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -49,6 +49,8 @@ class NumericValue(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValueNumeric]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value

--- a/xknx/devices/raw_value.py
+++ b/xknx/devices/raw_value.py
@@ -36,7 +36,7 @@ class RawValue(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sensor class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
         self.always_callback = always_callback
         self.respond_to_read = respond_to_read
         self.remote_value = RemoteValueRaw(

--- a/xknx/devices/raw_value.py
+++ b/xknx/devices/raw_value.py
@@ -49,6 +49,8 @@ class RawValue(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValueRaw]:
         """Iterate the devices RemoteValue classes."""
         yield self.remote_value

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -37,6 +37,7 @@ class Scene(Device):
             after_update_cb=self.after_update,
         )
         self.scene_number = int(scene_number)
+        self._start_state_initialization_listener()
 
     def _iter_remote_values(self) -> Iterator[RemoteValueSceneNumber]:
         """Iterate the devices RemoteValue classes."""

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -22,17 +22,19 @@ class Scene(Device):
         xknx: XKNX,
         name: str,
         group_address: GroupAddressesType | None = None,
+        sync_state: bool | int | float | str = True,
         scene_number: int = 1,
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sceneclass."""
-        super().__init__(xknx, name, device_updated_cb, True)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         # TODO: state_updater: disable for scene number per default?
         self.scene_value = RemoteValueSceneNumber(
             xknx,
             group_address=group_address,
             device_name=self.name,
+            sync_state=sync_state,
             feature_name="Scene number",
             after_update_cb=self.after_update,
         )

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -26,7 +26,7 @@ class Scene(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sceneclass."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, True)
 
         # TODO: state_updater: disable for scene number per default?
         self.scene_value = RemoteValueSceneNumber(

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -38,7 +38,7 @@ class Sensor(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Sensor class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.sensor_value: RemoteValueControl | RemoteValueSensor
         if isinstance(value_type, str) and value_type in [

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -66,6 +66,8 @@ class Sensor(Device):
             )
         self.always_callback = always_callback
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -40,7 +40,7 @@ class Switch(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ):
         """Initialize Switch class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self.reset_after = reset_after
         self._reset_task_name = f"switch.reset_{id(self)}"

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -56,6 +56,8 @@ class Switch(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValueSwitch]:
         """Iterate the devices RemoteValue classes."""
         yield self.switch

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -229,6 +229,8 @@ class Weather(Device):
             after_update_cb=self.after_update,
         )
 
+        self._start_state_initialization_listener()
+
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
         """Iterate the devices remote values."""
         yield self._temperature

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -101,7 +101,7 @@ class Weather(Device):
         device_updated_cb: DeviceCallbackType | None = None,
     ) -> None:
         """Initialize Weather class."""
-        super().__init__(xknx, name, device_updated_cb)
+        super().__init__(xknx, name, device_updated_cb, sync_state)
 
         self._temperature = RemoteValueNumeric(
             xknx,

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -83,19 +83,14 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
         self.telegram: Telegram | None = None
         self.after_update_cb: AsyncCallbackType | None = after_update_cb
 
-        if sync_state and self.group_address_state:
-            self.xknx.state_updater.register_remote_value(
-                self, tracker_options=sync_state
-            )
+        # if sync_state and self.group_address_state:
+        #    self.xknx.state_updater.register_remote_value(
+        #        self, tracker_options=sync_state
+        #    )
 
     def __del__(self) -> None:
         """Destructor. Removing self from StateUpdater if was registered."""
-        try:
-            self.xknx.state_updater.unregister_remote_value(self)
-        except (KeyError, AttributeError):
-            # KeyError if it was never added to StateUpdater
-            # AttributeError if instantiation failed (tests mostly)
-            pass
+        pass
 
     @property
     def value(self) -> ValueType | None:
@@ -193,7 +188,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
                 feature_name=self.feature_name,
             )
         decoded_payload = self.from_knx(_new_payload)
-        self.xknx.state_updater.update_received(self)
+        # self.xknx.state_updater.update_received(self)
         if self._value is None or always_callback or self._value != decoded_payload:
             self._value = decoded_payload
             self.telegram = telegram

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -86,7 +86,6 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
 
         # start state updater
         self.state_updater = StateUpdater(xknx, self, sync_state)
-        self.state_updater.start()
 
     def __del__(self) -> None:
         """Destructor. Removing self from StateUpdater if was registered."""
@@ -192,7 +191,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
                 feature_name=self.feature_name,
             )
         decoded_payload = self.from_knx(_new_payload)
-        # self.xknx.state_updater.update_received(self)
+        self.state_updater.update_received()
         if self._value is None or always_callback or self._value != decoded_payload:
             self._value = decoded_payload
             self.telegram = telegram

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -91,8 +91,11 @@ class RemoteValue(StateUpdaterMixin, ABC, Generic[DPTPayloadType, ValueType]):
 
     def __del__(self) -> None:
         """Destructor. Removing self from StateUpdater if was registered."""
-        if self.started:
-            self.stop()
+        try:
+            if self.started:
+                self.stop()
+        except AttributeError:
+            pass
 
     @property
     def value(self) -> ValueType | None:
@@ -292,14 +295,14 @@ class RemoteValue(StateUpdaterMixin, ABC, Generic[DPTPayloadType, ValueType]):
     def __eq__(self, other: object) -> bool:
         """Equal operator."""
         for key, value in self.__dict__.items():
-            if key == "after_update_cb" or key == "remote_value" or key == "_worker":
+            if key in ("after_update_cb", "remote_value", "_worker"):
                 continue
             if key not in other.__dict__:
                 return False
             if other.__dict__[key] != value:
                 return False
         for key, value in other.__dict__.items():
-            if key == "after_update_cb" or key == "remote_value" or key == "_worker":
+            if key in ("after_update_cb", "remote_value", "_worker"):
                 continue
             if key not in self.__dict__:
                 return False


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This PR aims to provide the ability to read the state of the state updater run (i.e. after the first init) for each remote value independently. This means that instead of having one global state updater for all remote values each remote value now has its one state updater.

This PR removes the global state updater and instead have one state updater per remote value.

Additionally, each device is now able to know when its state is properly read once from the bus and will then - and only then - set the available property. This will be used in HA.

See https://community.home-assistant.io/t/is-there-any-way-to-prevent-template-warnings-errors-on-startup-for-yet-non-existing-state-attributes/357342



Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
