### PR TITLE
Use upper case L for liter

### DIFF
--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -244,21 +244,21 @@ class DPTPower2Byte(DPT2ByteFloat):
 
 
 class DPTVolumeFlow(DPT2ByteFloat):
-    """DPT 9.025 DPT_Value_Volume_Flow (l/h)."""
+    """DPT 9.025 DPT_Value_Volume_Flow (L/h)."""
 
     dpt_main_number = 9
     dpt_sub_number = 25
     value_type = "volume_flow"
-    unit = "l/h"
+    unit = "L/h"
 
 
 class DPTRainAmount(DPT2ByteFloat):
-    """DPT 9.026 DPT_Rain_Amount (l/m²)."""
+    """DPT 9.026 DPT_Rain_Amount (L/m²)."""
 
     dpt_main_number = 9
     dpt_sub_number = 26
     value_type = "rain_amount"
-    unit = "l/m²"
+    unit = "L/m²"
 
     value_min = -671088.64
     value_max = 670760.96

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -85,7 +85,7 @@ class DPTVolumeLiquidLitre(DPT4ByteUnsigned):
     dpt_main_number = 12
     dpt_sub_number = 1200
     value_type = "volume_liquid_litre"
-    unit = "l"
+    unit = "L"
 
 
 class DPTVolumeM3(DPT4ByteUnsigned):


### PR DESCRIPTION
This matches unit used in home assistant.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

The unit used for liters in home assistant is upper case L. So let's provide that as default.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)