### PR TITLE
Handle invalid payloads per RemoteValue, log a readable warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Do a ConnectionStateRequest heartbeat on TCP tunnel connections too
 
+### Devices
+
+- Handle invalid payloads per RemoteValue, log a readable warning
+
 ## 0.19.1 Bugfix for route_back 2022-01-31
 
 ### Connection

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -5,7 +5,6 @@ import pytest
 from xknx import XKNX
 from xknx.devices import BinarySensor
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
 
@@ -119,8 +118,10 @@ class TestBinarySensor:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await binary_sensor.process(telegram)
+            log_mock.assert_called_once()
+            assert binary_sensor.state is None
 
     #
     # TEST SWITCHED ON

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -5,7 +5,6 @@ import pytest
 from xknx import XKNX
 from xknx.devices import Light
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 
@@ -1279,34 +1278,42 @@ class TestLight:
     async def test_process_dimm_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_brightness="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_dimm_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_brightness="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray((23, 24))),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_color(self):
         """Test process / reading telegrams from telegram queue. Test if color is processed."""
@@ -1608,34 +1615,42 @@ class TestLight:
     async def test_process_tunable_white_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_tunable_white="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_tunable_white_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_tunable_white="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray((23, 24))),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_color_temperature(self):
         """Test process / reading telegrams from telegram queue. Test if color temperature is processed."""
@@ -1665,34 +1680,42 @@ class TestLight:
     async def test_process_color_temperature_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_color_temperature="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_color_temperature_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
+        cb_mock = AsyncMock()
         light = Light(
             xknx,
             name="TestLight",
             group_address_switch="1/2/3",
             group_address_color_temperature="1/2/5",
+            device_updated_cb=cb_mock,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray(23)),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await light.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     def test_has_group_address(self):
         """Test has_group_address."""

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -1,11 +1,10 @@
 """Unit test for Notification objects."""
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from xknx import XKNX
 from xknx.devices import Notification
 from xknx.dpt import DPTArray, DPTBinary, DPTString
-from xknx.exceptions import CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 
@@ -69,24 +68,34 @@ class TestNotification:
     async def test_process_payload_invalid_length(self):
         """Test process wrong telegram (wrong payload length)."""
         xknx = XKNX()
-        notification = Notification(xknx, "Warning", group_address="1/2/3")
+        cb_mock = AsyncMock()
+        notification = Notification(
+            xknx, "Warning", group_address="1/2/3", device_updated_cb=cb_mock
+        )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((23, 24))),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await notification.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     async def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
         xknx = XKNX()
-        notification = Notification(xknx, "Warning", group_address="1/2/3")
+        cb_mock = AsyncMock()
+        notification = Notification(
+            xknx, "Warning", group_address="1/2/3", device_updated_cb=cb_mock
+        )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        with pytest.raises(CouldNotParseTelegram):
+        with patch("logging.Logger.warning") as log_mock:
             await notification.process(telegram)
+            log_mock.assert_called_once()
+            cb_mock.assert_not_called()
 
     #
     # TEST SET MESSAGE

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -2,7 +2,6 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import CouldNotParseTelegram
 from xknx.remote_value import RemoteValue1Count
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -58,15 +57,17 @@ class TestRemoteValue1Count:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -300,6 +300,22 @@ class TestRemoteValueOperationMode:
 
         assert remote_value.value is None
 
+    async def test_to_process_error_binary_operation_mode(self):
+        """Test processing invalid payload."""
+        xknx = XKNX()
+        remote_value = RemoteValueBinaryOperationMode(
+            xknx,
+            group_address="1/2/3",
+            operation_mode=HVACOperationMode.COMFORT,
+        )
+        invalid_telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(
+                DPTArray((1,)),
+            ),
+        )
+        assert await remote_value.process(telegram=invalid_telegram) is False
+
     async def test_to_process_error_controller_mode(self):
         """Test process errornous telegram."""
         xknx = XKNX()

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -285,18 +285,20 @@ class TestRemoteValueOperationMode:
             group_address=GroupAddress("1/2/3"),
             climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None
 
     async def test_to_process_error_controller_mode(self):
         """Test process errornous telegram."""
