### PR TITLE
Handle ConversionError in RemoteValue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Devices
+
+- Handle ConversionError in RemoteValue, log a readable warning
+
 ## 0.18.15 Come back almighty Gateway Scanner
 
 ### Internals

--- a/test/dpt_tests/dpt_hvac_mode_test.py
+++ b/test/dpt_tests/dpt_hvac_mode_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx.dpt import DPTControllerStatus, DPTHVACMode
 from xknx.dpt.dpt_hvac_mode import HVACOperationMode
-from xknx.exceptions import ConversionError, CouldNotParseKNXIP
+from xknx.exceptions import ConversionError
 
 
 class TestDPTControllerStatus:
@@ -68,7 +68,7 @@ class TestDPTControllerStatus:
 
     def test_mode_from_knx_wrong_code(self):
         """Test parsing of DPTHVACMode with wrong code."""
-        with pytest.raises(CouldNotParseKNXIP):
+        with pytest.raises(ConversionError):
             DPTHVACMode.from_knx((0x05,))
 
     def test_controller_status_from_knx_wrong_value(self):
@@ -78,5 +78,5 @@ class TestDPTControllerStatus:
 
     def test_controller_status_from_knx_wrong_code(self):
         """Test parsing of DPTControllerStatus with wrong code."""
-        with pytest.raises(CouldNotParseKNXIP):
+        with pytest.raises(ConversionError):
             DPTControllerStatus.from_knx((0x00,))

--- a/test/remote_value_tests/remote_value_control_test.py
+++ b/test/remote_value_tests/remote_value_control_test.py
@@ -58,11 +58,11 @@ class TestRemoteValueControl:
                 payload=GroupValueWrite(DPTArray(0x01)),
             )
             await remote_value.process(telegram)
-        with pytest.raises(ConversionError):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(0x10)),
-            )
-            await remote_value.process(telegram)
-            # pylint: disable=pointless-statement
-            remote_value.value
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0x10)),
+        )
+        assert await remote_value.process(telegram) is False
+        # pylint: disable=pointless-statement
+        remote_value.value

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -71,9 +71,9 @@ class TestRemoteValue:
         """Test for warning if RemoteValue is read only."""
         xknx = XKNX()
         remote_value = RemoteValue(xknx, group_address_state=GroupAddress("1/2/3"))
-        with patch("logging.Logger.warning") as mock_info:
+        with patch("logging.Logger.warning") as mock_warning:
             await remote_value.set(23)
-            mock_info.assert_called_with(
+            mock_warning.assert_called_with(
                 "Attempted to set value for non-writable device: %s - %s (value: %s)",
                 "Unknown",
                 "Unknown",
@@ -86,8 +86,8 @@ class TestRemoteValue:
         remote_value = RemoteValue(xknx)
         assert remote_value.unit_of_measurement is None
 
-    async def test_process_unsupported_payload(self):
-        """Test if exception is raised when processing telegram with unsupported payload."""
+    async def test_process_unsupported_payload_type(self):
+        """Test if exception is raised when processing telegram with unsupported payload type."""
         xknx = XKNX()
         remote_value = RemoteValue(xknx)
         with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid, patch(
@@ -122,6 +122,34 @@ class TestRemoteValue:
             with pytest.raises(CouldNotParseTelegram, match=r".*payload invalid.*"):
                 await remote_value.process(telegram)
 
+    async def test_process_unsupported_payload(self):
+        """Test warning is logged when processing telegram with unsupported payload."""
+        xknx = XKNX()
+        remote_value = RemoteValue(xknx)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/1"),
+            payload=GroupValueWrite(DPTArray((0x01, 0x02))),
+        )
+        with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid, patch(
+            "xknx.remote_value.RemoteValue.has_group_address"
+        ) as patch_has_group_address, patch(
+            "xknx.remote_value.RemoteValue.from_knx"
+        ) as patch_from, patch(
+            "logging.Logger.warning"
+        ) as mock_warning:
+            patch_valid.return_value = telegram.payload.value
+            patch_has_group_address.return_value = True
+            patch_from.side_effect = ConversionError("TestError")
+
+            assert await remote_value.process(telegram) is False
+            mock_warning.assert_called_once_with(
+                "Can not process %s for %s - %s: %s",
+                telegram,
+                "Unknown",
+                "Unknown",
+                ConversionError("TestError"),
+            )
+
     async def test_read_state(self):
         """Test read state while waiting for the result."""
         xknx = XKNX()
@@ -149,12 +177,12 @@ class TestRemoteValue:
 
         with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid, patch(
             "xknx.core.ValueReader.read", new_callable=AsyncMock
-        ) as patch_read, patch("logging.Logger.warning") as mock_info:
+        ) as patch_read, patch("logging.Logger.warning") as mock_warning:
             patch_valid.return_value = False
             patch_read.return_value = None
 
             await remote_value.read_state(wait_for_result=True)
-            mock_info.assert_called_with(
+            mock_warning.assert_called_once_with(
                 "Could not sync group address '%s' (%s - %s)",
                 GroupAddress("1/2/3"),
                 "Unknown",

--- a/xknx/dpt/dpt_hvac_mode.py
+++ b/xknx/dpt/dpt_hvac_mode.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Generic, TypeVar
 
-from xknx.exceptions import ConversionError, CouldNotParseKNXIP
+from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
 
@@ -51,9 +51,10 @@ class _DPTClimateMode(DPTBase, Generic[HVACModeType]):
     def from_knx(cls, raw: tuple[int, ...]) -> HVACModeType:
         """Parse/deserialize from KNX/IP raw data."""
         cls.test_bytesarray(raw)
-        if raw[0] in cls.SUPPORTED_MODES:
+        try:
             return cls.SUPPORTED_MODES[raw[0]]
-        raise CouldNotParseKNXIP("Could not parse HVACOperationMode")
+        except KeyError:
+            raise ConversionError(f"Payload not supported for {cls.__name__}", raw=raw)
 
     @classmethod
     def to_knx(cls, value: HVACModeType) -> tuple[int]:
@@ -61,7 +62,7 @@ class _DPTClimateMode(DPTBase, Generic[HVACModeType]):
         for knx_value, mode in cls.SUPPORTED_MODES.items():
             if mode == value:
                 return (knx_value,)
-        raise ConversionError(f"Could not parse {cls.__name__}", value=value)
+        raise ConversionError(f"Value not supported for {cls.__name__}", value=value)
 
 
 class DPTHVACContrMode(_DPTClimateMode[HVACControllerMode]):
@@ -135,4 +136,4 @@ class DPTControllerStatus(_DPTClimateMode[HVACOperationMode]):
             return HVACOperationMode.STANDBY
         if raw[0] & 1 > 0:
             return HVACOperationMode.COMFORT
-        raise CouldNotParseKNXIP("Could not parse HVACOperationMode")
+        raise ConversionError(f"Payload not supported for {cls.__name__}", raw=raw)


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Handle ConversionError in RemoteValue. Log a warning when `DPT*.from_knx()` raises `ConversionError` for each RemoteValue processing the Telegram instead of handling the exception in TelegramQueue.
As a result wrongly configured GAs can be identified more easily. 

Eg. when using `operation_mode_state_address` instead of `controller_mode_state_address` in one Climate entity the name and feature name of the climate entity will be logged instead of a generic Conversion error from the TelegramQueue.
Other devices using the same GA with a different DPT* will not be prevented from trying to parse it.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
