### PR TITLE
Don't handle KNX IP Secure devices when using automatic connection mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 
 - Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
 - Skip SearchResponse results for Core-V2 devices - wait for SearchResponseExtended
+- Identify interfaces having KNX IP Secure Tunneling required and skip if using Automatic connection mode
 
 ### Internals
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 ### Discovery
 
 - Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
+- Prefer SearchResponseExtended over SearchResponse results for same gateway
 
 ### Internals
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+### Discovery
+
+- Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
+
 ## 0.20.4 Fix exposure of time and date
 
 ### Bugfixes

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 ### Discovery
 
 - Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
-- Prefer SearchResponseExtended over SearchResponse results for same gateway
+- Skip SearchResponse results for Core-V2 devices - wait for SearchResponseExtended
 
 ### Internals
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,10 @@
 
 - Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
 
+### Internals
+
+- make HPAI hashable and add `addr_tuple` convenice property
+
 ## 0.20.4 Fix exposure of time and date
 
 ### Bugfixes

--- a/examples/example_gatewayscanner.py
+++ b/examples/example_gatewayscanner.py
@@ -3,16 +3,13 @@ import asyncio
 
 from xknx import XKNX
 from xknx.io import GatewayScanner
-from xknx.knxip import KNXIPServiceType
 
 
 async def main():
     """Search for available KNX/IP devices with GatewayScanner and print out result if a device was found."""
     xknx = XKNX()
     gatewayscanner = GatewayScanner(xknx)
-    gateways = await gatewayscanner.scan(
-        search_request_type=KNXIPServiceType.SEARCH_REQUEST_EXTENDED
-    )
+    gateways = await gatewayscanner.scan()
 
     if not gateways:
         print("No Gateways found")

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -166,8 +166,6 @@ class TestGatewayScanner:
             udp_transport_mock,
             interface="en1",
         )
-
-        assert str(gateway_scanner.found_gateways[0]) == str(self.gateway_desc_both)
         assert len(gateway_scanner.found_gateways) == 1
 
         gateway_scanner._response_rec_callback(
@@ -177,6 +175,10 @@ class TestGatewayScanner:
             interface="eth1",
         )
         assert len(gateway_scanner.found_gateways) == 1
+
+        assert str(
+            gateway_scanner.found_gateways[test_search_response.body.control_endpoint]
+        ) == str(self.gateway_desc_both)
 
     @patch("xknx.io.gateway_scanner.netifaces", autospec=True)
     async def test_scan_timeout(self, netifaces_mock):

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -12,7 +12,8 @@ from xknx.knxip import (
     DIBServiceFamily,
     DIBSuppSVCFamilies,
     KNXIPFrame,
-    KNXIPServiceType,
+    SearchRequest,
+    SearchRequestExtended,
     SearchResponse,
 )
 from xknx.telegram import IndividualAddress
@@ -193,36 +194,9 @@ class TestGatewayScanner:
         assert timed_out_scan == []
 
     @patch("xknx.io.gateway_scanner.netifaces", autospec=True)
