### PR TITLE
SecureRouting: verify MAC before timer handling

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ nav_order: 2
 
 - SecureRouting: verify MAC of received TimerNotify frames.
 - SecureRouting: verify and handle timer value of received SecureWrapper frames after verification of MAC.
+- SecureRouting: Discard received unencrypted RoutingIndication frames.
 
 ### Internals
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,11 @@ nav_order: 2
 
 # Unreleased changes
 
+### IP Secure
+
+- SecureRouting: verify MAC of received TimerNotify frames.
+- SecureRouting: verify and handle timer value of received SecureWrapper frames after verification of MAC.
+
 ### Internals
 
 - Parse T_Data_Broadcast TPCI. Forward these telegrams to the Management class.

--- a/test/io_tests/routing_test.py
+++ b/test/io_tests/routing_test.py
@@ -31,7 +31,6 @@ class TestRouting:
         routing = Routing(
             self.xknx,
             individual_address=None,
-            # telegram_received_callback=self.tg_received_mock,
             telegram_received_callback=self.xknx.knxip_interface.telegram_received,
             local_ip="192.168.1.1",
         )


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
SecureRouting: verify MAC before timer handling

- Verify MAC of received TimerNotify frames.
- Verify and handle timer value of received SecureWrapper frames after verification of MAC to ensure authenticity.
- Discard received unencrypted RoutingIndication frames.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)