### PR TITLE
 Properly log repeated heartbeat errors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ nav_order: 2
 ### Bugfixes
 
 - Correctly retry sending a TunnellingRequest if no TunnellingAck was received for the first time for UDP tunnelling connections.
+- Properly log repeated heartbeat errors
 
 ## 1.0.0 Support for lukewarm temperatures 2022-08-13
 

--- a/test/io_tests/tunnel_test.py
+++ b/test/io_tests/tunnel_test.py
@@ -8,21 +8,25 @@ from xknx import XKNX
 from xknx.dpt import DPTArray
 from xknx.exceptions import CommunicationError
 from xknx.io import TCPTunnel, UDPTunnel
+from xknx.io.const import CONNECTIONSTATE_REQUEST_TIMEOUT, HEARTBEAT_RATE
 from xknx.io.gateway_scanner import GatewayDescriptor
 from xknx.knxip import (
     HPAI,
     CEMIFrame,
+    ConnectionStateRequest,
+    ConnectionStateResponse,
     ConnectRequest,
     ConnectResponse,
     DescriptionRequest,
     DescriptionResponse,
     DisconnectRequest,
     DisconnectResponse,
+    ErrorCode,
     KNXIPFrame,
     TunnellingAck,
     TunnellingRequest,
 )
-from xknx.knxip.knxip_enum import CEMIMessageCode
+from xknx.knxip.knxip_enum import CEMIMessageCode, HostProtocol
 from xknx.telegram import IndividualAddress, Telegram, TelegramDirection
 from xknx.telegram.apci import GroupValueWrite
 
@@ -379,3 +383,171 @@ class TestTCPTunnel:
         # one call for the outgoing request. No Acks for TCP.
         assert self.tunnel.transport.send.call_count == 1
         await task
