### PR TITLE
Raise if an initial connection can not be established

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 
 ### Connection
 
+- Raise if an initial connection can not be established, auto-reconnect only when the connection was successful once
 - Add support for TCP tunnel connections
 - Optionally run KNXIPInterface in separate thread
 - Handle separate Tunneling control and data endpoints

--- a/test/xknx_test.py
+++ b/test/xknx_test.py
@@ -101,6 +101,28 @@ class TestXknxModule:
         new_callable=AsyncMock,
         side_effect=OSError,
     )
+    async def test_xknx_start_tunneling_initial_connection_error(
+        self, transport_connect_mock
+    ):
+        """Test xknx start raising when socket can't be set up."""
+        xknx = XKNX(
+            state_updater=True,
+            connection_config=ConnectionConfig(
+                connection_type=ConnectionType.TUNNELING, gateway_ip="127.0.0.2"
+            ),
+        )
+        with pytest.raises(CommunicationError):
+            await xknx.start()
+        transport_connect_mock.assert_called_once()
+        assert xknx.telegram_queue._consumer_task is None  # not started
+        assert not xknx.state_updater.started
+        assert not xknx.started.is_set()
+
+    @patch(
+        "xknx.io.transport.UDPTransport.connect",
+        new_callable=AsyncMock,
+        side_effect=OSError,
+    )
     async def test_xknx_start_routing_initial_connection_error(
         self, transport_connect_mock
     ):

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -56,7 +56,7 @@ class KNXIPInterface:
         self.connection_config = connection_config
 
     async def start(self) -> None:
-        """Start KNX/IP interface."""
+        """Start KNX/IP interface. Raise `CommunicationError` if connection fails."""
         await self._start()
 
     async def _start(self) -> None:
@@ -309,7 +309,10 @@ def find_local_ip(gateway_ip: str) -> str:
         logger.warning(
             "No interface on same subnet as gateway found. Falling back to default gateway."
         )
-        default_gateway = _find_default_gateway()
+        try:
+            default_gateway = _find_default_gateway()
+        except KeyError as err:
+            raise CommunicationError(f"No route to {gateway} found") from err
         local_ip = _scan_interfaces(default_gateway)
     assert isinstance(local_ip, str)
     return local_ip

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -9,6 +9,7 @@ import logging
 from typing import TYPE_CHECKING, Callable
 
 from xknx.core import XknxConnectionState
+from xknx.exceptions import CommunicationError
 from xknx.knxip import (
     HPAI,
     CEMIFrame,
@@ -107,7 +108,7 @@ class Routing(Interface):
             )
             # close udp transport to prevent open file descriptors
             self.udp_transport.stop()
-            raise ex
+            raise CommunicationError("Routing could not be started") from ex
         await self.xknx.connection_manager.connection_state_changed(
             XknxConnectionState.CONNECTED
         )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Raise if an initial connection can not be established.

For Tunneling: auto-reconnect only when the connection was successful once.

This enables HA to gracefully fail on `async_setup_entry` with
>[homeassistant.config_entries] Config entry 'Tunneling @ 10.1.0.10' for knx integration not ready yet: Tunnel connection could not be established; Retrying in background

rather than silently running xknx's auto_reconnect when connection parameters were configured wrongly.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
