### PR TITLE
Properly shutdown ClimateMode if we shutdown Climate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased changes
+
+### Bug fixes
+
+- Properly shutdown climate mode if climate.shutdown() is called and ClimateMode exists
+
 ## 0.20.1 Add support for DPT 16.001 and SearchRequestExtended
 
 ### Features

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -94,6 +94,8 @@ await climate.set_setpoint_shift(1)
 # Reading climate device
 await climate.sync(wait_for_result=True)
 print("Current temperature: ", climate.temperature)
+# Shutdown the Climate and the underlying ClimateMode!
+climate.shutdown()
 ```
 
 ## [](#header-2)Example

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -159,6 +159,33 @@ class TestClimate:
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
 
+    def test_remove_climate_removes_climate_mode(self):
+        """Test shutting down climate will also shut down related ClimateMode."""
+
+        xknx = XKNX()
+        climate_mode = ClimateMode(
+            xknx,
+            name=None,
+            group_address_operation_mode="1/2/4",
+            group_address_operation_mode_state="1/2/5",
+            group_address_operation_mode_protection="1/2/6",
+            group_address_operation_mode_night="1/2/7",
+            group_address_operation_mode_comfort="1/2/8",
+            group_address_operation_mode_standby="1/2/9",
+            group_address_controller_status="1/2/10",
+            group_address_controller_status_state="1/2/11",
+            group_address_controller_mode="1/2/12",
+            group_address_controller_mode_state="1/2/13",
+            group_address_heat_cool="1/2/14",
+            group_address_heat_cool_state="1/2/15",
+        )
+
+        climate = Climate(xknx, name="TestClimate", mode=climate_mode)
+
+        assert len(xknx.devices) == 2
+        climate.shutdown()
+        assert len(xknx.devices) == 0
+
     async def test_process_callback_mode(self):
         """Test if after_update_callback is called after update of Climate object was changed."""
 

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -173,6 +173,12 @@ class Climate(Device):
         """Set power status to off."""
         await self.on.off()
 
+    def shutdown(self) -> None:
+        """Shutdown this device and the underlying mode."""
+        super().shutdown()
+        if self.mode:
+            self.mode.shutdown()
+
     @property
     def initialized_for_setpoint_shift_calculations(self) -> bool:
         """Test if object is initialized for setpoint shift calculations."""

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -78,7 +78,8 @@ class Device(ABC):
         self, device_updated_cb: DeviceCallbackType
     ) -> None:
         """Unregister device updated callback."""
-        self.device_updated_cbs.remove(device_updated_cb)
+        if device_updated_cb in self.device_updated_cbs:
+            self.device_updated_cbs.remove(device_updated_cb)
 
     async def after_update(self) -> None:
         """Execute callbacks after internal state has been changed."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Also shutdown ClimateMode if we call Climate.shutdown(). Those two types of devices inevitably belong together and should be treated like that as well. A Climate can exist without a ClimateMode but there is no reason a ClimateMode shall exist without a Climate.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