@@ -304,18 +306,20 @@ class TestRemoteValueOperationMode:
         remote_value = RemoteValueControllerMode(
             xknx, group_address=GroupAddress("1/2/3")
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None
 
     async def test_to_process_error_heat_cool(self):
         """Test process errornous telegram."""
@@ -325,15 +329,17 @@ class TestRemoteValueOperationMode:
             group_address=GroupAddress("1/2/3"),
             controller_mode=HVACControllerMode.COOL,
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x01,))),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x01,))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueColorRGB
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -74,15 +74,17 @@ class TestRemoteValueColorRGB:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueColorRGBW
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -103,23 +103,25 @@ class TestRemoteValueColorRGBW:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(
-                    DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67))
-                ),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(
+                DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67))
+            ),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_xyy_test.py
+++ b/test/remote_value_tests/remote_value_color_xyy_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueColorXYY
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -82,15 +82,17 @@ class TestRemoteValueColorXYY:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_control_test.py
+++ b/test/remote_value_tests/remote_value_control_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueControl
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -52,17 +52,17 @@ class TestRemoteValueControl:
         remote_value = RemoteValueControl(
             xknx, group_address=GroupAddress("1/2/3"), value_type="stepwise"
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray(0x01)),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x01)),
+        )
+        assert await remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(0x10)),
         )
         assert await remote_value.process(telegram) is False
-        # pylint: disable=pointless-statement
-        remote_value.value
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_datetime_test.py
+++ b/test/remote_value_tests/remote_value_datetime_test.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueDateTime
 
 
@@ -46,6 +46,7 @@ class TestRemoteValueDateTime:
         """Testing KNX/Byte representation of DPTDateTime object."""
         xknx = XKNX()
         rv_datetime = RemoteValueDateTime(xknx, value_type="datetime")
-        assert not rv_datetime.payload_valid(
-            DPTArray((0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
-        )
+        with pytest.raises(CouldNotParseTelegram):
+            rv_datetime.payload_valid(
+                DPTArray((0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
+            )

--- a/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
+++ b/test/remote_value_tests/remote_value_dpt_2_byte_unsigned_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueDpt2ByteUnsigned
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -73,21 +73,23 @@ class TestRemoteValueDptValue2Ucount:
         remote_value = RemoteValueDpt2ByteUnsigned(
             xknx, group_address=GroupAddress("1/2/3")
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64,))),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x53, 0x42))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64,))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x53, 0x42))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueDptValue1Ucount
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -73,15 +73,17 @@ class TestRemoteValueDptValue1Ucount:
         remote_value = RemoteValueDptValue1Ucount(
             xknx, group_address=GroupAddress("1/2/3")
         )
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_raw_test.py
+++ b/test/remote_value_tests/remote_value_raw_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueRaw
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -126,44 +126,44 @@ class TestRemoteValueRaw:
         rv_1 = RemoteValueRaw(xknx, payload_length=1, group_address="1/1/1")
         rv_2 = RemoteValueRaw(xknx, payload_length=2, group_address="1/2/2")
 
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/0/0"),
-                payload=GroupValueWrite(DPTArray((0x01,))),
-            )
-            await rv_0.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/0/0"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await rv_0.process(telegram)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/0/0"),
+            payload=GroupValueWrite(DPTArray((0x01,))),
+        )
+        assert await rv_0.process(telegram) is False
 
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/1/1"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await rv_1.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/1/1"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await rv_1.process(telegram)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/0/0"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await rv_0.process(telegram) is False
+        assert rv_0.value is None
 
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/2"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await rv_2.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/2"),
-                payload=GroupValueWrite(DPTArray((0x64,))),
-            )
-            await rv_2.process(telegram)
+        telegram = Telegram(
+            destination_address=GroupAddress("1/1/1"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await rv_1.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/1/1"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await rv_1.process(telegram) is False
+        assert rv_1.value is None
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/2"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await rv_2.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/2"),
+            payload=GroupValueWrite(DPTArray((0x64,))),
+        )
+        assert await rv_2.process(telegram) is False
+        assert rv_2.value is None
 
     def test_to_knx_error(self):
         """Test to_knx function with wrong parameters."""

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueSceneNumber
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -67,22 +67,17 @@ class TestRemoteValueSceneNumber:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(
-                    DPTArray(
-                        (
-                            0x64,
-                            0x65,
-                        )
-                    )
-                ),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -1,8 +1,8 @@
 """Unit test for RemoteValueSensor objects."""
 import pytest
 from xknx import XKNX
-from xknx.dpt import DPTBase
-from xknx.exceptions import ConversionError
+from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTValue1Ucount
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value import RemoteValueNumeric, RemoteValueSensor
 
 
@@ -35,6 +35,21 @@ class TestRemoteValueSensor:
         """Test if all members of DPTMAP implement payload_length."""
         for dpt_class in DPTBase.__recursive_subclasses__():
             assert isinstance(dpt_class.payload_length, int)
