### PR TITLE
GroupValue_Response triggers state update

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ nav_order: 2
 - Lock sending telegrams via a Tunnel until a confirmation is received
 - Use device subclass for `device_updated_cb` callback argument type hint
 - Fix CEMI Frame Ack-request flag set wrongly
+- `GroupValue_Response` triggers state update, when `always_callback: true`
 
 ## 0.21.3 Cover updates 2022-05-17
 

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -725,9 +725,10 @@ class TestSensor:
         after_update_callback.assert_called_once()
         after_update_callback.reset_mock()
 
-        # verify not called when processing read responses
+        # verify called when processing read responses
         await sensor.process(response_telegram)
-        after_update_callback.assert_not_called()
+        after_update_callback.assert_called_once()
+        after_update_callback.reset_mock()
 
     #
     # SYNC

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -81,7 +81,7 @@ class Sensor(Device):
 
     async def process_group_response(self, telegram: "Telegram") -> None:
         """Process incoming GroupValueResponse telegrams."""
-        await self.sensor_value.process(telegram)
+        await self.sensor_value.process(telegram, always_callback=self.always_callback)
 
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
A sensor with the option `always_callback: true` set, triggers a state_update in Homeassistant on a `GroupValue_Response` and therefore triggers state_updates in conjunction with `sync_state`.

Fixes #965 

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)