### PR TITLE
Decouple CEMI parsing from KNXIPFrame parsing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Internal
+
+- Decouple KNXIPFrame parsing from CEMIFrame parsing. TunnellingRequest and RoutingIndication now carry the raw cemi frame payload as bytes. This allows decoupled CEMIFrame parsing at a later time (in Interface class rather than in KNXIPTransport class) for better error handling and upcoming features.
+
 # 2.1.0 Enhance notification device
 
 ### Devices

--- a/test/io_tests/request_response_tests/tunnelling_test.py
+++ b/test/io_tests/request_response_tests/tunnelling_test.py
@@ -24,16 +24,16 @@ class TestTunnelling:
         """Test tunnelling from KNX bus."""
         data_endpoint = ("192.168.1.2", 4567)
         udp_transport = UDPTransport(("192.168.1.1", 0), ("192.168.1.2", 1234))
-        cemi = CEMIFrame.init_from_telegram(
+        raw_cemi = CEMIFrame.init_from_telegram(
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
                 payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
             )
-        )
+        ).to_knx()
         tunnelling_request = TunnellingRequest(
             communication_channel_id=23,
             sequence_counter=42,
-            cemi=cemi,
+            raw_cemi=raw_cemi,
         )
         tunnelling = Tunnelling(udp_transport, data_endpoint, tunnelling_request)
         tunnelling.timeout_in_seconds = 0

--- a/test/io_tests/routing_test.py
+++ b/test/io_tests/routing_test.py
@@ -64,6 +64,23 @@ class TestRouting:
         ]
 
     @patch("logging.Logger.warning")
+    async def test_routing_indication_received_apci_unsupported(self, logging_mock):
+        """Test Tunnel sending ACK for unsupported frames."""
+        routing = Routing(
+            self.xknx,
+            individual_address=None,
+            telegram_received_callback=self.tg_received_mock,
+            local_ip="192.168.1.1",
+        )
+        # LDataInd Unsupported Extended APCI from 0.0.1 to 0/0/0 broadcast
+        # <UnsupportedCEMIMessage description="APCI not supported: 0b1111111000 in CEMI: 2900b0d0000100000103f8" />
+        raw = bytes.fromhex("0610 0530 0010 2900b0d0000100000103f8")
+
+        routing.transport.data_received_callback(raw, ("192.168.1.2", 3671))
+        self.tg_received_mock.assert_not_called()
+        logging_mock.assert_called_once()
+
+    @patch("logging.Logger.warning")
     async def test_routing_lost_message(self, logging_mock):
         """Test class for received RoutingLostMessage frames."""
         routing = Routing(

--- a/test/io_tests/routing_test.py
+++ b/test/io_tests/routing_test.py
@@ -37,20 +37,18 @@ class TestRouting:
         # L_Data.ind T_Connect from 1.0.250 to 1.0.255 (xknx tunnel endpoint)
         # communication_channel_id: 0x02   sequence_counter: 0x81
         raw_ind = bytes.fromhex("0610 0530 0010 2900b06010fa10ff0080")
-
         _cemi = CEMIFrame()
         _cemi.from_knx(raw_ind[6:])
         test_telegram = _cemi.telegram
         test_telegram.direction = TelegramDirection.INCOMING
 
         response_telegram = Telegram(tpci=tpci.TDisconnect())
+        response_cemi = CEMIFrame.init_from_telegram(
+            telegram=response_telegram,
+            src_addr=DEFAULT_INDIVIDUAL_ADDRESS,
+        )
         response_frame = KNXIPFrame.init_from_body(
-            RoutingIndication(
-                cemi=CEMIFrame.init_from_telegram(
-                    telegram=response_telegram,
-                    src_addr=DEFAULT_INDIVIDUAL_ADDRESS,
-                )
-            )
+            RoutingIndication(raw_cemi=response_cemi.to_knx())
         )
 
         async def tg_received_mock(telegram):

--- a/test/io_tests/secure_group_test.py
+++ b/test/io_tests/secure_group_test.py
@@ -410,23 +410,27 @@ class TestSecureGroup:
         secure_timer = secure_group.secure_timer
         secure_timer.timer_authenticated = True
 
-        test_cemi = CEMIFrame.init_from_telegram(
+        raw_test_cemi = CEMIFrame.init_from_telegram(
             Telegram(
                 destination_address=GroupAddress("1/2/3"),
                 payload=apci.GroupValueRead(),
             )
-        )
+        ).to_knx()
 
         with patch.object(
             secure_timer, "reschedule", wraps=secure_timer.reschedule
         ) as mock_reschedule:
             assert not secure_timer.sched_update
-            secure_group.send(KNXIPFrame.init_from_body(RoutingIndication(test_cemi)))
+            secure_group.send(
+                KNXIPFrame.init_from_body(RoutingIndication(raw_cemi=raw_test_cemi))
+            )
             mock_reschedule.assert_called_once()
             mock_reschedule.reset_mock()
             # no reschedule when sched_update is true
             secure_timer.reschedule(update=(bytes(2), bytes(6)))
             assert secure_timer.sched_update
             mock_reschedule.reset_mock()
-            secure_group.send(KNXIPFrame.init_from_body(RoutingIndication(test_cemi)))
+            secure_group.send(
+                KNXIPFrame.init_from_body(RoutingIndication(raw_cemi=raw_test_cemi))
+            )
             mock_reschedule.assert_not_called()

--- a/test/io_tests/tunnel_test.py
+++ b/test/io_tests/tunnel_test.py
@@ -126,13 +126,14 @@ class TestUDPTunnel:
         self.tunnel.expected_sequence_number = 10
 
         test_telegram = Telegram(payload=GroupValueWrite(DPTArray((1,))))
+        cemi = CEMIFrame.init_from_telegram(
+            test_telegram, code=CEMIMessageCode.L_DATA_IND
+        )
         test_frame = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=1,
                 sequence_counter=10,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram, code=CEMIMessageCode.L_DATA_IND
-                ),
+                raw_cemi=cemi.to_knx(),
             )
         )
         test_ack = KNXIPFrame.init_from_body(TunnellingAck(sequence_counter=10))