+
+    def test_payload_valid(self):
+        """Test payload_valid method."""
+        xknx = XKNX()
+        remote_value = RemoteValueSensor(xknx=xknx, value_type="pulse")
+        valid_payload = DPTArray(DPTValue1Ucount.to_knx(1))
+
+        assert remote_value.dpt_class == DPTValue1Ucount
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value.payload_valid(None)
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value.payload_valid(DPTArray((1, 2, 3, 4)))
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value.payload_valid(DPTBinary(1))
+        assert remote_value.payload_valid(valid_payload) == valid_payload
 
 
 class TestRemoteValueNumeric:

--- a/test/remote_value_tests/remote_value_setepoint_shift_test.py
+++ b/test/remote_value_tests/remote_value_setepoint_shift_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTValue1Count
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.remote_value.remote_value_setpoint_shift import (
     RemoteValueSetpointShift,
     SetpointShiftMode,
@@ -19,22 +19,26 @@ class TestRemoteValueSetpointShift:
         dpt_6_payload = DPTArray(DPTValue1Count.to_knx(1))
         dpt_9_payload = DPTArray(DPTTemperature.to_knx(1))
 
-        assert remote_value.payload_valid(DPTBinary(0)) is None
-        assert remote_value.payload_valid(DPTArray((0, 1, 2))) is None
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value.payload_valid(DPTBinary(0))
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value.payload_valid(DPTArray((0, 1, 2)))
 
         # DPT 6 - payload_length 1
         assert remote_value.dpt_class is None
         assert remote_value.payload_valid(dpt_6_payload) == dpt_6_payload
         assert remote_value.dpt_class == SetpointShiftMode.DPT6010.value
-        #   DPT 9 is invalid now
-        assert remote_value.payload_valid(dpt_9_payload) is None
+        with pytest.raises(CouldNotParseTelegram):
+            # DPT 9 is invalid now
+            remote_value.payload_valid(dpt_9_payload)
 
         remote_value.dpt_class = None
         # DPT 9 - payload_length 2
         assert remote_value.payload_valid(dpt_9_payload) == dpt_9_payload
         assert remote_value.dpt_class == SetpointShiftMode.DPT9002.value
-        #   DPT 6 is invalid now
-        assert remote_value.payload_valid(dpt_6_payload) is None
+        with pytest.raises(CouldNotParseTelegram):
+            # DPT 6 is invalid now
+            remote_value.payload_valid(dpt_6_payload)
 
     def test_payload_valid_preassigned_mode(self):
         """Test if setpoint_shift_mode is assigned properly by payload length."""
@@ -49,17 +53,25 @@ class TestRemoteValueSetpointShift:
         dpt_9_payload = DPTArray(DPTTemperature.to_knx(1))
 
         assert remote_value_6.dpt_class == DPTValue1Count
-        assert remote_value_6.payload_valid(None) is None
-        assert remote_value_6.payload_valid(dpt_9_payload) is None
-        assert remote_value_6.payload_valid(DPTArray((1, 2, 3, 4))) is None
-        assert remote_value_6.payload_valid(DPTBinary(1)) is None
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_6.payload_valid(None)
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_6.payload_valid(dpt_9_payload)
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_6.payload_valid(DPTArray((1, 2, 3, 4)))
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_6.payload_valid(DPTBinary(1))
         assert remote_value_6.payload_valid(dpt_6_payload) == dpt_6_payload
 
         assert remote_value_9.dpt_class == DPTTemperature
-        assert remote_value_9.payload_valid(None) is None
-        assert remote_value_9.payload_valid(dpt_6_payload) is None
-        assert remote_value_9.payload_valid(DPTArray((1, 2, 3))) is None
-        assert remote_value_9.payload_valid(DPTBinary(1)) is None
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_9.payload_valid(None)
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_9.payload_valid(dpt_6_payload)
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_9.payload_valid(DPTArray((1, 2, 3)))
+        with pytest.raises(CouldNotParseTelegram):
+            remote_value_9.payload_valid(DPTBinary(1))
         assert remote_value_9.payload_valid(dpt_9_payload) == dpt_9_payload
 
     def test_to_knx_uninitialized(self):

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueStep
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -82,17 +82,17 @@ class TestRemoteValueStep:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray(0x01)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(3)),
-            )
-            await remote_value.process(telegram)
-            # pylint: disable=pointless-statement
-            remote_value.value
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x01)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(3)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueString
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -127,15 +127,17 @@ class TestRemoteValueString:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x64, 0x65))),
-            )
-            await remote_value.process(telegram)
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueSwitch
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -96,17 +96,17 @@ class TestRemoteValueSwitch:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray(0x01)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(3)),
-            )
-            await remote_value.process(telegram)
-            # pylint: disable=pointless-statement
-            remote_value.value
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x01)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(3)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_temp_test.py
+++ b/test/remote_value_tests/remote_value_temp_test.py
@@ -1,0 +1,64 @@
+"""Unit test for RemoteValueSceneNumber objects."""
+import pytest
+from xknx import XKNX
+from xknx.dpt import DPTArray, DPTBinary
+from xknx.exceptions import ConversionError
+from xknx.remote_value import RemoteValueTemp
+from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram.apci import GroupValueWrite
+
+
+@pytest.mark.asyncio
+class TestRemoteValueTemp:
+    """Test class for RemoteValueTemp objects."""
+
+    def test_to_knx(self):
+        """Test to_knx function with normal operation."""
+        xknx = XKNX()
+        remote_value = RemoteValueTemp(xknx)
+        assert remote_value.to_knx(11) == DPTArray((0x04, 0x4C))
+
+    def test_from_knx(self):
+        """Test from_knx function with normal operation."""
+        xknx = XKNX()
+        remote_value = RemoteValueTemp(xknx)
+        assert remote_value.from_knx(DPTArray((0x04, 0x4C))) == 11
+
+    def test_to_knx_error(self):
+        """Test to_knx function with wrong parametern."""
+        xknx = XKNX()
+        remote_value = RemoteValueTemp(xknx)
+        with pytest.raises(ConversionError):
+            remote_value.to_knx(-300)
+        with pytest.raises(ConversionError):
+            remote_value.to_knx("abc")
+
+    async def test_process(self):
+        """Test process telegram."""
+        xknx = XKNX()
+        remote_value = RemoteValueTemp(xknx, group_address=GroupAddress("1/2/3"))
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x04, 0x4C))),
+        )
+        await remote_value.process(telegram)
+        assert remote_value.value == 11
+
+    async def test_to_process_error(self):
+        """Test process errornous telegram."""
+        xknx = XKNX()
+        remote_value = RemoteValueTemp(xknx, group_address=GroupAddress("1/2/3"))
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64,))),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -109,18 +109,15 @@ class TestRemoteValue:
         """Test if exception is raised when processing telegram with invalid payload."""
         xknx = XKNX()
         remote_value = RemoteValue(xknx)
