### PR TITLE
Fix wrong string length in keyfile signature verification

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ nav_order: 2
 - Return `bytes` from `BaseAddress.to_knx()` instead of `tuple[int, int]`. This is used in `IndividualAddress` and `GroupAddress`.
 - Add `BaseAddress.from_knx()` to instantiate from `bytes`, remove instantiation form `tuple[int, int]`.
 - Refactor APCI to return complete Subclass `APCI.from_knx()` and removed `APCI.resolve_apci()`.
+- Fix wrong string length in keyfile signature verification for multi-byte UTF-8 encoded attribute values.
 
 # 2.3.0 Routing security, DPTs and CEMI-Refactoring 2023-01-10
 

--- a/xknx/secure/keyring.py
+++ b/xknx/secure/keyring.py
@@ -414,12 +414,12 @@ class KeyringSAXContentHandler(ContentHandler):
 
     def append_string(self, value: str | bytes) -> None:
         """Append a string to a byte array for signature verification."""
-        self.output.append(len(value))
 
         if isinstance(value, str):
-            self.output.extend(value.encode("utf-8"))
-        if isinstance(value, bytes):
-            self.output.extend(value)
+            value = value.encode("utf-8")
+
+        self.output.append(len(value))
+        self.output.extend(value)
 
 
 def verify_keyring_signature(path: str, password: str) -> bool:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Attribute values during keyfile signature verification are prefixed with their length. However this was wrong, when the UTF-8 encoded string contained multi-byte characters. This fixes that. Keyfiles that contain project names with umlauts (äüö) should pass signature verification now.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [X] The changes are documented in the changelog (docs/changelog.md)