### PR TITLE
Use `__repr__` instead of `__str__` in xknx.knxip

### DIFF
--- a/test/knxip_tests/srp_test.py
+++ b/test/knxip_tests/srp_test.py
@@ -71,11 +71,11 @@ class TestKNXIPSRP:
                 SRP.request_device_description(
                     [DIBTypeCode.SUPP_SVC_FAMILIES, DIBTypeCode.TUNNELING_INFO]
                 ),
-                bytes.fromhex("04 84 02 07"),
+                bytes.fromhex("04 04 02 07"),
             ),
             (
                 SRP.request_device_description([DIBTypeCode.SUPP_SVC_FAMILIES]),
-                bytes.fromhex("04 84 02 00"),
+                bytes.fromhex("04 04 02 00"),
             ),
         ],
     )

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -526,7 +526,7 @@ class TestStringRepresentations:
         assert (
             str(connect_request)
             == '<ConnectRequest control_endpoint="192.168.42.1:33941/udp" data_endpoint="192.168.42.2:33942/udp" '
-            'request_type="ConnectRequestType.TUNNEL_CONNECTION" />'
+            'request_type="ConnectRequestType.TUNNEL_CONNECTION" flags="0x2" />'
         )
 
     def test_connect_response(self):
@@ -550,7 +550,7 @@ class TestStringRepresentations:
         disconnect_request.control_endpoint = HPAI(ip_addr="192.168.42.1", port=33941)
         assert (
             str(disconnect_request)
-            == '<DisconnectRequest CommunicationChannelID="13" control_endpoint="192.168.42.1:33941/udp" />'
+            == '<DisconnectRequest communication_channel_id="13" control_endpoint="192.168.42.1:33941/udp" />'
         )
 
     def test_disconnect_response(self):
@@ -559,7 +559,7 @@ class TestStringRepresentations:
         disconnect_response.communication_channel_id = 23
         assert (
             str(disconnect_response)
-            == '<DisconnectResponse CommunicationChannelID="23" status_code="ErrorCode.E_NO_ERROR" />'
+            == '<DisconnectResponse communication_channel_id="23" status_code="ErrorCode.E_NO_ERROR" />'
         )
 
     def test_connectionstate_request(self):
@@ -571,7 +571,7 @@ class TestStringRepresentations:
         )
         assert (
             str(connectionstate_request)
-            == '<ConnectionStateRequest CommunicationChannelID="23", control_endpoint="192.168.42.1:33941/udp" />'
+            == '<ConnectionStateRequest communication_channel_id="23", control_endpoint="192.168.42.1:33941/udp" />'
         )
 
     def test_connectionstate_response(self):
@@ -580,7 +580,7 @@ class TestStringRepresentations:
         connectionstate_response.communication_channel_id = 23
         assert (
             str(connectionstate_response)
-            == '<ConnectionStateResponse CommunicationChannelID="23" status_code="ErrorCode.E_NO_ERROR" />'
+            == '<ConnectionStateResponse communication_channel_id="23" status_code="ErrorCode.E_NO_ERROR" />'
         )
 
     def test_search_reqeust(self):

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -194,7 +194,7 @@ class CEMIFrame:
             + self.payload.to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<CEMIFrame "

--- a/xknx/knxip/connect_request.py
+++ b/xknx/knxip/connect_request.py
@@ -71,11 +71,12 @@ class ConnectRequest(KNXIPBody):
             self.control_endpoint.to_knx() + self.data_endpoint.to_knx() + cri_to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<ConnectRequest "
             f'control_endpoint="{self.control_endpoint}" '
             f'data_endpoint="{self.data_endpoint}" '
-            f'request_type="{self.request_type}" />'
+            f'request_type="{self.request_type}" '
+            f'flags="{hex(self.flags)}" />'
         )

--- a/xknx/knxip/connect_response.py
+++ b/xknx/knxip/connect_response.py
@@ -83,7 +83,7 @@ class ConnectResponse(KNXIPBodyResponse):
             + crd_to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<ConnectResponse "

--- a/xknx/knxip/connectionstate_request.py
+++ b/xknx/knxip/connectionstate_request.py
@@ -52,10 +52,10 @@ class ConnectionStateRequest(KNXIPBody):
             + self.control_endpoint.to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<ConnectionStateRequest "
