### PR TITLE
Fix exposure of date, time and datetime object when threaded=True

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Bugfixes
+
+- Fix exposure of datetime, time and date objects to the Bus
+
 ### Internal
 
 - Include base class in `DPTBase.parse_transcoder()` lookup

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -115,7 +115,7 @@ class XKNX:
         """Start XKNX module. Connect to KNX/IP devices and start state updater."""
         if self.connection_config.threaded:
             await self.connection_manager.register_loop()
-        self.task_registry.start()
+            await self.task_registry.register_loop()
         self.knxip_interface = knx_interface_factory(
             xknx=self,
             connection_config=self.connection_config,
@@ -128,6 +128,7 @@ class XKNX:
         await self.knxip_interface.start()
         await self.telegram_queue.start()
         self.state_updater.start()
+        self.task_registry.start()
         self.started.set()
         if self.daemon_mode:
             await self.loop_until_sigint()


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
I assume that the second event loop in the connection thread was executed before the
tasks in the task registry were registered. And probably for some reason the currently running event loop
was the one from the connection thread. Since the event loop had already been started with run_forever() no new
tasks would be scheduled.

Fixes https://github.com/home-assistant/core/issues/69328

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have performed a self-review of my own code
- [x] The documentation has been adjusted accordingly
- [x] The changes generate no new warnings
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
