### PR TITLE
Fix management frame handling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ nav_order: 2
 
 # Changelog
 
+# Unreleased changes
+
+### Management
+
+- Fix APCI service parsing for 10bit control fileds.
+- Set reasonable default count values for APCI classes.
+- Set xknx.current_address for routing connections so management frames received over Routing are handled properly.
+- Fix wrong length of AuthorizeRequest.
+- Raise sane error messages in Management.
+
 # 1.2.0 Secure Routing 2022-10-10
 
 ### Features

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -1014,7 +1014,7 @@ class TestAuthorizeRequest:
         """Test the test_calculated_length method."""
         payload = AuthorizeRequest(key=12345678)
 
-        assert payload.calculated_length() == 5
+        assert payload.calculated_length() == 6
 
     def test_from_knx(self):
         """Test the from_knx method."""

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -172,6 +172,7 @@ class Routing(Interface):
 
     async def connect(self) -> bool:
         """Start routing."""
+        self.xknx.current_address = self.xknx.own_address
         await self.xknx.connection_manager.connection_state_changed(
             XknxConnectionState.CONNECTING
         )

--- a/xknx/management/management.py
+++ b/xknx/management/management.py
@@ -152,7 +152,7 @@ class P2PConnection:
             self._response_waiter.cancel()
             raise ManagementConnectionError(
                 f"Connection to {self.address} failed: {exc}"
-            )
+            ) from exc
         except CommunicationError as exc:
             self._response_waiter.cancel()
             raise ManagementConnectionError("Error while sending Telegram") from exc
@@ -177,7 +177,7 @@ class P2PConnection:
         except ConfirmationError as exc:
             raise ManagementConnectionError(
                 f"Disconnect from {self.address} failed: {exc}"
-            )
+            ) from exc
         except CommunicationError as exc:
             raise ManagementConnectionError("Error while sending Telegram") from exc
         finally:
@@ -253,9 +253,11 @@ class P2PConnection:
             except asyncio.TimeoutError:
                 raise ManagementConnectionTimeout(
                     "No ACK received for repeated telegram."
-                )
+                ) from None
         except ConfirmationError as exc:
-            raise ManagementConnectionError(f"Error while sending Telegram: {exc}")
+            raise ManagementConnectionError(
+                f"Error while sending Telegram: {exc}"
+            ) from exc
         except CommunicationError as exc:
             raise ManagementConnectionError("Error while sending Telegram") from exc
         finally:
@@ -277,7 +279,9 @@ class P2PConnection:
                 self._response_waiter, timeout=MANAGAMENT_CONNECTION_TIMEOUT
             )
         except asyncio.TimeoutError:
-            raise ManagementConnectionTimeout()
+            raise ManagementConnectionTimeout(
+                f"Timeout while waiting for {expected_payload}"
+            ) from None
         finally:
             # set up new Future for the next request
             self._response_waiter = asyncio.get_event_loop().create_future()

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -1094,7 +1094,7 @@ class AuthorizeRequest(APCI):
 
     def calculated_length(self) -> int:
         """Get length of APCI payload."""
-        return 5
+        return 6
 
     def from_knx(self, raw: bytes) -> None:
         """Parse/deserialize from KNX/IP raw data."""

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -420,7 +420,7 @@ class ADCRead(APCI):
 
     CODE = APCIService.ADC_READ
 
-    def __init__(self, channel: int = 0, count: int = 0) -> None:
+    def __init__(self, channel: int = 0, count: int = 1) -> None:
         """Initialize a new instance of ADCRead."""
         self.channel = channel
         self.count = count
@@ -495,7 +495,7 @@ class MemoryRead(APCI):
 
     CODE = APCIService.MEMORY_READ
 
-    def __init__(self, address: int = 0, count: int = 0) -> None:
+    def __init__(self, address: int = 0, count: int = 1) -> None:
         """Initialize a new instance of MemoryRead."""
         self.address = address
         self.count = count
@@ -538,7 +538,7 @@ class MemoryWrite(APCI):
     CODE = APCIService.MEMORY_WRITE
 
     def __init__(
-        self, address: int = 0, count: int = 0, data: bytes | None = None
+        self, address: int = 0, count: int = 1, data: bytes | None = None
     ) -> None:
         """Initialize a new instance of MemoryWrite."""
 
@@ -590,7 +590,7 @@ class MemoryResponse(APCI):
     CODE = APCIService.MEMORY_RESPONSE
 
     def __init__(
-        self, address: int = 0, count: int = 0, data: bytes | None = None
+        self, address: int = 0, count: int = 1, data: bytes | None = None
     ) -> None:
         """Initialize a new instance of MemoryResponse."""
 
@@ -745,7 +745,7 @@ class UserMemoryRead(APCI):
 
     CODE = APCIUserService.USER_MEMORY_READ
 
-    def __init__(self, address: int = 0, count: int = 0) -> None:
+    def __init__(self, address: int = 0, count: int = 1) -> None:
         """Initialize a new instance of UserMemoryRead."""
         self.address = address
         self.count = count
@@ -790,7 +790,7 @@ class UserMemoryWrite(APCI):
     CODE = APCIUserService.USER_MEMORY_WRITE
 
     def __init__(
-        self, address: int = 0, count: int = 0, data: bytes | None = None
+        self, address: int = 0, count: int = 1, data: bytes | None = None
     ) -> None:
         """Initialize a new instance of UserMemoryWrite."""
 
@@ -844,7 +844,7 @@ class UserMemoryResponse(APCI):
     CODE = APCIUserService.USER_MEMORY_RESPONSE
 
     def __init__(
-        self, address: int = 0, count: int = 0, data: bytes | None = None
+        self, address: int = 0, count: int = 1, data: bytes | None = None
     ) -> None:
         """Initialize a new instance of UserMemoryResponse."""
 
@@ -1152,7 +1152,7 @@ class PropertyValueRead(APCI):
         self,
         object_index: int = 0,
         property_id: int = 0,
-        count: int = 0,
+        count: int = 1,
         start_index: int = 1,
     ) -> None:
         """Initialize a new instance of PropertyValueRead."""
@@ -1216,7 +1216,7 @@ class PropertyValueWrite(APCI):
         self,
         object_index: int = 0,
         property_id: int = 0,
-        count: int = 0,
+        count: int = 1,
         start_index: int = 0,
         data: bytes | None = None,
     ) -> None:
@@ -1295,7 +1295,7 @@ class PropertyValueResponse(APCI):
         self,
         object_index: int = 0,
         property_id: int = 0,
-        count: int = 0,
+        count: int = 1,
         start_index: int = 0,
         data: bytes | None = None,
     ) -> None:
@@ -1407,7 +1407,7 @@ class PropertyDescriptionResponse(APCI):
         property_id: int = 0,
         property_index: int = 0,
         type_: int = 0,
-        max_count: int = 0,
+        max_count: int = 1,
         access: int = 0,
     ) -> None:
         """Initialize a new instance of PropertyDescriptionRead."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- fix APCI service parsing for 10bit control fileds
- set reasonable default count values for APCI classes
- set xknx.current_address for routing connections so management frames received over Routing are handled
- fix wrong length of AuthorizeRequest
- raise sane error messages in Management 

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)