### PR TITLE
Typo in the "connection_state_changed_cb" example which makes the example fail.

### DIFF
--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -146,7 +146,7 @@ async def main():
 asyncio.run(main())
 ```
 
-An awaitable `connection_state_change_cb` will be called every time the connection state to the gateway changes. Example:
+An awaitable `connection_state_changed_cb` will be called every time the connection state to the gateway changes. Example:
 
 ```python
 import asyncio
@@ -154,12 +154,12 @@ from xknx import XKNX
 from xknx.core import XknxConnectionState
 
 
-async def connection_state_change_cb(state: XknxConnectionState):
+async def connection_state_changed_cb(state: XknxConnectionState):
     print("Callback received with state {0}".format(state.name))
 
 
 async def main():
-    xknx = XKNX(connection_state_change_cb=connection_state_change_cb, daemon_mode=True)
+    xknx = XKNX(connection_state_changed_cb=connection_state_changed_cb, daemon_mode=True)
     await xknx.start()
     await xknx.stop()
 


### PR DESCRIPTION
Type in the connection_state_changed_cb  example.
It currently says "connection_state_change_cb" instead of "connection_state_changed_cb". 
While this is a simple typo it makes the code fail.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