@@ -193,14 +194,15 @@ class TestUDPTunnel:
         self.tunnel.expected_sequence_number = 23
 
         test_telegram = Telegram(payload=GroupValueWrite(DPTArray((1,))))
+        cemi = CEMIFrame.init_from_telegram(
+            test_telegram, code=CEMIMessageCode.L_DATA_CON
+        )
         test_ack = KNXIPFrame.init_from_body(TunnellingAck(sequence_counter=23))
         confirmation = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=1,
                 sequence_counter=23,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram, code=CEMIMessageCode.L_DATA_CON
-                ),
+                raw_cemi=cemi.to_knx(),
             )
         )
         task = asyncio.create_task(self.tunnel.send_telegram(test_telegram))
@@ -224,27 +226,29 @@ class TestUDPTunnel:
         self.tunnel.expected_sequence_number = 15
 
         test_telegram = Telegram(payload=GroupValueWrite(DPTArray((1,))))
+        cemi = CEMIFrame.init_from_telegram(
+            test_telegram,
+            code=CEMIMessageCode.L_DATA_REQ,
+            src_addr=self.tunnel._src_address,
+        )
         request = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=self.tunnel.communication_channel,
                 sequence_counter=self.tunnel.sequence_number,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram,
-                    code=CEMIMessageCode.L_DATA_REQ,
-                    src_addr=self.tunnel._src_address,
-                ),
+                raw_cemi=cemi.to_knx(),
             )
         )
         test_ack = KNXIPFrame.init_from_body(
             TunnellingAck(sequence_counter=self.tunnel.sequence_number)
         )
+        confirmation_cemi = CEMIFrame.init_from_telegram(
+            test_telegram, code=CEMIMessageCode.L_DATA_CON
+        )
         confirmation = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=1,
                 sequence_counter=15,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram, code=CEMIMessageCode.L_DATA_CON
