### PR TITLE
Disable TelegramQueue rate limiting by default

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ nav_order: 2
 ### Internal
 
 - Removed `own_address` from `XKNX` class. `ConnectionConfig` `individual_address` can be used to set a source address for routing instead.
+- Disable TelegramQueue rate limiting by default.
 
 ### Connection
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,14 +8,16 @@ nav_order: 2
 
 # Unreleased changes
 
-### Internal
+### Interface changes
 
 - Removed `own_address` from `XKNX` class. `ConnectionConfig` `individual_address` can be used to set a source address for routing instead.
 - Disable TelegramQueue rate limiting by default.
+- Separate discovery multicast group from routing group. Add `multicast_group` and `multicast_port` `ConnectionConfig` parameters.
 
-### Connection
+### Connection and Discovery
 
 - GatewayScanFilter now also matches secure enabled gateways by default. The `secure` argument as been replaced by `secure_tunnelling` and `secure_routing` arguments. When multiple methods are `True` a gateway is matched if one of them is supported. Non-secure methods don't match if secure is required for that gateway.
+- Self description queries more information from Core v2 devices via SearchRequestExtended.
 
 ### Features
 
@@ -29,14 +31,9 @@ nav_order: 2
 - Fix wrong length of AuthorizeRequest.
 - Raise sane error messages in Management.
 
-# Internal
-
-- Self description queries more information from Core v2 devices via SearchRequestExtended.
-
 # Bugfixes
 
 - No mutable default arguments. Fixes unexpected behaviour like GatewayScanner not finding all interfaces.
-- Separate discovery multicast group from routing group. Add `multicast_group` and `multicast_port` `ConnectionConfig` parameters.
 
 # 1.2.1 Hotfix release 2022-11-20
 

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -24,7 +24,7 @@ xknx = XKNX(
     connection_state_changed_cb=None,
     telegram_received_cb=None,
     device_updated_cb=None,
-    rate_limit=DEFAULT_RATE_LIMIT,
+    rate_limit=0,
     multicast_group=DEFAULT_MCAST_GRP,
     multicast_port=DEFAULT_MCAST_PORT,
     log_directory=None,
@@ -43,7 +43,7 @@ The constructor of the XKNX object takes several parameters:
 - `connection_state_changed_cb` is a callback which is called every time the connection state to the gateway changes. See [callbacks](#callbacks) documentation for details.
 - `telegram_received_cb` is a callback which is called after every received KNX telegram. See [callbacks](#callbacks) documentation for details.
 - `device_updated_cb` is an async callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
-- `rate_limit` in telegrams per second - can be used to limit the outgoing traffic to the KNX/IP interface. The default value is 20 packets per second.
+- `rate_limit` in telegrams per second - can be used to limit the outgoing traffic to the KNX/IP interface by the telegram queue. `0` disables rate limiter. Disabled by default.
 - `multicast_group` is the multicast group used for discovery - can be used to override the default multicast address (`224.0.23.12`)
 - `multicast_port` is the multicast port used for discovery - can be used to override the default multicast port (`3671`)
 - `log_directory` is the path to the log directory - when set to a valid directory we log to a dedicated file in this directory called `xknx.log`. The log files are rotated each night and will exist for 7 days. After that the oldest one will be deleted.

--- a/test/core_tests/telegram_queue_test.py
+++ b/test/core_tests/telegram_queue_test.py
@@ -49,8 +49,9 @@ class TestTelegramQueue:
     @patch("asyncio.sleep", new_callable=AsyncMock)
     async def test_rate_limit(self, async_sleep_mock):
         """Test rate limit."""
-        xknx = XKNX()
-        xknx.rate_limit = 20  # 50 ms per outgoing telegram
+        xknx = XKNX(
+            rate_limit=20,  # 50 ms per outgoing telegram
+        )
         sleep_time = 0.05  # 1 / 20
 
         telegram_in = Telegram(

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -183,7 +183,6 @@ class TestSensorExposeLoop:
         """Test sensor and expose_sensor with different values."""
         xknx = XKNX()
         xknx.knxip_interface = AsyncMock()
-        xknx.rate_limit = False
         await xknx.telegram_queue.start()
 
         expose = ExposeSensor(
@@ -254,7 +253,6 @@ class TestBinarySensorExposeLoop:
         """Test binary_sensor and expose_sensor with binary values."""
         xknx = XKNX()
         xknx.knxip_interface = AsyncMock()
-        xknx.rate_limit = False
         await xknx.telegram_queue.start()
 
         expose = ExposeSensor(
@@ -317,7 +315,6 @@ class TestBinarySensorInternalGroupAddressExposeLoop:
         """Test binary_sensor and expose_sensor with binary values."""
         xknx = XKNX()
         xknx.knxip_interface = AsyncMock()
-        xknx.rate_limit = False
 
         telegram_callback = AsyncMock()
         xknx.telegram_queue.register_telegram_received_cb(

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -36,8 +36,6 @@ logger = logging.getLogger("xknx.log")
 class XKNX:
     """Class for reading and writing KNX/IP packets."""
 
-    DEFAULT_RATE_LIMIT = 20
-
     def __init__(
         self,
         address_format: GroupAddressType = GroupAddressType.LONG,
@@ -45,7 +43,7 @@ class XKNX:
         device_updated_cb: Callable[[Device], Awaitable[None]] | None = None,
         connection_state_changed_cb: Callable[[XknxConnectionState], Awaitable[None]]
         | None = None,
-        rate_limit: int = DEFAULT_RATE_LIMIT,
+        rate_limit: int = 0,
         multicast_group: str = DEFAULT_MCAST_GRP,
         multicast_port: int = DEFAULT_MCAST_PORT,
         log_directory: str | None = None,


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Disable TelegramQueue rate limiting by default. 
This is now properly handled by tunnel/routing classes and should not be needed in normal operation.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)