-    @patch("xknx.io.GatewayScanner._search_interface", autospec=True)
-    async def test_send_search_requests(self, _search_interface_mock, netifaces_mock):
-        """Test finding all valid interfaces to send search requests to. No requests are sent."""
-        xknx = XKNX()
-
-        netifaces_mock.interfaces.return_value = self.fake_interfaces
-        netifaces_mock.ifaddresses = lambda interface: self.fake_ifaddresses[interface]
-        netifaces_mock.AF_INET = 2
-
-        async def async_none():
-            return None
-
-        _search_interface_mock.return_value = asyncio.ensure_future(async_none())
-
-        gateway_scanner = GatewayScanner(xknx, timeout_in_seconds=0)
-
-        test_scan = await gateway_scanner.scan()
-
-        assert _search_interface_mock.call_count == 2
-        expected_calls = [
-            ((gateway_scanner, "lo0", "127.0.0.1", KNXIPServiceType.SEARCH_REQUEST),),
-            ((gateway_scanner, "en1", "10.1.1.2", KNXIPServiceType.SEARCH_REQUEST),),
-        ]
-        assert _search_interface_mock.call_args_list == expected_calls
-        assert test_scan == []
-
-    @patch("xknx.io.gateway_scanner.netifaces", autospec=True)
-    @patch("xknx.io.GatewayScanner._search_interface", autospec=True)
-    async def test_send_search_request_extended(
-        self, _search_interface_mock, netifaces_mock
+    @patch("xknx.io.GatewayScanner._send_search_requests")
+    async def test_search_all_interfaces(
+        self, _send_search_requests_mock, netifaces_mock
     ):
         """Test finding all valid interfaces to send search request extended to. No requests are sent."""
         xknx = XKNX()
@@ -231,36 +205,37 @@ class TestGatewayScanner:
         netifaces_mock.ifaddresses = lambda interface: self.fake_ifaddresses[interface]
         netifaces_mock.AF_INET = 2
 
-        async def async_none():
-            return None
-
-        _search_interface_mock.return_value = asyncio.ensure_future(async_none())
-
         gateway_scanner = GatewayScanner(xknx, timeout_in_seconds=0)
 
-        test_scan = await gateway_scanner.scan(KNXIPServiceType.SEARCH_REQUEST_EXTENDED)
+        test_scan = await gateway_scanner.scan()
 
-        assert _search_interface_mock.call_count == 2
+        assert _send_search_requests_mock.call_count == 2
         expected_calls = [
-            (
-                (
-                    gateway_scanner,
-                    "lo0",
-                    "127.0.0.1",
-                    KNXIPServiceType.SEARCH_REQUEST_EXTENDED,
-                ),
-            ),
-            (
-                (
-                    gateway_scanner,
-                    "en1",
-                    "10.1.1.2",
-                    KNXIPServiceType.SEARCH_REQUEST_EXTENDED,
-                ),
-            ),
+            (("lo0", "127.0.0.1"),),
+            (("en1", "10.1.1.2"),),
         ]
-        assert _search_interface_mock.call_args_list == expected_calls
+        assert _send_search_requests_mock.call_args_list == expected_calls
         assert test_scan == []
+
+    @patch("xknx.io.gateway_scanner.UDPTransport.connect")
+    @patch("xknx.io.gateway_scanner.UDPTransport.send")
+    async def test_send_search_requests(
+        self,
+        udp_transport_send_mock,
+        udp_transport_connect_mock,
+    ):
+        """Test if both search requests are sent per interface."""
+        xknx = XKNX()
+        gateway_scanner = GatewayScanner(xknx, timeout_in_seconds=0)
+
+        await gateway_scanner._send_search_requests(interface="en1", ip_addr="10.1.1.2")
+
+        assert udp_transport_connect_mock.call_count == 1
+        assert udp_transport_send_mock.call_count == 2
+        frame_1 = udp_transport_send_mock.call_args_list[0].args[0]
+        frame_2 = udp_transport_send_mock.call_args_list[1].args[0]
+        assert isinstance(frame_1.body, SearchRequestExtended)
+        assert isinstance(frame_2.body, SearchRequest)
 
 
 def fake_router_search_response() -> KNXIPFrame:

--- a/xknx/io/gateway_scanner.py
+++ b/xknx/io/gateway_scanner.py
@@ -103,22 +103,6 @@ class GatewayDescriptor:
                 self.tunnelling_slots = dib.slots
                 continue
 
-    def match_free_slot(
-        self, individual_addresses: set[IndividualAddress]
-    ) -> IndividualAddress:
-        """Return free slot for tunnelling."""
-        if not self.tunnelling_slots:
-            raise KeyError(f"No slots information available for {self}")
-        if known_slots := individual_addresses.intersection(self.tunnelling_slots):
-            for _ia in known_slots:
-                if (
-                    self.tunnelling_slots[_ia].usable
-                    and self.tunnelling_slots[_ia].free
-                ):
-                    return _ia
-            raise KeyError(f"No free slot found on {self}")
-        raise KeyError(f"No known slot found on {self}")
-
     def __repr__(self) -> str:
         """Return object as representation string."""
         return (

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -149,6 +149,7 @@ class KNXIPInterface:
     async def _start_automatic(self) -> None:
         """Start GatewayScanner and connect to the found device."""
         scan_filter = self.connection_config.scan_filter
+        scan_filter.secure = False  # secure not supported for automatic connection
         gateway, local_interface_ip = await self.find_gateway(scan_filter)
         self._gateway_info = gateway
 

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -189,10 +189,7 @@ class _Tunnel(Interface):
             self.communication_channel = connect.communication_channel
             # assign data_endpoint received from server
             self._data_endpoint_addr = (
-                (
-                    connect.data_endpoint.ip_addr,
-                    connect.data_endpoint.port,
-                )
+                connect.data_endpoint.addr_tuple
                 if not connect.data_endpoint.route_back
                 else None
             )

--- a/xknx/knxip/hpai.py
+++ b/xknx/knxip/hpai.py
@@ -33,6 +33,11 @@ class HPAI:
         """Return True if HPAI is a route back address information."""
         return self.ip_addr == "0.0.0.0"
 
+    @property
+    def addr_tuple(self) -> tuple[str, int]:
+        """Return tuple of ip address and port."""
+        return self.ip_addr, self.port
+
     def from_knx(self, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
         if len(raw) < HPAI.LENGTH:
@@ -73,3 +78,7 @@ class HPAI:
     def __eq__(self, other: object) -> bool:
         """Equal operator."""
         return self.__dict__ == other.__dict__
+
+    def __hash__(self) -> int:
+        """Hash function."""
+        return hash((self.ip_addr, self.port, self.protocol))


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
### Discovery

 - Send SearchRequest and SearchRequestExtended simultaneously when using GatewayScanner
 - Skip SearchResponse results for Core-V2 devices - wait for SearchResponseExtended
- Identify interfaces having KNX IP Secure Tunneling required and skip if using Automatic connection mode

 ### Internals

 - make HPAI hashable and add `addr_tuple` convenice property

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
