### PR TITLE
Disconnect when tunnelling sequence number gets out of sync

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - ExposeSensor: Add `cooldown` option to allow rate-limiting of sent telegrams.
 
+### Connection
+
+- Disconnect when tunnelling sequence number (UDP) gets out of sync.
+
 ### Internals
 
 - Add `task.done()` to TaskRegistry tasks.

--- a/test/io_tests/tunnel_test.py
+++ b/test/io_tests/tunnel_test.py
@@ -155,7 +155,9 @@ class TestUDPTunnel:
         assert self.tunnel.expected_sequence_number == 11
         assert self.tg_received_mock.call_count == 1
         # wrong sequence number - no ACK, not processed
-        self.tunnel._request_received(test_frame_9, None, None)
+        # reconnect if `auto_reconnect` was True
+        with pytest.raises(CommunicationError):
+            self.tunnel._request_received(test_frame_9, None, None)
         await time_travel(0)
         assert self.tunnel.transport.send.call_args_list == []
         self.tunnel.transport.send.reset_mock()

--- a/xknx/io/tunnel.py
+++ b/xknx/io/tunnel.py
@@ -607,6 +607,9 @@ class UDPTunnel(_Tunnel):
             self.expected_sequence_number,
             tunneling_request,
         )
+        # Tunnelling server should repeat that frame and disconnect after that was also not ACKed.
+        # some don't seem to initiate disconnection here so we take a shortcut and disconnect ourselves
+        self._tunnel_lost()
 
     def _send_tunnelling_ack(
         self, communication_channel_id: int, sequence_counter: int


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Disconnect when tunnelling sequence number gets out of sync

If we receive a wrong sequence numnber we should ignore that frame and not ACK it according to the specs.
The Tunnelling server should then repeat that frame and disconnect after that second frame was also not ACKed.

Some devices don't seem to initiate disconnection here so we take a shortcut and disconnect (reconnect) ourselves when receiving the first incorrect frame.

I'm just not sure if we should, instead of ignoring, send a Tunnelling ACK with `E_SEQUENCE_NUMBER`. Unfortunately there is no mention of this error code in the specs besides of its initial definition 🙄 I wonder how ETS handles that, but have no idea how to test this.

Fixes #1084

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)