### PR TITLE
Stop SecureSession keepalive_task when session is stopped

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Bug fixes
+
+- Stop SecureSession keepalive_task when session is stopped (and don't restart it from sending STATUS_CLOSE)
+
 ## 0.20.0 IP Secure 2022-03-29
 
 ### Features

--- a/test/io_tests/secure_session_test.py
+++ b/test/io_tests/secure_session_test.py
@@ -177,6 +177,7 @@ class TestSecureSession:
             mock_send.assert_called_once_with(session_status_close_frame)
             mock_super_send.assert_called_once()
             mock_transport.close.assert_called_once()
+            assert self.session._keepalive_task is None
 
     def test_uninitialized(self):
         """Test for raising when an encrypted Frame arrives at an uninitialized Session."""

--- a/xknx/io/secure_session.py
+++ b/xknx/io/secure_session.py
@@ -187,7 +187,6 @@ class SecureSession(TCPTransport):
         if self._session_status_handler:
             self.unregister_callback(self._session_status_handler)
             self._session_status_handler = None
-        self.stop_keepalive_task()
         if self.transport and self.initialized:
             self.send(
                 KNXIPFrame.init_from_body(
@@ -197,6 +196,7 @@ class SecureSession(TCPTransport):
                     )
                 )
             )
+        self.stop_keepalive_task()
         self.initialized = False
         super().stop()
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Stop SecureSession keepalive_task on `stop()` once and forever.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