-        with patch("xknx.remote_value.RemoteValue.payload_valid") as patch_valid, patch(
-            "xknx.remote_value.RemoteValue.has_group_address"
-        ) as patch_has_group_address:
-            patch_valid.return_value = None
-            patch_has_group_address.return_value = True
+        with patch(
+            "xknx.remote_value.RemoteValue.has_group_address", remote_value=True
+        ):
 
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/1"),
                 payload=GroupValueWrite(DPTArray((0x01, 0x02))),
             )
-            with pytest.raises(CouldNotParseTelegram, match=r".*payload invalid.*"):
-                await remote_value.process(telegram)
+            assert await remote_value.process(telegram) is False
 
     async def test_process_unsupported_payload(self):
         """Test warning is logged when processing telegram with unsupported payload."""

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -2,7 +2,7 @@
 import pytest
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueUpDown
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueWrite
@@ -82,17 +82,17 @@ class TestRemoteValueUpDown:
         """Test process errornous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray(0x01)),
-            )
-            await remote_value.process(telegram)
-        with pytest.raises(CouldNotParseTelegram):
-            telegram = Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTBinary(3)),
-            )
-            await remote_value.process(telegram)
-            # pylint: disable=pointless-statement
-            remote_value.value
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray(0x01)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(3)),
+        )
+        assert await remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -186,7 +186,7 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
             decoded_payload = self.from_knx(_new_payload)
         except (ConversionError, CouldNotParseTelegram) as err:
             logger.warning(
-                "Can not process %s \n for %s - %s: %s",
+                "Can not process %s for %s - %s: %s",
                 telegram,
                 self.device_name,
                 self.feature_name,

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -147,11 +147,9 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
         return group_address in remote_value_addresses()
 
     @abstractmethod
-    # TODO: typing - remove Optional
-    def payload_valid(
-        self, payload: DPTArray | DPTBinary | None
-    ) -> DPTPayloadType | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTPayloadType:
         """Return payload if telegram payload may be parsed - to be implemented in derived class."""
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     @abstractmethod
     def from_knx(self, payload: DPTPayloadType) -> ValueType:
@@ -182,21 +180,13 @@ class RemoteValue(ABC, Generic[DPTPayloadType, ValueType]):
                 device_name=self.device_name,
                 feature_name=self.feature_name,
             )
-        _new_payload = self.payload_valid(telegram.payload.value)
-        if _new_payload is None:
-            raise CouldNotParseTelegram(
-                "payload invalid",
-                payload=str(telegram.payload),
-                destination_address=str(telegram.destination_address),
-                source_address=str(telegram.source_address),
-                device_name=self.device_name,
-                feature_name=self.feature_name,
-            )
+
         try:
+            _new_payload = self.payload_valid(telegram.payload.value)
             decoded_payload = self.from_knx(_new_payload)
-        except ConversionError as err:
+        except (ConversionError, CouldNotParseTelegram) as err:
             logger.warning(
-                "Can not process %s for %s - %s: %s",
+                "Can not process %s \n for %s - %s: %s",
                 telegram,
                 self.device_name,
                 self.feature_name,

--- a/xknx/remote_value/remote_value_1count.py
+++ b/xknx/remote_value/remote_value_1count.py
@@ -6,6 +6,7 @@ DPT 6.010.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTValue1Count
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
@@ -13,13 +14,11 @@ from .remote_value import RemoteValue
 class RemoteValue1Count(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX 6.010 (DPT_Value_1_Count)."""
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -85,13 +85,11 @@ class RemoteValueOperationMode(RemoteValueClimateModeBase[DPTArray, HVACOperatio
         """Return a list of all supported operation modes."""
         return list(self._climate_mode_transcoder.SUPPORTED_MODES.values())
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Any) -> DPTArray:
         """Convert value to payload."""
@@ -133,13 +131,11 @@ class RemoteValueControllerMode(
         """Return a list of all supported operation modes."""
         return list(DPTHVACContrMode.SUPPORTED_MODES.values())
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     @staticmethod
     def to_knx(value: Any) -> DPTArray:
@@ -194,9 +190,11 @@ class RemoteValueBinaryOperationMode(
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Any) -> DPTBinary:
         """Convert value to payload."""
@@ -276,9 +274,11 @@ class RemoteValueBinaryHeatCool(
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     @staticmethod
     def supported_operation_modes() -> list[HVACControllerMode]:

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence, Tuple
 
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -40,13 +40,11 @@ class RemoteValueColorRGB(RemoteValue[DPTArray, Tuple[int, int, int]]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 3
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 3:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Sequence[int]) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence, Tuple
 
 from xknx.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -41,13 +41,11 @@ class RemoteValueColorRGBW(RemoteValue[DPTArray, Tuple[int, int, int, int]]):
         )
         self.previous_value: tuple[int, int, int, int] = (0, 0, 0, 0)
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 6
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 6:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Sequence[int]) -> DPTArray:
         """

--- a/xknx/remote_value/remote_value_color_xyy.py
+++ b/xknx/remote_value/remote_value_color_xyy.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.dpt.dpt_color import DPTColorXYY, XYYColor
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -42,14 +43,11 @@ class RemoteValueColorXYY(RemoteValue[DPTArray, XYYColor]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray)
-            and len(payload.value) == self.PAYLOAD_LENGTH
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == self.PAYLOAD_LENGTH:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: XYYColor) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from xknx.dpt import DPTArray, DPTBinary, DPTControlStepCode
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -50,9 +50,11 @@ class RemoteValueControl(RemoteValue[DPTBinary, Any]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Any) -> DPTBinary:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary, DPTDate, DPTDateTime, DPTTime
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -62,14 +62,14 @@ class RemoteValueDateTime(RemoteValue[DPTArray, time.struct_time]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray)
+        if (
+            isinstance(payload, DPTArray)
             and len(payload.value) == self.dpt_class.payload_length
-            else None
-        )
+        ):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: time.struct_time) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPT2ByteUnsigned, DPTArray, DPTBinary
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -39,13 +40,11 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray, int]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 2
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 2:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_dpt_value_1_ucount.py
+++ b/xknx/remote_value/remote_value_dpt_value_1_ucount.py
@@ -6,6 +6,7 @@ DPT 5.010.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTValue1Ucount
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
@@ -13,13 +14,11 @@ from .remote_value import RemoteValue
 class RemoteValueDptValue1Ucount(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 5.010."""
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_raw.py
+++ b/xknx/remote_value/remote_value_raw.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union
 
 from xknx.dpt.dpt import DPTArray, DPTBinary
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -45,13 +45,13 @@ class RemoteValueRaw(RemoteValue[Union[DPTArray, DPTBinary], int]):
 
     def payload_valid(
         self, payload: DPTArray | DPTBinary | None
-    ) -> DPTArray | DPTBinary | None:
+    ) -> DPTArray | DPTBinary:
         """Test if telegram payload may be parsed."""
         if isinstance(payload, DPTBinary) and self.payload_length == 0:
             return payload
         if isinstance(payload, DPTArray) and len(payload.value) == self.payload_length:
             return payload
