### PR TITLE
Add support for separate fan speed and on/off GAs

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ nav_order: 2
 - Lock sending telegrams via a Tunnel until a confirmation is received
 - Use device subclass for `device_updated_cb` callback argument type hint
 - Fix CEMI Frame Ack-request flag set wrongly
+- Fan: Add support for dedicated on/off switch GA
 
 ## 0.21.3 Cover updates 2022-05-17
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -9,16 +9,18 @@ nav_order: 4
 
 ## [](#header-2)Overview
 
-Fans are simple representations of KNX controlled fans. They support setting the speed and the oscillation.
+Fans are simple representations of KNX controlled fans. They support switching on/off, setting the speed and the oscillation.
 
 ## [](#header-2)Interface
 
 - `xknx` XKNX object.
 - `name` name of the device.
-- `group_address` is the KNX group address of the fan speed. Used for sending. *DPT 5.001 / 5.010*
-- `group_address_state` is the KNX group address of the fan speed state. Used for updating and reading state. *DPT 5.001 / 5.010*
+- `group_address_speed` is the KNX group address of the fan speed. Used for sending. If no `group_address_switch` is provided, it will implicitly control switching the fan on/off as well. *DPT 5.001 / 5.010*
+- `group_address_speed_state` is the KNX group address of the fan speed state. Used for updating and reading state. *DPT 5.001 / 5.010*
 - `group_address_oscillation` is the KNX group address of the oscillation. Used for sending. *DPT 1.001*
 - `group_address_oscillation_state` is the KNX group address of the fan oscillation state. Used for updating and reading state. *DPT 1.001*
