### PR TITLE
Set unit_of_measurement for DPTString to None

### DIFF
--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -90,7 +90,6 @@ class TestDPTString:
         with pytest.raises(ConversionError):
             DPTString.from_knx(raw)
 
-    
     def test_no_unit_of_measurement(self):
         """Test for no unit set for DPT 16"""
         assert DPTString.unit is None

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -93,7 +93,4 @@ class TestDPTString:
     
     def test_no_unit_of_measurement(self):
         """Test for no unit set for DPT 16"""
-        assert DPTString.unit == None
-        assert DPTString.unit != ""
-        assert DPTLatin1.unit == None
-        assert DPTLatin1.unit != ""
+        assert DPTString.unit is None

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -89,3 +89,11 @@ class TestDPTString:
         """Test parsing of KNX string with wrong elements length."""
         with pytest.raises(ConversionError):
             DPTString.from_knx(raw)
+
+    
+    def test_no_unit_of_measurement(self):
+        """Test for no unit set for DPT 16"""
+        assert DPTString.unit == None
+        assert DPTString.unit != ""
+        assert DPTLatin1.unit == None
+        assert DPTLatin1.unit != ""

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -17,7 +17,7 @@ class DPTString(DPTBase):
     dpt_main_number = 16
     dpt_sub_number = 0
     value_type = "string"
-    unit = ""
+    unit = None
 
     _encoding = "ascii"
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
The representation of a sensor in Home Assistant depends on the unit of measurement. If a sensor has an attribute 'unit_of_measurement' it will be treated as a numerical value and therefore be shown in a graph in the history. This does not work for strings. By removing the attribute the sensor will be shown in the logbook instead / the history depiction is changed from a graph to a "state list".

Wrong:
![grafik](https://user-images.githubusercontent.com/88034398/171814829-4d83a39b-a30d-4a39-85e5-ed4406e7d41d.png)

Fixed:
![grafik](https://user-images.githubusercontent.com/88034398/171815023-276fc9be-4011-4508-a1e6-755dce8bfece.png)

It was discussed in the HA forum:
https://community.home-assistant.io/t/knx-string-sensor/427315

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)