-        return None
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray | DPTBinary:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -43,13 +44,11 @@ class RemoteValueScaling(RemoteValue[DPTArray, int]):
         self.range_from = range_from
         self.range_to = range_to
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: float) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_scene_number.py
+++ b/xknx/remote_value/remote_value_scene_number.py
@@ -6,6 +6,7 @@ DPT 17.001.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTSceneNumber
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
@@ -13,13 +14,11 @@ from .remote_value import RemoteValue
 class RemoteValueSceneNumber(RemoteValue[DPTArray, int]):
     """Abstraction for remote value of KNX DPT 17.001 (DPT_Scene_Number)."""
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 1
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -10,7 +10,7 @@ from abc import abstractmethod
 from typing import TYPE_CHECKING, TypeVar, Union
 
 from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -55,14 +55,14 @@ class _RemoteValueGeneric(RemoteValue[DPTArray, ValueType]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray)
+        if (
+            isinstance(payload, DPTArray)
             and len(payload.value) == self.dpt_class.payload_length
-            else None
-        )
+        ):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: ValueType) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -47,9 +47,11 @@ class RemoteValueStep(RemoteValue[DPTBinary, "RemoteValueStep.Direction"]):
         )
         self.invert = invert
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     # from KNX Association System Specifications AS v1.5.00:
     # 1.007 DPT_Step   0 = Decrease 1 = Increase

