### PR TITLE
Fix rate limiter wait time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Connection
+
+- Fix rate limiter wait time. Don't add time waiting for ACK or L_DATA.con frames to the rate_limit.
+
 ## 0.18.15 Come back almighty Gateway Scanner
 
 ### Internals

--- a/xknx/core/telegram_queue.py
+++ b/xknx/core/telegram_queue.py
@@ -72,6 +72,7 @@ class TelegramQueue:
         self.telegram_received_cbs: list[TelegramQueue.Callback] = []
         self.outgoing_queue: asyncio.Queue[Telegram | None] = asyncio.Queue()
         self._consumer_task: Awaitable[tuple[None, None]] | None = None
+        self._rate_limiter: asyncio.Task[None] | None = None
 
     def register_telegram_received_cb(
         self,
@@ -143,19 +144,22 @@ class TelegramQueue:
 
     async def _outgoing_rate_limiter(self) -> None:
         """Endless loop for processing outgoing telegrams."""
-        rate_limiter: asyncio.Task[None] | None = None
         while True:
             telegram = await self.outgoing_queue.get()
             # Breaking up queue if None is pushed to the queue
             if telegram is None:
                 self.outgoing_queue.task_done()
+                if self._rate_limiter:
+                    self._rate_limiter.cancel()
                 break
 
             # limit rate to knx bus - defaults to 20 per second
             if self.xknx.rate_limit and not isinstance(
                 telegram.destination_address, InternalGroupAddress
             ):
-                rate_limiter = asyncio.create_task(
+                if self._rate_limiter is not None:
+                    await self._rate_limiter
+                self._rate_limiter = asyncio.create_task(
                     asyncio.sleep(1 / self.xknx.rate_limit)
                 )
 
@@ -174,8 +178,6 @@ class TelegramQueue:
             finally:
                 self.outgoing_queue.task_done()
                 self.xknx.telegrams.task_done()
-                if rate_limiter is not None:
-                    await rate_limiter
 
     async def _process_all_telegrams(self) -> None:
         """Process all telegrams being queued. Used in unit tests."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Don't add time waiting for ACK or L_DATA.con frames to the rate_limit. It is now waited in an extra task.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
