### PR TITLE
Fix for Cover device_updated_cb 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ nav_order: 2
 
 - Parse Data Secure credentials form Keyring from non-IP-Secure interfaces.
 - Parse Data Secure credentials from Keyrings exported for specific interfaces.
+- Added `always_callback=True` while processing telegrams for Cover’s target position to avoid some cases when callback was not triggered.
 
 ### Protocol
 

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -830,6 +830,9 @@ class TestCover:
             ("1/2/1", DPTBinary(1), "long"),
             ("1/2/2", DPTBinary(1), "short"),
             ("1/2/4", DPTArray(42), "position"),
+            ("1/2/3", DPTBinary(1), "stop"),
+            # call position with same value again to make sure `always_callback` is set for target position
+            ("1/2/4", DPTArray(42), "position"),
             ("1/2/5", DPTArray(42), "position state"),
             ("1/2/6", DPTArray(42), "angle"),
             ("1/2/7", DPTArray(51), "angle state"),

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -360,7 +360,7 @@ class Cover(Device):
                 await self._stop_position_update()
 
         await self.position_current.process(telegram, always_callback=True)
-        await self.position_target.process(telegram)
+        await self.position_target.process(telegram, always_callback=True)
         await self.angle.process(telegram)
         await self.locked.process(telegram)
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Added `always_callback=True` to Cover's `position_target.process()` to avoid some cases when a callback was not triggered when cover was sent to the same target position after stop command.
E.g. move to 50% position -> stop -> move to 50% position
This led to the situation that the `device_updated_cb` was not triggered.

Fixes #1189

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)