### PR TITLE
Fix task registry for restarting tasks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased changes
 
+### Bugfixes
+
+- Fix exposure of datetime, time and date objects to the Bus again
+
+### Internals
+
+- TaskRegistry takes functions returning coroutines instead of coroutines directly
+
 ## 0.21.0 Search and connect 2022-04-30
 
 ### Discovery

--- a/test/core_tests/task_registry_test.py
+++ b/test/core_tests/task_registry_test.py
@@ -79,6 +79,7 @@ class TestTaskRegistry:
         await xknx.connection_manager.connection_state_changed(
             XknxConnectionState.CONNECTED
         )
+        # pylint: disable=attribute-defined-outside-init
         self.test = 0
 
         async def callback() -> None:

--- a/test/core_tests/task_registry_test.py
+++ b/test/core_tests/task_registry_test.py
@@ -22,7 +22,7 @@ class TestTaskRegistry:
 
         task = xknx.task_registry.register(
             name="test",
-            task=callback(),
+            task=callback,
         )
         assert len(xknx.task_registry.tasks) == 1
         task.start()
@@ -39,7 +39,7 @@ class TestTaskRegistry:
 
         task = xknx.task_registry.register(
             name="test",
-            task=callback(),
+            task=callback,
         )
         assert len(xknx.task_registry.tasks) == 1
         task.start()
@@ -60,7 +60,7 @@ class TestTaskRegistry:
 
         task = xknx.task_registry.register(
             name="test",
-            task=callback(),
+            task=callback,
         )
         assert len(xknx.task_registry.tasks) == 1
         task.start()
@@ -70,7 +70,7 @@ class TestTaskRegistry:
     #
     # TEST CONNECTION HANDLING
     #
-    async def test_reconnect_handling(self):
+    async def test_reconnect_handling(self, time_travel):
         """Test reconnect handling."""
 
         xknx = XKNX()
@@ -79,27 +79,42 @@ class TestTaskRegistry:
         await xknx.connection_manager.connection_state_changed(
             XknxConnectionState.CONNECTED
         )
+        self.test = 0
 
         async def callback() -> None:
             """Reset tasks."""
-            await asyncio.sleep(100)
+            try:
+                while True:
+                    await asyncio.sleep(100)
+                    self.test += 1
+            except asyncio.CancelledError:
+                self.test -= 1
 
         task = xknx.task_registry.register(
-            name="test", task=callback(), restart_after_reconnect=True
+            name="test", task=callback, restart_after_reconnect=True
         )
         assert len(xknx.task_registry.tasks) == 1
         task.start()
+        assert task._task is not None
+        await time_travel(100)
+        assert self.test == 1
         await xknx.connection_manager.connection_state_changed(
             XknxConnectionState.DISCONNECTED
         )
         assert task._task is None
+        assert self.test == 0
         await xknx.connection_manager.connection_state_changed(
             XknxConnectionState.CONNECTED
         )
         assert task._task is not None
+        assert self.test == 0
+        await time_travel(100)
+        assert self.test == 1
         assert len(xknx.task_registry.tasks) == 1
 
         xknx.task_registry.stop()
         assert len(xknx.task_registry.tasks) == 0
         assert task._task is None
+        await asyncio.sleep(0)  # iterate loop to cancel task
+        assert self.test == 0
         assert len(xknx.connection_manager._connection_state_changed_cbs) == 0

--- a/xknx/core/task_registry.py
+++ b/xknx/core/task_registry.py
@@ -23,21 +23,16 @@ class Task:
         name: str,
         task: AsyncCallbackType,
         restart_after_reconnect: bool = False,
-        loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         """Initialize Task class."""
         self.name = name
         self.task = task
         self.restart_after_reconnect = restart_after_reconnect
         self._task: asyncio.Task[None] | None = None
-        self._loop = loop
 
     def start(self) -> None:
         """Start a task."""
-        if self._loop is not None:
-            self._task = self._loop.create_task(self.task, name=self.name)
-        else:
-            self._task = asyncio.create_task(self.task, name=self.name)
+        self._task = asyncio.create_task(self.task, name=self.name)
 
     def __await__(self) -> Generator[None, None, None]:
         """Wait for task to be finished."""
@@ -71,14 +66,8 @@ class TaskRegistry:
 
     def __init__(self, xknx: XKNX) -> None:
         """Initialize TaskRegistry class."""
-        self._main_loop: asyncio.AbstractEventLoop | None = None
-
         self.xknx = xknx
         self.tasks: list[Task] = []
