### PR TITLE
Fix DPT 2 Byte numeric limits and refactor logic

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ nav_order: 2
 
 # Changelog
 
+## Unreleased changes
+
+### Internal
+
+- Fix DPT2ByteFloat numeric range issues
+
 ## 0.22.1 Wrong delivery 2022-07-29
 
 ### Management

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -79,6 +79,13 @@ class TestDPTFloat:
         assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_max) == (0x7F, 0xFF)
         assert DPT2ByteFloat.from_knx((0x7F, 0xFF)) == DPT2ByteFloat.value_max
 
+    def test_close_to_limit(self):
+        """Test parsing and streaming of DPT2ByteFloat with numeric limit."""
+        assert DPT2ByteFloat.to_knx(20.48) == (0x0C, 0x00)
+        assert DPT2ByteFloat.from_knx((0x0C, 0x00)) == 20.48
+        assert DPT2ByteFloat.to_knx(-20.48) == (0x80, 0x00)
+        assert DPT2ByteFloat.from_knx((0x80, 0x00)) == -20.48
+
     def test_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value."""
         assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_min) == (0xF8, 0x00)


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Fix numeric limits for DPT 2 Byte Float and refactor the logic to be better readable according to the spec.

Fixes https://github.com/home-assistant/core/issues/76686

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)