### PR TITLE
Refactor GatewayScanFilter

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Connection
+
+- GatewayScanFilter now also matches secure enabled gateways by default. The `secure` argument as been replaced by `secure_tunnelling` and `secure_routing` arguments. When multiple methods are `True` a gateway is matched if one of them is supported. Non-secure methods don't match if secure is required for that gateway.
+
 ### Features
 
 - Add support for python 3.11

--- a/test/io_tests/gateway_scanner_test.py
+++ b/test/io_tests/gateway_scanner_test.py
@@ -214,72 +214,99 @@ class TestGatewayScanner:
         supports_secure=True,
     )
     gateway_desc_secure_tunnel.tunnelling_requires_secure = True
+    gateway_desc_secure_router = GatewayDescriptor(
+        name="KNX-Secure-Router",
+        ip_addr="10.1.1.12",
+        port=3761,
+        local_interface="en1",
+        local_ip="10.1.1.100",
+        supports_tunnelling=False,
+        supports_routing=True,
+    )
+    gateway_desc_secure_router.routing_requires_secure = True
 
     def test_gateway_scan_filter_match(self):
         """Test match function of gateway filter."""
         filter_default = GatewayScanFilter()
-        filter_tunnel = GatewayScanFilter(tunnelling=True)
-        filter_tcp_tunnel = GatewayScanFilter(tunnelling_tcp=True, secure=None)
-        filter_secure_tunnel = GatewayScanFilter(tunnelling_tcp=True, secure=True)
-        filter_router = GatewayScanFilter(routing=True)
+        filter_tunnel = GatewayScanFilter(routing=False, secure_routing=False)
+        filter_tcp_tunnel = GatewayScanFilter(
+            tunnelling=False,
+            tunnelling_tcp=True,
+            secure_tunnelling=None,
+            routing=False,
+            secure_routing=False,
+        )
+        filter_secure_tunnel = GatewayScanFilter(
+            tunnelling=False,
+            tunnelling_tcp=False,
+            secure_tunnelling=True,
+            routing=False,
+            secure_routing=False,
+        )
+        filter_router = GatewayScanFilter(
+            tunnelling=False,
+            tunnelling_tcp=False,
+            secure_tunnelling=False,
+            routing=True,
+            secure_routing=False,
+        )
         filter_name = GatewayScanFilter(name="KNX-Router")
-        filter_no_tunnel = GatewayScanFilter(tunnelling=False)
-        filter_no_router = GatewayScanFilter(routing=False)
-        filter_tunnel_and_router = GatewayScanFilter(tunnelling=True, routing=True)
+        filter_secure_router = GatewayScanFilter(
+            tunnelling=False,
+            tunnelling_tcp=False,
+            secure_tunnelling=False,
+            routing=False,
+            secure_routing=True,
+        )
 
         assert filter_default.match(self.gateway_desc_interface)
         assert filter_default.match(self.gateway_desc_router)
         assert filter_default.match(self.gateway_desc_both)
         assert not filter_default.match(self.gateway_desc_neither)
-        assert not filter_default.match(self.gateway_desc_secure_tunnel)
+        assert filter_default.match(self.gateway_desc_secure_tunnel)
+        assert filter_default.match(self.gateway_desc_secure_router)
 
         assert filter_tunnel.match(self.gateway_desc_interface)
         assert not filter_tunnel.match(self.gateway_desc_router)
         assert filter_tunnel.match(self.gateway_desc_both)
         assert not filter_tunnel.match(self.gateway_desc_neither)
-        assert not filter_tunnel.match(self.gateway_desc_secure_tunnel)
+        assert filter_tunnel.match(self.gateway_desc_secure_tunnel)
+        assert not filter_tunnel.match(self.gateway_desc_secure_router)
 
         assert not filter_tcp_tunnel.match(self.gateway_desc_interface)
         assert not filter_tcp_tunnel.match(self.gateway_desc_router)
         assert filter_tcp_tunnel.match(self.gateway_desc_both)
         assert not filter_tcp_tunnel.match(self.gateway_desc_neither)
