### PR TITLE
Require destination_address for Telegram

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,8 @@ nav_order: 2
 - Refactor APCI to return complete Subclass `APCI.from_knx()` and removed `APCI.resolve_apci()`.
 - Rename `xknx.secure.ip_secure` to `xknx.secure.security_primitives`.
 - Fix wrong string length in keyfile signature verification for multi-byte UTF-8 encoded attribute values.
+- `destination_address` in `Telegram` init is no longer optional.
+- `timestamp` in `Telegram` is removed.
 
 # 2.3.0 Routing security, DPTs and CEMI-Refactoring 2023-01-10
 

--- a/xknx/telegram/telegram.py
+++ b/xknx/telegram/telegram.py
@@ -15,7 +15,6 @@ It contains
 """
 from __future__ import annotations
 
-from datetime import datetime
 from enum import Enum
 
 from .address import GroupAddress, IndividualAddress, InternalGroupAddress
@@ -35,21 +34,17 @@ class Telegram:
 
     def __init__(
         self,
-        destination_address: GroupAddress
-        | IndividualAddress
-        | InternalGroupAddress
-        | None = None,
+        destination_address: GroupAddress | IndividualAddress | InternalGroupAddress,
         direction: TelegramDirection = TelegramDirection.OUTGOING,
         payload: APCI | None = None,
         source_address: IndividualAddress | None = None,
         tpci: TPCI | None = None,
     ) -> None:
         """Initialize Telegram class."""
-        self.destination_address = destination_address or GroupAddress(0)
+        self.destination_address = destination_address
         self.direction = direction
         self.payload = payload
         self.source_address = source_address or IndividualAddress(0)
-        self.timestamp = datetime.now()
         self.tpci: TPCI
         if tpci is None:
             if isinstance(destination_address, GroupAddress):
@@ -89,14 +84,7 @@ class Telegram:
 
     def __eq__(self, other: object) -> bool:
         """Equal operator."""
-        for key, value in self.__dict__.items():
-            if key == "timestamp":
-                continue
-            if key not in other.__dict__:
-                return False
-            if other.__dict__[key] != value:
-                return False
-        return all(key in self.__dict__ for key in other.__dict__)
+        return self.__dict__ == other.__dict__
 
     def __hash__(self) -> int:
         """Hash function."""


### PR DESCRIPTION
and remove timestamp

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Require destination_address for Telegram.
- Remove timestamp from Telegram

There are no Telegrams without destination_address and there is no good default value for that.
Timestamp is not used anywhere and doesn't really resemble the time the telegram is sent to the bus (for outgoing) since it is possible to create a Telegram instance and pass it to the telegram queue at any other time - even multiple times, but the timestamp is always created on instantiation.

Tests will probably pass when #1127 was merged and this is rebased.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)