### PR TITLE
Update HA Device Classes

### DIFF
--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -134,7 +134,7 @@ class TestWeather:
 
         assert weather.wind_speed == 469237.76
         assert weather._wind_speed.unit_of_measurement == "m/s"
-        assert weather._wind_speed.ha_device_class is None
+        assert weather._wind_speed.ha_device_class == "wind_speed"
 
     async def test_wind_bearing(self):
         """Test wind bearing received."""

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -212,6 +212,7 @@ class DPTVoltage(DPT2ByteFloat):
     dpt_sub_number = 20
     value_type = "voltage"
     unit = "mV"
+    ha_device_class = "voltage"
 
 
 class DPTCurrent(DPT2ByteFloat):
@@ -221,6 +222,7 @@ class DPTCurrent(DPT2ByteFloat):
     dpt_sub_number = 21
     value_type = "curr"
     unit = "mA"
+    ha_device_class = "current"
 
 
 class DPTPowerDensity(DPT2ByteFloat):

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -132,6 +132,7 @@ class DPTWsp(DPT2ByteFloat):
     dpt_sub_number = 5
     value_type = "wind_speed_ms"
     unit = "m/s"
+    ha_device_class = "wind_speed"
 
     value_min = 0
     value_max = 670760
@@ -294,6 +295,7 @@ class DPTWspKmh(DPT2ByteFloat):
     dpt_sub_number = 28
     value_type = "wind_speed_kmh"
     unit = "km/h"
+    ha_device_class = "wind_speed"
 
     value_min = 0
     value_max = 670760

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -146,3 +146,4 @@ class DPTLengthM(DPT2ByteSigned):
     dpt_sub_number = 12
     value_type = "length_m"
     unit = "m"
+    ha_device_class = "distance"

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -125,6 +125,7 @@ class DPTLengthMm(DPT2ByteUnsigned):
     dpt_sub_number = 11
     value_type = "length_mm"
     unit = "mm"
+    ha_device_class = "distance"
 
 
 class DPTUElCurrentmA(DPT2ByteUnsigned):
@@ -134,6 +135,7 @@ class DPTUElCurrentmA(DPT2ByteUnsigned):
     dpt_sub_number = 12
     value_type = "current"
     unit = "mA"
+    ha_device_class = "current"
 
 
 class DPTBrightness(DPT2ByteUnsigned):
@@ -143,6 +145,7 @@ class DPTBrightness(DPT2ByteUnsigned):
     dpt_sub_number = 13
     value_type = "brightness"
     unit = "lx"
+    ha_device_class = "illuminance"
 
 
 class DPTColorTemperature(DPT2ByteUnsigned):

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -145,7 +145,6 @@ class DPTBrightness(DPT2ByteUnsigned):
     dpt_sub_number = 13
     value_type = "brightness"
     unit = "lx"
-    ha_device_class = "illuminance"
 
 
 class DPTColorTemperature(DPT2ByteUnsigned):

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -145,6 +145,7 @@ class DPTBrightness(DPT2ByteUnsigned):
     dpt_sub_number = 13
     value_type = "brightness"
     unit = "lx"
+    ha_device_class = "illuminance"
 
 
 class DPTColorTemperature(DPT2ByteUnsigned):

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -422,7 +422,7 @@ class DPTLength(DPT4ByteFloat):
     value_type = "length"
     unit = "m"
     ha_device_class = "distance"
-    
+
 
 class DPTLightQuantity(DPT4ByteFloat):
     """DPT 14.040 DPT_Value_Light_Quantity."""

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -441,7 +441,6 @@ class DPTLuminance(DPT4ByteFloat):
     dpt_sub_number = 41
     value_type = "luminance"
     unit = "cd/m²"
-    ha_device_class = "illuminance"
 
 
 class DPTLuminousFlux(DPT4ByteFloat):
@@ -451,7 +450,6 @@ class DPTLuminousFlux(DPT4ByteFloat):
     dpt_sub_number = 42
     value_type = "luminous_flux"
     unit = "lm"
-    ha_device_class = "illuminance"
 
 
 class DPTLuminousIntensity(DPT4ByteFloat):
@@ -461,7 +459,6 @@ class DPTLuminousIntensity(DPT4ByteFloat):
     dpt_sub_number = 43
     value_type = "luminous_intensity"
     unit = "cd"
-    ha_device_class = "illuminance"
 
 
 class DPTMagneticFieldStrength(DPT4ByteFloat):

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -239,6 +239,7 @@ class DPTElectricCurrent(DPT4ByteFloat):
     dpt_sub_number = 19
     value_type = "electric_current"
     unit = "A"
+    ha_device_class = "current"
 
 
 class DPTElectricCurrentDensity(DPT4ByteFloat):
@@ -365,6 +366,7 @@ class DPTFrequency(DPT4ByteFloat):
     dpt_sub_number = 33
     value_type = "frequency"
     unit = "Hz"
+    ha_device_class = "frequency"
 
 
 class DPTAngularFrequency(DPT4ByteFloat):
@@ -419,6 +421,8 @@ class DPTLength(DPT4ByteFloat):
     dpt_sub_number = 39
     value_type = "length"
     unit = "m"
+    ha_device_class = "distance"
+    
 
 
 class DPTLightQuantity(DPT4ByteFloat):
@@ -530,6 +534,7 @@ class DPTMass(DPT4ByteFloat):
     dpt_sub_number = 51
     value_type = "mass"
     unit = "kg"
+    ha_device_class = "weight"
 
 
 class DPTMassFlux(DPT4ByteFloat):
@@ -658,6 +663,7 @@ class DPTSpeed(DPT4ByteFloat):
     dpt_sub_number = 65
     value_type = "speed"
     unit = "m/s"
+    ha_device_class = "speed"
 
 
 class DPTStress(DPT4ByteFloat):
@@ -793,3 +799,4 @@ class DPTApparentPower(DPT4ByteFloat):
     dpt_sub_number = 80
     value_type = "apparent_power"
     unit = "VA"
+    ha_device_class = "apparent_power"

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -424,7 +424,6 @@ class DPTLength(DPT4ByteFloat):
     ha_device_class = "distance"
     
 
-
 class DPTLightQuantity(DPT4ByteFloat):
     """DPT 14.040 DPT_Value_Light_Quantity."""
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
I have added the following home assistant device classes which could be clearly assigned to KNX DPTs:
- voltage
- current
- distance
- frequency
- weight
- speed
- apparent_power
- wind_speed

Furthermore I have corrected device class 'illuminance'. 
- Added  to 7.013 brightness (lx)
- Removed from 14.41 luminance (cd/m²), 14.42 luminous_flux (lm) and 14.43 luminous_intensity (cd).  These DPTs do not match with HA illuminance unit of measurement lx. Starting HA 2023.1 Home Assistant is rising a warning if device_class unit of measurement does not match with the entity's unit of measurement. Example: `Entity sensor.example (<class 'homeassistant.components.knx.sensor.KNXSensor'>) is using native unit of measurement '%' which is not a valid unit for the device class ('illuminance') it is using; expected one of ['lx']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+knx%22`

I did not find any test in XKNX. Please advice if and where to add tests. Thank you....


Fixes #1179 

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)