-            f'CommunicationChannelID="{self.communication_channel_id}", '
+            f'communication_channel_id="{self.communication_channel_id}", '
             f'control_endpoint="{self.control_endpoint}" />'
         )

--- a/xknx/knxip/connectionstate_response.py
+++ b/xknx/knxip/connectionstate_response.py
@@ -44,10 +44,10 @@ class ConnectionStateResponse(KNXIPBodyResponse):
         """Serialize to KNX/IP raw data."""
         return bytes((self.communication_channel_id, self.status_code.value))
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<ConnectionStateResponse "
-            f'CommunicationChannelID="{self.communication_channel_id}" '
+            f'communication_channel_id="{self.communication_channel_id}" '
             f'status_code="{self.status_code}" />'
         )

--- a/xknx/knxip/description_request.py
+++ b/xknx/knxip/description_request.py
@@ -32,6 +32,6 @@ class DescriptionRequest(KNXIPBody):
         """Serialize to KNX/IP raw data."""
         return self.control_endpoint.to_knx()
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return f'<DescriptionRequest control_endpoint="{self.control_endpoint}" />'

--- a/xknx/knxip/description_response.py
+++ b/xknx/knxip/description_response.py
@@ -48,7 +48,7 @@ class DescriptionResponse(KNXIPBody):
         """Serialize to KNX/IP raw data."""
         return b"".join(dib.to_knx() for dib in self.dibs)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
-        _dibs_str = ",\n".join(dib.__str__() for dib in self.dibs)
+        _dibs_str = ",\n".join(dib.__repr__() for dib in self.dibs)
         return "<DescriptionResponse " f'dibs="[\n{_dibs_str}\n]" />'

--- a/xknx/knxip/dib.py
+++ b/xknx/knxip/dib.py
@@ -112,7 +112,7 @@ class DIBGeneric(DIB):
             + bytes(len(self.data) % 2)  # padding
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return f'<DIB dtc="{self.dtc}" data="{", ".join(f"0x{i:02x}" for i in self.data)}" />'
 
@@ -197,7 +197,7 @@ class DIBDeviceInformation(DIB):
             + name_str_to_knx(self.name)
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<DIBDeviceInformation "
@@ -230,7 +230,7 @@ class DIBSuppSVCFamilies(DIB):
             """Serialize to KNX/IP raw data."""
             return bytes((self.name.value, self.version))
 
-        def __str__(self) -> str:
+        def __repr__(self) -> str:
             """Return object as readable string."""
             return f'<Family name="{self.name}" version="{self.version}" />'
 
@@ -281,7 +281,7 @@ class DIBSuppSVCFamilies(DIB):
             )
         ) + b"".join(family.to_knx() for family in self.families)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         _families_str = ", ".join(
             f"{family.name} version: {family.version}" for family in self.families
@@ -360,7 +360,7 @@ class DIBTunnelingInfo(DIB):
             )
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             f"<{self.__class__.__name__} max_adpu_lenght={self.max_apdu_length} "

--- a/xknx/knxip/disconnect_request.py
+++ b/xknx/knxip/disconnect_request.py
@@ -45,10 +45,10 @@ class DisconnectRequest(KNXIPBody):
             + self.control_endpoint.to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<DisconnectRequest "
-            f'CommunicationChannelID="{self.communication_channel_id}" '
+            f'communication_channel_id="{self.communication_channel_id}" '
             f'control_endpoint="{self.control_endpoint}" />'
         )

--- a/xknx/knxip/disconnect_response.py
+++ b/xknx/knxip/disconnect_response.py
@@ -49,10 +49,10 @@ class DisconnectResponse(KNXIPBodyResponse):
             )
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<DisconnectResponse "
-            f'CommunicationChannelID="{self.communication_channel_id}" '
+            f'communication_channel_id="{self.communication_channel_id}" '
             f'status_code="{self.status_code}" />'
         )

--- a/xknx/knxip/header.py
+++ b/xknx/knxip/header.py
@@ -55,7 +55,7 @@ class KNXIPHeader:
             + self.total_length.to_bytes(2, "big")
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<KNXIPHeader "