+
+    async def test_tunnel_heartbeat(self, time_travel):
+        """Test tunnel sends heartbeat frame."""
+        local_addr = ("192.168.1.1", 12345)
+        remote_hpai = HPAI(
+            ip_addr="192.168.1.2", port=3671, protocol=HostProtocol.IPV4_TCP
+        )
+        self.tunnel.transport.connect = AsyncMock()
+        self.tunnel.transport.getsockname = Mock(return_value=(local_addr))
+        self.tunnel.transport.send = Mock()
+        self.tunnel.transport.stop = Mock()
+        self.tunnel._tunnel_lost = Mock()
+
+        # Connect
+        connection_task = asyncio.create_task(self.tunnel.connect())
+        await time_travel(0)
+        self.tunnel.transport.connect.assert_called_once()
+
+        connect_response_frame = KNXIPFrame.init_from_body(
+            ConnectResponse(
+                communication_channel=23,
+                data_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+                identifier=7,
+            )
+        )
+        self.tunnel.transport.handle_knxipframe(connect_response_frame, remote_hpai)
+        await connection_task
+        self.tunnel.transport.send.reset_mock()
+
+        # Send heartbeat
+        heartbeat_request = KNXIPFrame.init_from_body(
+            ConnectionStateRequest(
+                communication_channel_id=23,
+                control_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+            )
+        )
+        heartbeat_response = KNXIPFrame.init_from_body(
+            ConnectionStateResponse(
+                communication_channel_id=23,
+                status_code=ErrorCode.E_NO_ERROR,
+            )
+        )
+        await time_travel(HEARTBEAT_RATE)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel.transport.handle_knxipframe(heartbeat_response, remote_hpai)
+        # test no retry-heartbeat was sent
+        await time_travel(CONNECTIONSTATE_REQUEST_TIMEOUT)
+        self.tunnel.transport.send.assert_not_called()
+        # next regular heartbeat
+        await time_travel(HEARTBEAT_RATE - CONNECTIONSTATE_REQUEST_TIMEOUT)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel._tunnel_lost.assert_not_called()
+
+    async def test_tunnel_heartbeat_no_answer(self, time_travel):
+        """Test tunnel sends heartbeat frame."""
+        local_addr = ("192.168.1.1", 12345)
+        remote_hpai = HPAI(
+            ip_addr="192.168.1.2", port=3671, protocol=HostProtocol.IPV4_TCP
+        )
+        self.tunnel.transport.connect = AsyncMock()
+        self.tunnel.transport.getsockname = Mock(return_value=(local_addr))
+        self.tunnel.transport.send = Mock()
+        self.tunnel.transport.stop = Mock()
+        self.tunnel._tunnel_lost = Mock()
+
+        # Connect
+        connection_task = asyncio.create_task(self.tunnel.connect())
+        await time_travel(0)
+        self.tunnel.transport.connect.assert_called_once()
+
+        connect_response_frame = KNXIPFrame.init_from_body(
+            ConnectResponse(
+                communication_channel=23,
+                data_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+                identifier=7,
+            )
+        )
+        self.tunnel.transport.handle_knxipframe(connect_response_frame, remote_hpai)
+        await connection_task
+        self.tunnel.transport.send.reset_mock()
+
+        # Send heartbeat
+        heartbeat_request = KNXIPFrame.init_from_body(
+            ConnectionStateRequest(
+                communication_channel_id=23,
+                control_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+            )
+        )
+        await time_travel(HEARTBEAT_RATE)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        # no answer - repeat 3 times
+        await time_travel(CONNECTIONSTATE_REQUEST_TIMEOUT)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        await time_travel(CONNECTIONSTATE_REQUEST_TIMEOUT)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        await time_travel(CONNECTIONSTATE_REQUEST_TIMEOUT)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        await time_travel(CONNECTIONSTATE_REQUEST_TIMEOUT)
+        # no answer - tunnel lost
+        self.tunnel._tunnel_lost.assert_called_once()
+
+    async def test_tunnel_heartbeat_error(self, time_travel):
+        """Test tunnel sends heartbeat frame."""
+        local_addr = ("192.168.1.1", 12345)
+        remote_hpai = HPAI(
+            ip_addr="192.168.1.2", port=3671, protocol=HostProtocol.IPV4_TCP
+        )
+        self.tunnel.transport.connect = AsyncMock()
+        self.tunnel.transport.getsockname = Mock(return_value=(local_addr))
+        self.tunnel.transport.send = Mock()
+        self.tunnel.transport.stop = Mock()
+        self.tunnel._tunnel_lost = Mock()
+
+        # Connect
+        connection_task = asyncio.create_task(self.tunnel.connect())
+        await time_travel(0)
+        self.tunnel.transport.connect.assert_called_once()
+
+        connect_response_frame = KNXIPFrame.init_from_body(
+            ConnectResponse(
+                communication_channel=23,
+                data_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+                identifier=7,
+            )
+        )
+        self.tunnel.transport.handle_knxipframe(connect_response_frame, remote_hpai)
+        await connection_task
+        self.tunnel.transport.send.reset_mock()
+
+        # Send heartbeat
+        heartbeat_request = KNXIPFrame.init_from_body(
+            ConnectionStateRequest(
+                communication_channel_id=23,
+                control_endpoint=HPAI(protocol=HostProtocol.IPV4_TCP),
+            )
+        )
+        heartbeat_error_response = KNXIPFrame.init_from_body(
+            ConnectionStateResponse(
+                communication_channel_id=23,
+                status_code=ErrorCode.E_CONNECTION_ID,
+            )
+        )
+        await time_travel(HEARTBEAT_RATE)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel.transport.handle_knxipframe(heartbeat_error_response, remote_hpai)
+        # repeat 3 times
+        await time_travel(0)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel.transport.handle_knxipframe(heartbeat_error_response, remote_hpai)
+        await time_travel(0)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel.transport.handle_knxipframe(heartbeat_error_response, remote_hpai)
+        await time_travel(0)
+        self.tunnel.transport.send.assert_called_once_with(heartbeat_request)
+        self.tunnel.transport.send.reset_mock()
+        self.tunnel.transport.handle_knxipframe(heartbeat_error_response, remote_hpai)
+        await time_travel(0)
+        # third retry had an error - tunnel lost
+        self.tunnel._tunnel_lost.assert_called_once()

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -410,7 +410,7 @@ class _Tunnel(Interface):
                 if not success:
                     await self._do_heartbeat_failed()
             except CommunicationError as err:
-                logger.warning("Heartbeat to KNX bus failed. %s", err)
+                logger.warning(err)
                 self._tunnel_lost()
 
     async def _do_heartbeat_failed(self) -> None:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Before we were always logging 
> WARNING (KNX Interface) [xknx.log] Heartbeat to KNX bus failed. No answer from tunneling server.

even if we had an answer with an error status code like `E_CONNECTION_ID`

See https://github.com/home-assistant/core/issues/77113

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)