+- `group_address_switch` is the KNX group address of the fan on/off state. If not used, on/off will implicitly be controlled via `group_address_speed` instead. Used for sending. *DPT 1.001*
+- `group_address_switch_state` is the KNX group address of the fan on/off state. Used for updating and reading state. *DPT 1.001*
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `device_updated_cb` awaitable callback for each update.
 - `max_step` Maximum step amount for fans which are controlled with steps and not percentage. If this attribute is set, the fan is controlled by sending the step value in the range `0` and `max_step`. In that case, the group address DPT changes from *DPT 5.001* to *DPT 5.010*. Default: None

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -28,12 +28,14 @@ Fans are simple representations of KNX controlled fans. They support switching o
 ## [](#header-2)Example
 
 ```python
-fan = Fan(xknx,
-              'TestFan',
-              group_address='1/2/1',
-              group_address_state='1/2/2',
-              group_address_oscillation='1/2/3',
-              group_address_oscillation_state='1/2/4')
+fan = Fan(
+    xknx,
+    'TestFan',
+    group_address_speed='1/2/1',
+    group_address_speed_state='1/2/2',
+    group_address_oscillation='1/2/3',
+    group_address_oscillation_state='1/2/4'
+)
 
 # Set the fan speed
 await fan.set_speed(50)
@@ -44,8 +46,11 @@ print(fan.current_speed)
 # Set the oscillation
 await fan.set_oscillation(True)
 
-# Accessing speed
+# Accessing oscillation
 print(fan.current_oscillation)
+
+# Accessing on/off state
+print(fan.is_on)
 
 # Requesting state via KNX GroupValueRead
 await fan.sync()

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -406,9 +406,13 @@ class TestFan:
             group_address_speed_state="1/7/2",
             group_address_oscillation="1/6/1",
             group_address_oscillation_state="1/6/2",
+            group_address_switch="1/5/1",
+            group_address_switch_state="1/5/2",
         )
         assert fan.has_group_address(GroupAddress("1/7/1"))
         assert fan.has_group_address(GroupAddress("1/7/2"))
         assert not fan.has_group_address(GroupAddress("1/7/3"))
         assert fan.has_group_address(GroupAddress("1/6/1"))
         assert fan.has_group_address(GroupAddress("1/6/2"))
+        assert fan.has_group_address(GroupAddress("1/5/1"))
+        assert fan.has_group_address(GroupAddress("1/5/2"))

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -60,6 +60,43 @@ class TestFan:
         )
 
     #
+    # TEST SWITCH ON/OFF
+    #
+    async def test_swith_on_off(self):
+        """Test switching on/off of a Fan."""
+        xknx = XKNX()
+        fan = Fan(xknx, name="TestFan", group_address_switch="1/2/3")
+
+        # Turn the fan on
+        await fan.turn_on()
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+
+        # Turn the fan off
+        await fan.turn_off()
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(0)),
+        )
+
+        # Turn the fan on again this time with a provided speed, which however has no
+        # additional effect, since in the switch GA mode, the speed during switching on
+        # will not be considered since that is controlled independently in this mode
+        await fan.turn_on(55)
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+
+    #
     # TEST SET SPEED
     #
     async def test_set_speed(self):

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -61,7 +61,7 @@ class Fan(Device):
         self.max_step = max_step
 
         # If there is a dedicated switch GA, it controls the on/off behavior of the fan.
-        # Otherwise the speed GA of the fan implicitely controls the on/off behavior instead.
+        # Otherwise the speed GA of the fan implicitly controls the on/off behavior instead.
         # `self.switch.initialized`` can be used to check which setup is used.
         self.switch = RemoteValueSwitch(
             xknx,

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -122,7 +122,7 @@ class Fan(Device):
             return bool(self.switch.value)
         return bool(self.current_speed)
 
-    async def turn_on(self, speed: int) -> None:
+    async def turn_on(self, speed: int | None = None) -> None:
         """Turn on fan."""
         if self.switch.initialized:
             await self.set_on()
@@ -144,9 +144,10 @@ class Fan(Device):
         """Switch off fan."""
         await self.switch.off()
 
-    async def set_speed(self, speed: int) -> None:
+    async def set_speed(self, speed: int | None) -> None:
         """Set the fan to a designated speed."""
-        await self.speed.set(speed)
+        if speed is not None:
+            await self.speed.set(speed)
 
     async def set_oscillation(self, oscillation: bool) -> None:
         """Set the fan oscillation mode on or off."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from xknx.telegram import Telegram
     from xknx.xknx import XKNX
 
-DEFAULT_TURN_ON_PERCENTAGE = 50
+DEFAULT_TURN_ON_SPEED = 50
 
 logger = logging.getLogger("xknx.log")
 
@@ -129,10 +129,11 @@ class Fan(Device):
         if self.switch.initialized:
             await self.switch.on()
             # For a switch GA fan, we only use an explicitly provided speed, but not
-            # arbitrarily set a default percentage here, compared to the speed GA based fans below.
-            await self.set_speed(speed)
+            # arbitrarily set a default speed here, compared to the speed GA based fans below.
+            if speed is not None:
+                await self.set_speed(speed)
         else:
-            await self.set_speed(speed or DEFAULT_TURN_ON_PERCENTAGE)
+            await self.set_speed(speed or DEFAULT_TURN_ON_SPEED)
 
     async def turn_off(self) -> None:
         """Turn off fan."""
@@ -141,10 +142,9 @@ class Fan(Device):
         else:
             await self.set_speed(0)
 
-    async def set_speed(self, speed: int | None) -> None:
+    async def set_speed(self, speed: int) -> None:
         """Set the fan to a designated speed."""
-        if speed is not None:
-            await self.speed.set(speed)
+        await self.speed.set(speed)
 
     async def set_oscillation(self, oscillation: bool) -> None:
         """Set the fan oscillation mode on or off."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -125,24 +125,16 @@ class Fan(Device):
     async def turn_on(self, speed: int | None = None) -> None:
         """Turn on fan."""
         if self.switch.initialized:
-            await self.set_on()
+            await self.switch.on()
         else:
             await self.set_speed(speed)
 
     async def turn_off(self) -> None:
         """Turn off fan."""
         if self.switch.initialized:
-            await self.set_off()
+            await self.switch.off()
         else:
             await self.set_speed(0)
-
-    async def set_on(self) -> None:
-        """Switch on fan."""
-        await self.switch.on()
-
-    async def set_off(self) -> None:
-        """Switch off fan."""
-        await self.switch.off()
 
     async def set_speed(self, speed: int | None) -> None:
         """Set the fan to a designated speed."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from xknx.telegram import Telegram
     from xknx.xknx import XKNX
 
+DEFAULT_TURN_ON_PERCENTAGE = 50
+
 logger = logging.getLogger("xknx.log")
 
 
@@ -126,8 +128,11 @@ class Fan(Device):
         """Turn on fan."""
         if self.switch.initialized:
             await self.switch.on()
-        else:
+            # For a switch GA fan, we only use an explicitly provided speed, but not
+            # arbitrarily set a default percentage here, compared to the speed GA based fans below.
             await self.set_speed(speed)
+        else:
+            await self.set_speed(speed or DEFAULT_TURN_ON_PERCENTAGE)
 
     async def turn_off(self) -> None:
         """Turn off fan."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -61,18 +61,17 @@ class Fan(Device):
         self.max_step = max_step
 
         # If there is no dedicated speed GA, then the main GA of the fan serves
-        # as speed GA (and implicitely on/off as well). If however there is a dedicated GA,
-        # then the regular state GA becomes an on/off switch.
-        if group_address_speed is not None:
-            self.switch = RemoteValueSwitch(
-                xknx,
-                group_address,
-                group_address_state,
-                sync_state=sync_state,
-                device_name=self.name,
-                feature_name="State",
-                after_update_cb=self.after_update,
-            )
+        # as speed GA (and implicitely on/off as well). If however there is a dedicated
+        # speed GA, then the regular state GA becomes an on/off switch.
+        self.switch = RemoteValueSwitch(
+            xknx,
+            group_address if group_address_speed is not None else None,
+            group_address_state if group_address_speed_state is not None else None,
+            sync_state=sync_state,
+            device_name=self.name,
+            feature_name="State",
+            after_update_cb=self.after_update,
+        )
 
         if self.mode == FanSpeedMode.STEP:
             self.speed = RemoteValueDptValue1Ucount(

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -60,8 +60,9 @@ class Fan(Device):
         self.mode = FanSpeedMode.STEP if max_step else FanSpeedMode.PERCENT
         self.max_step = max_step
 
-        # If there is no dedicated switch GA, then the speed GA of the fan
-        # controls the on/off behavior as well.
+        # If there is a dedicated switch GA, it controls the on/off behavior of the fan.
+        # Otherwise the speed GA of the fan implicitely controls the on/off behavior instead.
+        # `self.switch.initialized`` can be used to check which setup is used.
         self.switch = RemoteValueSwitch(
             xknx,
             group_address_switch,
@@ -113,11 +114,6 @@ class Fan(Device):
     def supports_oscillation(self) -> bool:
         """Return if fan supports oscillation."""
         return self.oscillation.initialized
-
-    @property
-    def has_on_off_switch(self) -> bool:
-        """Return if fan has separate speed GA, which in turns means a separate on/off switch GA."""
-        return self.switch.initialized
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

Added two new optional variables to provide GAs for fan switch. This closes the gap for fans where the steps/percentage have no influence on the on/off state. If those new GAs are not provided, then the existing behavior of controlling on/off via the fan speed remains.

The only breaking change part is that now if you turn on a fan without a switch GA, a default speed of 50% will automatically be set (unless the caller provides an explicit value of course). This default was previously set by the HA integration. See comment below reg. the reasoning behind it: https://github.com/XKNX/xknx/pull/967#discussion_r891028912

Corresponding HA integration PR: https://github.com/home-assistant/core/pull/73131

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] The documentation has been adjusted accordingly
- [X] Tests have been added that prove the fix is effective or that the feature works
- [X] The changes are documented in the changelog (docs/changelog.md)