### PR TITLE
Move individual address configuration to ConnectionConfig

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Internal
+
+- Removed `own_address` from `XKNX` class. `ConnectionConfig` `individual_address` can be used to set a source address for routing instead.
+
 ### Connection
 
 - GatewayScanFilter now also matches secure enabled gateways by default. The `secure` argument as been replaced by `secure_tunnelling` and `secure_routing` arguments. When multiple methods are `True` a gateway is matched if one of them is supported. Non-secure methods don't match if secure is required for that gateway.

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -20,7 +20,6 @@ The `XKNX()` object is the core element of any XKNX installation. It should be o
 
 ```python
 xknx = XKNX(
-    own_address=DEFAULT_ADDRESS,
     address_format=GroupAddressType.LONG,
     connection_state_changed_cb=None,
     telegram_received_cb=None,
@@ -37,7 +36,6 @@ xknx = XKNX(
 
 The constructor of the XKNX object takes several parameters:
 
-- `own_address` may be used to specify the individual (physical) KNX address of the XKNX daemon. If not speficied it uses `15.15.250`.
 - `address_format` may be used to specify the type of group addresses to use. Possible values are:
   - FREE: integer or hex representation
   - SHORT: representation like '1/34' without middle groups

--- a/test/io_tests/routing_test.py
+++ b/test/io_tests/routing_test.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 
 from xknx import XKNX
 from xknx.io import Routing
+from xknx.io.const import DEFAULT_INDIVIDUAL_ADDRESS
 from xknx.io.routing import (
     BUSY_DECREMENT_TIME,
     BUSY_INCREMENT_COOLDOWN,
@@ -12,7 +13,7 @@ from xknx.io.routing import (
     _RoutingFlowControl,
 )
 from xknx.knxip import CEMIFrame, KNXIPFrame, RoutingBusy, RoutingIndication
-from xknx.telegram import Telegram, TelegramDirection, tpci
+from xknx.telegram import IndividualAddress, Telegram, TelegramDirection, tpci
 
 
 class TestRouting:
@@ -29,7 +30,8 @@ class TestRouting:
         """Test Routing for responding to a transport layer connection."""
         routing = Routing(
             self.xknx,
-            self.tg_received_mock,
+            individual_address=None,
+            telegram_received_callback=self.tg_received_mock,
             local_ip="192.168.1.1",
         )
         # L_Data.ind T_Connect from 1.0.250 to 1.0.255 (xknx tunnel endpoint)
@@ -45,7 +47,8 @@ class TestRouting:
         response_frame = KNXIPFrame.init_from_body(
             RoutingIndication(
                 cemi=CEMIFrame.init_from_telegram(
-                    telegram=response_telegram, src_addr=self.xknx.own_address
+                    telegram=response_telegram,
+                    src_addr=DEFAULT_INDIVIDUAL_ADDRESS,
                 )
             )
         )
@@ -67,7 +70,8 @@ class TestRouting:
         """Test class for received RoutingLostMessage frames."""
         routing = Routing(
             self.xknx,
-            AsyncMock(),
+            individual_address=None,
+            telegram_received_callback=AsyncMock(),
             local_ip="192.168.1.1",
         )
         raw = bytes((0x06, 0x10, 0x05, 0x31, 0x00, 0x0A, 0x04, 0x00, 0x00, 0x05))

--- a/xknx/io/connection.py
+++ b/xknx/io/connection.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from enum import Enum, auto
 
+from xknx.telegram.address import IndividualAddress, IndividualAddressableType
+
 from .const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from .gateway_scanner import GatewayScanFilter
 
@@ -28,6 +30,7 @@ class ConnectionConfig:
         * ROUTING use KNX/IP multicast routing.
         * TUNNELING connect to a specific KNX/IP tunneling device via UDP.
         * TUNNELING_TCP connect to a specific KNX/IP tunneling v2 device via TCP.
+    * individual address: the individual address used as source address for routing.
     * local_ip: Local ip of the interface though which KNXIPInterface should connect.
     * gateway_ip: IP of KNX/IP tunneling device.
     * gateway_port: Port of KNX/IP tunneling device.
@@ -47,6 +50,7 @@ class ConnectionConfig:
         self,
         *,
         connection_type: ConnectionType = ConnectionType.AUTOMATIC,
+        individual_address: IndividualAddressableType | None = None,
         local_ip: str | None = None,
         local_port: int = 0,
         gateway_ip: str | None = None,
@@ -62,6 +66,9 @@ class ConnectionConfig:
     ):
         """Initialize ConnectionConfig class."""
         self.connection_type = connection_type
+        self.individual_address = (
+            IndividualAddress(individual_address) if individual_address else None
+        )
         self.local_ip = local_ip
         self.local_port = local_port
         self.gateway_ip = gateway_ip

--- a/xknx/io/const.py
+++ b/xknx/io/const.py
@@ -1,14 +1,18 @@
 """KNX Constants used within io."""
+from typing import Final
 
-DEFAULT_MCAST_GRP = "224.0.23.12"
-DEFAULT_MCAST_PORT = 3671
+from xknx.telegram.address import IndividualAddress
 
-CONNECTION_ALIVE_TIME = 120
-CONNECTIONSTATE_REQUEST_TIMEOUT = 10
-HEARTBEAT_RATE = CONNECTION_ALIVE_TIME - (CONNECTIONSTATE_REQUEST_TIMEOUT * 5)
+DEFAULT_INDIVIDUAL_ADDRESS: Final = IndividualAddress("15.15.250")
+DEFAULT_MCAST_GRP: Final = "224.0.23.12"
+DEFAULT_MCAST_PORT: Final = 3671
+
+CONNECTION_ALIVE_TIME: Final = 120
+CONNECTIONSTATE_REQUEST_TIMEOUT: Final = 10
+HEARTBEAT_RATE: Final = CONNECTION_ALIVE_TIME - (CONNECTIONSTATE_REQUEST_TIMEOUT * 5)
 
 # Maximum time an authenticated secure session may remain unused (without
 # any communication over this session) until the session will be dropped.
-SESSION_TIMEOUT = 60
-SESSION_KEEPALIVE_RATE = SESSION_TIMEOUT - 10
-XKNX_SERIAL_NUMBER = bytes.fromhex("00 00 78 6b 6e 78")
+SESSION_TIMEOUT: Final = 60
+SESSION_KEEPALIVE_RATE: Final = SESSION_TIMEOUT - 10
+XKNX_SERIAL_NUMBER: Final = bytes.fromhex("00 00 78 6b 6e 78")

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -25,7 +25,7 @@ from xknx.secure import load_key_ring
 from xknx.telegram import IndividualAddress, Telegram
 
 from .connection import ConnectionConfig, ConnectionType
-from .const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
+from .const import DEFAULT_INDIVIDUAL_ADDRESS, DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
 from .gateway_scanner import GatewayDescriptor, GatewayScanner
 from .routing import Routing, SecureRouting
 from .tunnel import SecureTunnel, TCPTunnel, UDPTunnel, _Tunnel
@@ -316,17 +316,21 @@ class KNXIPInterface:
         if local_ip is None:
             raise XKNXException("No network interface found.")
         util.validate_ip(local_ip, address_name="Local IP address")
+        individual_address = (
+            self.connection_config.individual_address or DEFAULT_INDIVIDUAL_ADDRESS
+        )
 
         logger.debug(
             "Starting Routing from %s as %s via %s:%s",
             local_ip,
-            self.xknx.own_address,
+            individual_address,
             multicast_group,
             multicast_port,
         )
         self._interface = Routing(
             self.xknx,
-            self.telegram_received,
+            individual_address=individual_address,
+            telegram_received_callback=self.telegram_received,
             local_ip=local_ip,
             multicast_group=multicast_group,
             multicast_port=multicast_port,
@@ -346,17 +350,21 @@ class KNXIPInterface:
         if local_ip is None:
             raise XKNXException("No network interface found.")
         util.validate_ip(local_ip, address_name="Local IP address")
+        individual_address = (
+            self.connection_config.individual_address or DEFAULT_INDIVIDUAL_ADDRESS
+        )
 
         logger.debug(
             "Starting Secure Routing from %s as %s via %s:%s",
             local_ip,
-            self.xknx.own_address,
+            individual_address,
             multicast_group,
             multicast_port,
         )
         self._interface = SecureRouting(
             self.xknx,
-            self.telegram_received,
+            individual_address=individual_address,
+            telegram_received_callback=self.telegram_received,
             local_ip=local_ip,
             backbone_key=backbone_key,
             latency_ms=latency_ms,

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -70,7 +70,7 @@ class _Tunnel(Interface):
         self._initial_connection = True
         self._is_reconnecting = False
         self._reconnect_task: asyncio.Task[None] | None = None
-        self._src_address = xknx.own_address
+        self._src_address = IndividualAddress(0)
         self._send_telegram_lock = asyncio.Lock()
         self._tunnelling_request_confirmation_event = asyncio.Event()
 
@@ -200,7 +200,7 @@ class _Tunnel(Interface):
             self._src_address = IndividualAddress(connect.identifier)
             self.xknx.current_address = self._src_address
             logger.debug(
-                "Tunnel established communication_channel=%s, address=%s",
+                "Tunnel established. communication_channel=%s, address=%s",
                 connect.communication_channel,
                 self._src_address,
             )

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -36,12 +36,10 @@ logger = logging.getLogger("xknx.log")
 class XKNX:
     """Class for reading and writing KNX/IP packets."""
 
-    DEFAULT_ADDRESS = "15.15.250"
     DEFAULT_RATE_LIMIT = 20
 
     def __init__(
         self,
-        own_address: str | IndividualAddress = DEFAULT_ADDRESS,
         address_format: GroupAddressType = GroupAddressType.LONG,
         telegram_received_cb: Callable[[Telegram], Awaitable[None]] | None = None,
         device_updated_cb: Callable[[Device], Awaitable[None]] | None = None,
@@ -71,7 +69,6 @@ class XKNX:
         self.daemon_mode = daemon_mode
         self.multicast_group = multicast_group
         self.multicast_port = multicast_port
-        self.own_address = IndividualAddress(own_address)
         self.rate_limit = rate_limit
         self.sigint_received = asyncio.Event()
         self.started = asyncio.Event()


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Removed `own_address` from `XKNX` class. `ConnectionConfig` `individual_address` can be used to set a source address for routing instead.

In a later addition this individual address can be used to look up a secure interface from a keyfile when using secure tunnelling.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)