-
-    async def register_loop(self) -> None:
-        """Register the main loop for thread safe interaction."""
-        self._main_loop = asyncio.get_running_loop()
 
     def register(
         self,
@@ -91,10 +80,7 @@ class TaskRegistry:
         self.unregister(name)
 
         _task: Task = Task(
-            name=name,
-            task=task,
-            restart_after_reconnect=restart_after_reconnect,
-            loop=self._main_loop,
+            name=name, task=task, restart_after_reconnect=restart_after_reconnect
         )
 
         if track_task:

--- a/xknx/core/task_registry.py
+++ b/xknx/core/task_registry.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import TYPE_CHECKING, Any, Coroutine, Generator, Union
+from typing import TYPE_CHECKING, Any, Callable, Coroutine, Generator
 
 from xknx.core import XknxConnectionState
 
-AsyncCallbackType = Union[Generator[Any, None, Any], Coroutine[Any, Any, None]]
+AsyncCallbackType = Callable[[], Coroutine[Any, Any, None]]
 
 if TYPE_CHECKING:
     from xknx import XKNX
@@ -32,7 +32,7 @@ class Task:
 
     def start(self) -> None:
         """Start a task."""
-        self._task = asyncio.create_task(self.task, name=self.name)
+        self._task = asyncio.create_task(self.task(), name=self.name)
 
     def __await__(self) -> Generator[None, None, None]:
         """Wait for task to be finished."""

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -11,6 +11,7 @@ A BinarySensor may also have Actions attached which are executed after state was
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import time
 from typing import TYPE_CHECKING, Iterator, cast
 
@@ -92,7 +93,8 @@ class BinarySensor(Device):
             if self.ignore_internal_state and self._context_timeout:
                 self.bump_and_get_counter(state)
                 self._context_task = self.xknx.task_registry.register(
-                    self._context_task_name, self._counter_task(self._context_timeout)
+                    name=self._context_task_name,
+                    task=partial(self._counter_task, self._context_timeout),
                 )
                 self._context_task.start()
             else:
@@ -156,8 +158,8 @@ class BinarySensor(Device):
         """Create Task for resetting state if 'reset_after' is configured."""
         if self.reset_after is not None and self.state:
             self._reset_task = self.xknx.task_registry.register(
-                self._reset_task_name,
-                self._reset_state(self.reset_after),
+                name=self._reset_task_name,
+                task=partial(self._reset_state, self.reset_after),
                 track_task=True,
             )
             self._reset_task.start()

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -7,6 +7,7 @@ broadcasting localtime periodically.
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import time
 from typing import TYPE_CHECKING, Iterator
 
@@ -65,8 +66,8 @@ class DateTime(Device):
 
         if self.localtime:
             task: Task = self.xknx.task_registry.register(
-                f"datetime.broadcast_{id(self)}",
-                broadcast_loop(self, minutes=minutes),
+                name=f"datetime.broadcast_{id(self)}",
+                task=partial(broadcast_loop, self, minutes),
                 restart_after_reconnect=True,
             )
             task.start()

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -368,7 +368,8 @@ class Light(Device):
         if self._individual_color_debounce_telegram_counter > 0:
             # task registry cancels existing task
             self.xknx.task_registry.register(
-                self._individual_color_debounce_task_name, debouncer()
+                name=self._individual_color_debounce_task_name,
+                task=debouncer,
             ).start()
             return
         self.xknx.task_registry.unregister(self._individual_color_debounce_task_name)

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -9,6 +9,7 @@ It provides functionality for
 from __future__ import annotations
 
 import asyncio
+from functools import partial
 import logging
 from typing import TYPE_CHECKING, Iterator
 
@@ -87,8 +88,8 @@ class Switch(Device):
         if await self.switch.process(telegram):
             if self.reset_after is not None and self.switch.value:
                 self._reset_task = self.xknx.task_registry.register(
-                    self._reset_task_name,
-                    self._reset_state(self.reset_after),
+                    name=self._reset_task_name,
+                    task=partial(self._reset_state, self.reset_after),
                     track_task=True,
                 )
                 self._reset_task.start()

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -115,7 +115,7 @@ class XKNX:
         """Start XKNX module. Connect to KNX/IP devices and start state updater."""
         if self.connection_config.threaded:
             await self.connection_manager.register_loop()
-            await self.task_registry.register_loop()
+        self.task_registry.start()
         self.knxip_interface = knx_interface_factory(
             xknx=self,
             connection_config=self.connection_config,
@@ -128,7 +128,6 @@ class XKNX:
         await self.knxip_interface.start()
         await self.telegram_queue.start()
         self.state_updater.start()
-        self.task_registry.start()
         self.started.set()
         if self.daemon_mode:
             await self.loop_until_sigint()


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
TaskRegistry takes functions returning coroutines instead of coroutines directly. This enables restarting tasks.

Without this we would get (if we awaited for)
```py
Task exception was never retrieved
future: <Task finished name='Task-3' coro=<test() done, defined at <stdin>:1> exception=RuntimeError('cannot reuse already awaited coroutine')>
RuntimeError: cannot reuse already awaited coroutine
```

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] The documentation has been adjusted accordingly
- [ ] The changes generate no new warnings
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog
- [ ] The Homeassistant plugin has been adjusted in case of new config options