-        assert filter_tcp_tunnel.match(self.gateway_desc_secure_tunnel)
+        assert not filter_tcp_tunnel.match(self.gateway_desc_secure_tunnel)
+        assert not filter_tcp_tunnel.match(self.gateway_desc_secure_router)
 
         assert not filter_secure_tunnel.match(self.gateway_desc_interface)
         assert not filter_secure_tunnel.match(self.gateway_desc_router)
         assert not filter_secure_tunnel.match(self.gateway_desc_both)
         assert not filter_secure_tunnel.match(self.gateway_desc_neither)
         assert filter_secure_tunnel.match(self.gateway_desc_secure_tunnel)
+        assert not filter_secure_tunnel.match(self.gateway_desc_secure_router)
 
         assert not filter_router.match(self.gateway_desc_interface)
         assert filter_router.match(self.gateway_desc_router)
         assert filter_router.match(self.gateway_desc_both)
         assert not filter_router.match(self.gateway_desc_neither)
         assert not filter_router.match(self.gateway_desc_secure_tunnel)
+        assert not filter_router.match(self.gateway_desc_secure_router)
 
         assert not filter_name.match(self.gateway_desc_interface)
         assert filter_name.match(self.gateway_desc_router)
         assert not filter_name.match(self.gateway_desc_both)
         assert not filter_name.match(self.gateway_desc_neither)
         assert not filter_name.match(self.gateway_desc_secure_tunnel)
+        assert not filter_name.match(self.gateway_desc_secure_router)
 
-        assert not filter_no_tunnel.match(self.gateway_desc_interface)
-        assert filter_no_tunnel.match(self.gateway_desc_router)
-        assert not filter_no_tunnel.match(self.gateway_desc_both)
-        assert not filter_no_tunnel.match(self.gateway_desc_neither)
-        assert not filter_no_tunnel.match(self.gateway_desc_secure_tunnel)
-
-        assert filter_no_router.match(self.gateway_desc_interface)
-        assert not filter_no_router.match(self.gateway_desc_router)
-        assert not filter_no_router.match(self.gateway_desc_both)
-        assert not filter_no_router.match(self.gateway_desc_neither)
-        assert not filter_no_router.match(self.gateway_desc_secure_tunnel)
-
-        assert not filter_tunnel_and_router.match(self.gateway_desc_interface)
-        assert not filter_tunnel_and_router.match(self.gateway_desc_router)
-        assert filter_tunnel_and_router.match(self.gateway_desc_both)
-        assert not filter_tunnel_and_router.match(self.gateway_desc_neither)
-        assert not filter_tunnel_and_router.match(self.gateway_desc_secure_tunnel)
+        assert not filter_secure_router.match(self.gateway_desc_interface)
+        assert not filter_secure_router.match(self.gateway_desc_router)
+        assert not filter_secure_router.match(self.gateway_desc_both)
+        assert not filter_secure_router.match(self.gateway_desc_neither)
+        assert not filter_secure_router.match(self.gateway_desc_secure_tunnel)
+        assert filter_secure_router.match(self.gateway_desc_secure_router)
 
     def test_search_response_reception(self):
         """Test function of gateway scanner."""

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -175,20 +175,26 @@ class KNXIPInterface:
         async for gateway in GatewayScanner(
             self.xknx,
             local_ip=self.connection_config.local_ip,
-            scan_filter=self.connection_config.scan_filter,  # secure disabled by default
+            scan_filter=self.connection_config.scan_filter,
         ).async_scan():
             try:
-                if gateway.supports_tunnelling_tcp:
+                if (
+                    gateway.supports_tunnelling_tcp
+                    and not gateway.tunnelling_requires_secure
+                ):
                     await self._start_tunnelling_tcp(
                         gateway_ip=gateway.ip_addr,
                         gateway_port=gateway.port,
                     )
-                elif gateway.supports_tunnelling:
+                elif (
+                    gateway.supports_tunnelling
+                    and not gateway.tunnelling_requires_secure
+                ):
                     await self._start_tunnelling_udp(
                         gateway_ip=gateway.ip_addr,
                         gateway_port=gateway.port,
                     )
-                elif gateway.supports_routing:
+                elif gateway.supports_routing and not gateway.routing_requires_secure:
                     await self._start_routing(
                         local_ip=self.connection_config.local_ip,
                     )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
GatewayScanFilter now also matches secure enabled gateways by default. The `secure` argument as been replaced by `secure_tunnelling` and `secure_routing` arguments. When multiple methods are `True` a gateway is matched if one of them is supported. Non-secure methods don't match if secure is required for that gateway.

In "Automatic" connection mode secure-required gateways are skipped.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)