--- a/xknx/remote_value/remote_value_string.py
+++ b/xknx/remote_value/remote_value_string.py
@@ -6,6 +6,7 @@ DPT 16.000
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTString
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
@@ -13,14 +14,14 @@ from .remote_value import RemoteValue
 class RemoteValueString(RemoteValue[DPTArray, str]):
     """Abstraction for remote value of KNX 16.000 (DPT_String_ASCII)."""
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray)
+        if (
+            isinstance(payload, DPTArray)
             and len(payload.value) == DPTString.payload_length
-            else None
-        )
+        ):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: str) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -42,9 +42,11 @@ class RemoteValueSwitch(RemoteValue[DPTBinary, bool]):
         )
         self.invert = bool(invert)
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: bool) -> DPTBinary:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_temp.py
+++ b/xknx/remote_value/remote_value_temp.py
@@ -6,6 +6,7 @@ DPT 9.001.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature
+from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
@@ -13,13 +14,11 @@ from .remote_value import RemoteValue
 class RemoteValueTemp(RemoteValue[DPTArray, float]):
     """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
         """Test if telegram payload may be parsed."""
-        return (
-            payload
-            if isinstance(payload, DPTArray) and len(payload.value) == 2
-            else None
-        )
+        if isinstance(payload, DPTArray) and len(payload.value) == 2:
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: float) -> DPTArray:
         """Convert value to payload."""

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -47,9 +47,11 @@ class RemoteValueUpDown(RemoteValue[DPTBinary, "RemoteValueUpDown.Direction"]):
         )
         self.invert = invert
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary | None:
+    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
         """Test if telegram payload may be parsed."""
-        return payload if isinstance(payload, DPTBinary) else None
+        if isinstance(payload, DPTBinary):
+            return payload
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: RemoteValueUpDown.Direction) -> DPTBinary:
         """Convert value to payload."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Handle invalid payloads in RemoteValue. Log a warning when RemoteValue.payload_valid() fails for each RemoteValue processing the Telegram instead of handling the exception in TelegramQueue.
As a result wrongly configured GAs can be identified more easily and wrongly configured GAs (eg. from typos) for one device don't affect other devices.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
