### PR TITLE
Revert handling incoming L_Data.req frames

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ nav_order: 2
 
 - Parse T_Data_Broadcast TPCI. Forward these telegrams to the Management class.
 - KNXIPHeader total_length is 2 bytes long. There are no reserved bytes.
+- Revert handling L_Data.req frames for incoming device management requests.
 
 # 2.2.0 Expose cooldown 2022-12-27
 

--- a/xknx/io/interface.py
+++ b/xknx/io/interface.py
@@ -8,12 +8,11 @@ Abstract base for a specific KNX/IP connection (Tunneling or Routing).
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections.abc import Awaitable
-from typing import Callable, Optional
+from typing import Callable
 
 from xknx.telegram import Telegram
 
-TelegramCallbackType = Callable[[Telegram], Awaitable[Optional[list[Telegram]]]]
+TelegramCallbackType = Callable[[Telegram], None]
 
 
 class Interface(ABC):

--- a/xknx/io/routing.py
+++ b/xknx/io/routing.py
@@ -269,17 +269,9 @@ class Routing(Interface):
         if cemi.src_addr == self.individual_address:
             logger.debug("Ignoring own packet")
             return
-        # TODO: is cemi message code L_DATA.req or .con valid for routing? if not maybe warn and ignore
-        asyncio.create_task(self.handle_cemi_frame(cemi))
-
-    async def handle_cemi_frame(self, cemi: CEMIFrame) -> None:
-        """Handle incoming telegram and send responses if applicable (device management)."""
         telegram = cemi.telegram
         telegram.direction = TelegramDirection.INCOMING
-
-        if response_tgs := await self.telegram_received_callback(telegram):
-            for response in response_tgs:
-                await self.send_telegram(response)
+        self.telegram_received_callback(telegram)
 
 
 class SecureRouting(Routing):


### PR DESCRIPTION
for incoming management requests. 
This was probably wrongly assumed to be a thing. 

I don't recall if I have read tcpdumps wrongly or had a faulty device... can't reproduce this anymore and the specs say that this is not a thing.

see #972 

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)