-                ),
+                raw_cemi=confirmation_cemi.to_knx(),
             )
         )
         confirmation_ack = KNXIPFrame.init_from_body(TunnellingAck(sequence_counter=15))
@@ -328,15 +332,16 @@ class TestUDPTunnel:
         # Send - use data endpoint
         self.tunnel.transport.send.reset_mock()
         test_telegram = Telegram(payload=GroupValueWrite(DPTArray((1,))))
+        cemi = CEMIFrame.init_from_telegram(
+            test_telegram,
+            code=CEMIMessageCode.L_DATA_REQ,
+            src_addr=IndividualAddress(7),
+        )
         test_telegram_frame = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=23,
                 sequence_counter=0,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram,
-                    code=CEMIMessageCode.L_DATA_REQ,
-                    src_addr=IndividualAddress(7),
-                ),
+                raw_cemi=cemi.to_knx(),
             )
         )
         asyncio.create_task(self.tunnel.send_telegram(test_telegram))
@@ -411,13 +416,14 @@ class TestTCPTunnel:
         self.tunnel.communication_channel = 1
 
         test_telegram = Telegram(payload=GroupValueWrite(DPTArray((1,))))
+        cemi = CEMIFrame.init_from_telegram(
+            test_telegram, code=CEMIMessageCode.L_DATA_CON
+        )
         confirmation = KNXIPFrame.init_from_body(
             TunnellingRequest(
                 communication_channel_id=1,
                 sequence_counter=23,
-                cemi=CEMIFrame.init_from_telegram(
-                    test_telegram, code=CEMIMessageCode.L_DATA_CON
-                ),
+                raw_cemi=cemi.to_knx(),
             )
         )
         task = asyncio.create_task(self.tunnel.send_telegram(test_telegram))

--- a/test/knxip_tests/cemi_frame_test.py
+++ b/test/knxip_tests/cemi_frame_test.py
@@ -1,7 +1,7 @@
 """Tests for the CEMIFrame object."""
 import pytest
 
-from xknx.exceptions import ConversionError, CouldNotParseKNXIP, UnsupportedCEMIMessage
+from xknx.exceptions import ConversionError, UnsupportedCEMIMessage
 from xknx.knxip.cemi_frame import CEMIFrame
 from xknx.knxip.knxip_enum import CEMIFlags, CEMIMessageCode
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
@@ -88,7 +88,7 @@ def test_invalid_tpci_apci(raw, err_msg):
 def test_invalid_apdu_len():
     """Test for invalid apdu len."""
     frame = CEMIFrame()
-    with pytest.raises(CouldNotParseKNXIP, match=r".*APDU LEN should be .*"):
+    with pytest.raises(UnsupportedCEMIMessage, match=r".*APDU LEN should be .*"):
         frame.from_knx(get_data(0x29, 0, 0, 0, 0, 2, 0, []))
 
 

--- a/test/knxip_tests/tunnelling_request_test.py
+++ b/test/knxip_tests/tunnelling_request_test.py
@@ -22,22 +22,24 @@ class TestKNXIPTunnellingRequest:
         assert isinstance(knxipframe.body, TunnellingRequest)
         assert knxipframe.body.communication_channel_id == 1
         assert knxipframe.body.sequence_counter == 23
-        assert isinstance(knxipframe.body.cemi, CEMIFrame)
+        assert isinstance(knxipframe.body.raw_cemi, bytes)
 