--- a/xknx/knxip/routing_indication.py
+++ b/xknx/knxip/routing_indication.py
@@ -49,6 +49,6 @@ class RoutingIndication(KNXIPBody):
             raise CouldNotParseKNXIP("No CEMIFrame defined.")
         return self.cemi.to_knx()
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return f'<RoutingIndication cemi="{self.cemi}" />'

--- a/xknx/knxip/search_request.py
+++ b/xknx/knxip/search_request.py
@@ -31,6 +31,6 @@ class SearchRequest(KNXIPBody):
         """Serialize to KNX/IP raw data."""
         return self.discovery_endpoint.to_knx()
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return f'<SearchRequest discovery_endpoint="{self.discovery_endpoint}" />'

--- a/xknx/knxip/search_request_extended.py
+++ b/xknx/knxip/search_request_extended.py
@@ -47,8 +47,10 @@ class SearchRequestExtended(KNXIPBody):
             bytes(srp) for srp in self.srps
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
-            f'<SearchRequestExtended discovery_endpoint="{self.discovery_endpoint}" />'
+            "<SearchRequestExtended "
+            f'discovery_endpoint="{self.discovery_endpoint}" '
+            f'srps="{self.srps}" />'
         )

--- a/xknx/knxip/search_response.py
+++ b/xknx/knxip/search_response.py
@@ -51,7 +51,7 @@ class SearchResponse(KNXIPBody):
             dib.to_knx() for dib in self.dibs
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         _dibs_str = ",\n".join(dib.__str__() for dib in self.dibs)
         return (

--- a/xknx/knxip/search_response_extended.py
+++ b/xknx/knxip/search_response_extended.py
@@ -25,7 +25,7 @@ class SearchResponseExtended(SearchResponse):
         """Initialize SearchResponse object."""
         super().__init__(control_endpoint)
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         _dibs_str = ",\n".join(dib.__str__() for dib in self.dibs)
         return (

--- a/xknx/knxip/secure_wrapper.py
+++ b/xknx/knxip/secure_wrapper.py
@@ -85,7 +85,7 @@ class SecureWrapper(KNXIPBody):
             + self.message_authentication_code
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             f"<SecureWrapper "

--- a/xknx/knxip/session_authenticate.py
+++ b/xknx/knxip/session_authenticate.py
@@ -60,7 +60,7 @@ class SessionAuthenticate(KNXIPBody):
             + self.message_authentication_code
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             f"<SessionAuthenticate "

--- a/xknx/knxip/session_request.py
+++ b/xknx/knxip/session_request.py
@@ -47,7 +47,7 @@ class SessionRequest(KNXIPBody):
         """Serialize to KNX/IP raw data."""
         return self.control_endpoint.to_knx() + self.ecdh_client_public_key
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             f"<SessionRequest "

--- a/xknx/knxip/session_response.py
+++ b/xknx/knxip/session_response.py
@@ -57,7 +57,7 @@ class SessionResponse(KNXIPBody):
             + self.message_authentication_code
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             f"<SessionResponse "

--- a/xknx/knxip/session_status.py
+++ b/xknx/knxip/session_status.py
@@ -53,6 +53,6 @@ class SessionStatus(KNXIPBody):
             )
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return f'<SessionStatus status="{self.status}" />'

--- a/xknx/knxip/srp.py
+++ b/xknx/knxip/srp.py
@@ -145,7 +145,7 @@ class SRP:
         """
         return SRP(
             srp_type=SearchRequestParameterType.REQUEST_DIBS,
-            mandatory=True,
+            mandatory=False,
             data=bytes(dib.value for dib in dibs),
         )
 

--- a/xknx/knxip/tunnelling_ack.py
+++ b/xknx/knxip/tunnelling_ack.py
@@ -51,7 +51,7 @@ class TunnellingAck(KNXIPBodyResponse):
             )
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<TunnellingAck "

--- a/xknx/knxip/tunnelling_request.py
+++ b/xknx/knxip/tunnelling_request.py
@@ -80,7 +80,7 @@ class TunnellingRequest(KNXIPBody):
             + self.cemi.to_knx()
         )
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """Return object as readable string."""
         return (
             "<TunnellingRequest "


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- These are perfectly reproduceable now so we can just print them in a better readable way anywhere. 
Additionally its a cheat-move to increase coverage for these package.
- Remove default `mandatory` flag of request_device_description SRP according to Frame sent by ETS

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
