### PR TITLE
Fix Windows TCP transport

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ nav_order: 2
 
 - Parse Data Secure credentials form Keyring from non-IP-Secure interfaces.
 - Parse Data Secure credentials from Keyrings exported for specific interfaces.
+- Fix Windows TCP transport bug when using IP Secure Tunnelling.
 
 ### Protocol
 

--- a/xknx/io/transport/tcp_transport.py
+++ b/xknx/io/transport/tcp_transport.py
@@ -40,8 +40,10 @@ class TCPTransport(KNXIPTransport):
             # cryptography (eg. X25519PublicKey.from_public_bytes() in IP Secure handshake)
             # https://github.com/python/cpython/issues/99941
             try:
-                if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
-                    self.data_received_callback = lambda data: data_received_callback(bytes(data))
+                if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):  # type: ignore[attr-defined]
+                    self.data_received_callback = lambda data: data_received_callback(
+                        bytes(data)
+                    )
             except AttributeError:
                 # asyncio.ProactorEventLoop is only available on Windows
                 pass

--- a/xknx/io/transport/tcp_transport.py
+++ b/xknx/io/transport/tcp_transport.py
@@ -34,7 +34,7 @@ class TCPTransport(KNXIPTransport):
             self.transport: asyncio.BaseTransport | None = None
             self.data_received_callback = data_received_callback
             self.connection_lost_callback = connection_lost_callback
-            
+
             # Workaround for issue of TCP Transport in ProactorEventLoop in py3.10 and py3.11
             # on Windows returning bytearray instead of bytes which lead to errors in
             # cryptography (eg. X25519PublicKey.from_public_bytes() in IP Secure handshake)

--- a/xknx/io/transport/tcp_transport.py
+++ b/xknx/io/transport/tcp_transport.py
@@ -34,6 +34,17 @@ class TCPTransport(KNXIPTransport):
             self.transport: asyncio.BaseTransport | None = None
             self.data_received_callback = data_received_callback
             self.connection_lost_callback = connection_lost_callback
+            
+            # Workaround for issue of TCP Transport in ProactorEventLoop in py3.10 and py3.11
+            # on Windows returning bytearray instead of bytes which lead to errors in
+            # cryptography (eg. X25519PublicKey.from_public_bytes() in IP Secure handshake)
+            # https://github.com/python/cpython/issues/99941
+            try:
+                if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):
+                    self.data_received_callback = lambda data: data_received_callback(bytes(data))
+            except AttributeError:
+                # asyncio.ProactorEventLoop is only available on Windows
+                pass
 
         def connection_made(self, transport: asyncio.BaseTransport) -> None:
             """Assign transport. Callback after udp connection was made."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Workaround for issue of TCP Transport in ProactorEventLoop in py3.10 and py3.11 on Windows returning bytearray instead of bytes which lead to errors when passed directly (or as slice) to some cryptography primitives (eg. X25519PublicKey.from_public_bytes() in IP Secure handshake)

See https://github.com/python/cpython/issues/99941

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)