-        assert knxipframe.body.cemi.telegram == Telegram(
+        incoming_cemi = CEMIFrame()
+        incoming_cemi.from_knx(knxipframe.body.raw_cemi)
+        assert incoming_cemi.telegram == Telegram(
             destination_address=GroupAddress("9/0/8"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
 
-        cemi = CEMIFrame(code=CEMIMessageCode.L_DATA_REQ)
-        cemi.telegram = Telegram(
+        outgoing_cemi = CEMIFrame(code=CEMIMessageCode.L_DATA_REQ)
+        outgoing_cemi.telegram = Telegram(
             destination_address=GroupAddress("9/0/8"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
         tunnelling_request = TunnellingRequest(
             communication_channel_id=1,
             sequence_counter=23,
-            cemi=cemi,
+            raw_cemi=outgoing_cemi.to_knx(),
         )
         knxipframe2 = KNXIPFrame.init_from_body(tunnelling_request)
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -626,9 +626,7 @@ class TestStringRepresentations:
         tunnelling_request.sequence_counter = 42
         assert (
             str(tunnelling_request)
-            == '<TunnellingRequest communication_channel_id="23" sequence_counter="42" '
-            'cemi="<CEMIFrame code="L_DATA_REQ" src_addr="IndividualAddress("0.0.0")" dst_addr="GroupAddress("0/0/0")" '
-            'flags="               0" tpci="TDataGroup()" payload="None" />" />'
+            == '<TunnellingRequest communication_channel_id="23" sequence_counter="42" cemi="" />'
         )
 
     def test_tunnelling_ack(self):
@@ -689,8 +687,4 @@ class TestStringRepresentations:
     def test_routing_indication_str(self):
         """Test string representation of GatewayDescriptor."""
         routing_indication = RoutingIndication()
-        assert (
-            str(routing_indication)
-            == '<RoutingIndication cemi="<CEMIFrame code="L_DATA_IND" src_addr="IndividualAddress("0.0.0")" '
-            'dst_addr="GroupAddress("0/0/0")" flags="               0" tpci="TDataGroup()" payload="None" />" />'
-        )
+        assert str(routing_indication) == '<RoutingIndication cemi="" />'

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -283,9 +283,8 @@ class _Tunnel(Interface):
                 logger.warning("Could not send CEMI frame: %s", ex)
                 skip_increase_sequence_number = True
             finally:
-                if skip_increase_sequence_number:
-                    return
-                self._increase_sequence_number()
+                if not skip_increase_sequence_number:
+                    self._increase_sequence_number()
 
     async def _tunnelling_request(self, cemi: CEMIFrame) -> None:
         """Send CEMI Frame to tunnelling server."""

--- a/xknx/knxip/cemi_frame.py
+++ b/xknx/knxip/cemi_frame.py
@@ -13,7 +13,7 @@ Documentation within:
 """
 from __future__ import annotations
 
-from xknx.exceptions import ConversionError, CouldNotParseKNXIP, UnsupportedCEMIMessage
+from xknx.exceptions import ConversionError, UnsupportedCEMIMessage
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
 from xknx.telegram.apci import APCI
 from xknx.telegram.tpci import TPCI, TDataGroup
@@ -159,7 +159,7 @@ class CEMIFrame:
         apdu = bytes([tpdu[0] & 0b11]) + tpdu[1:]  # clear TPCI bits
 
         if len(apdu) != (npdu_len + 1):  # TCPI octet not included in NPDU length
-            raise CouldNotParseKNXIP(
+            raise UnsupportedCEMIMessage(
                 f"APDU LEN should be {npdu_len} but is {len(apdu) - 1} in CEMI: {cemi.hex()}"
             )
 

--- a/xknx/knxip/tunnelling_request.py
+++ b/xknx/knxip/tunnelling_request.py
@@ -5,15 +5,10 @@ Tunnelling requests are used to transmit a KNX telegram within an existing KNX t
 """
 from __future__ import annotations
 
-import logging
-
-from xknx.exceptions import CouldNotParseKNXIP, UnsupportedCEMIMessage
+from xknx.exceptions import CouldNotParseKNXIP
 
 from .body import KNXIPBody
-from .cemi_frame import CEMIFrame, CEMIMessageCode
 from .knxip_enum import KNXIPServiceType
-
-logger = logging.getLogger("xknx.log")
 
 
 class TunnellingRequest(KNXIPBody):
@@ -26,46 +21,31 @@ class TunnellingRequest(KNXIPBody):
         self,
         communication_channel_id: int = 1,
         sequence_counter: int = 0,
-        cemi: CEMIFrame | None = None,
+        raw_cemi: bytes = b"",
     ):
         """Initialize TunnellingRequest object."""
         self.communication_channel_id = communication_channel_id
         self.sequence_counter = sequence_counter
-        self.cemi: CEMIFrame | None = cemi or CEMIFrame(code=CEMIMessageCode.L_DATA_REQ)
+        self.raw_cemi = raw_cemi
 
     def calculated_length(self) -> int:
         """Get length of KNX/IP body."""
-        assert self.cemi is not None
-        return TunnellingRequest.HEADER_LENGTH + self.cemi.calculated_length()
+        return TunnellingRequest.HEADER_LENGTH + len(self.raw_cemi)
 
     def from_knx(self, raw: bytes) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        assert self.cemi is not None
-
-        def header_from_knx(header: bytes) -> int:
-            """Parse header bytes."""
-            if header[0] != TunnellingRequest.HEADER_LENGTH:
-                raise CouldNotParseKNXIP("connection header wrong length")
-            if len(header) < TunnellingRequest.HEADER_LENGTH:
-                raise CouldNotParseKNXIP("connection header wrong length")
-            self.communication_channel_id = header[1]
-            self.sequence_counter = header[2]
-            return TunnellingRequest.HEADER_LENGTH
-
-        pos = header_from_knx(raw)
-        try:
-            pos += self.cemi.from_knx(raw[pos:])
-        except UnsupportedCEMIMessage as unsupported_cemi_err:
-            logger.debug("CEMI not supported: %s", unsupported_cemi_err)
-            # Set cemi to None - this is checked in Tunnel() to send Ack even for unsupported CEMI messages.
-            self.cemi = None
-            return len(raw)
-        return pos
+        if raw[0] != TunnellingRequest.HEADER_LENGTH:
+            raise CouldNotParseKNXIP("connection header wrong length")
+        if len(raw) < TunnellingRequest.HEADER_LENGTH:
+            raise CouldNotParseKNXIP("connection header wrong length")
+        self.communication_channel_id = raw[1]
+        self.sequence_counter = raw[2]
+        # raw[3] is reserved
+        self.raw_cemi = raw[TunnellingRequest.HEADER_LENGTH :]
+        return len(raw)
 
     def to_knx(self) -> bytes:
         """Serialize to KNX/IP raw data."""
-        if self.cemi is None:
-            raise CouldNotParseKNXIP("No CEMIFrame defined.")
         return (
             bytes(
                 (
@@ -75,7 +55,7 @@ class TunnellingRequest(KNXIPBody):
                     0x00,  # Reserved
                 )
             )
-            + self.cemi.to_knx()
+            + self.raw_cemi
         )
 
     def __repr__(self) -> str:
@@ -84,5 +64,5 @@ class TunnellingRequest(KNXIPBody):
             "<TunnellingRequest "
             f'communication_channel_id="{self.communication_channel_id}" '
             f'sequence_counter="{self.sequence_counter}" '
-            f'cemi="{self.cemi}" />'
+            f'cemi="{self.raw_cemi.hex()}" />'
         )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Decouple KNXIPFrame parsing from CEMIFrame parsing. TunnellingRequest and RoutingIndication now carry the raw cemi frame payload as bytes. This allows decoupled CEMIFrame parsing at a later time (in Interface class rather than in KNXIPTransport class).
- Remove some tests for RoutingIndication that actually tested CEMIFrame / Telegram functions.

We are now able to inject data into the cemi parser more easily without having to pass an xknx instance throughout the IPFrame parsers. This paves the way to pass DataSecure keys.
It would also be an option to add a separate CEMI-Handler in front of `Tunnel / Routing` classes - eg. for USB support (@kistlin may be interested).

A noticeable change of this is that the `xknx.knx` logger now doesn't show the CEMI contents anymore, but the hex representation of the raw bytes 😬
```log
<KNXIPFrame <KNXIPHeader HeaderLength="6" ProtocolVersion="16" KNXIPServiceType="TUNNELLING_REQUEST" Reserve="0" TotalLength="23" />
 body="<TunnellingRequest communication_channel_id="2" sequence_counter="34" cemi="2900bcd0111529150300800c5b" />" />
```

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)