### PR TITLE
Add support of color temperature brightness for lights

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - When `ConnectionConfig.individual_address` is set and a Keyring is given `ConnectionType.AUTOMATIC` will try to connect to the host of this address. If not found (in keyfile or discovery) it will raise.
 
+### Feature added
+
+- Support for color temperature brightness added. This is needed for dimmers having additionaly to the brightness a seperate brightness for the color temperature.
+
 # 2.5.0 Request IA 2023-02-14
 
 ### Connection

--- a/docs/light.md
+++ b/docs/light.md
@@ -33,6 +33,8 @@ The Light object is either a representation of a binary or dimm actor, LED-contr
 - `group_address_tunable_white_state` KNX group address for the current relative color temperature. *DPT 5.001*
 - `group_address_color_temperature` KNX group address to set absolute color temperature. *DPT 7.600*
 - `group_address_color_temperature_state` KNX group address for the current absolute color temperature. *DPT 7.600*
+- `group_address_color_temperature_brightness` KNX group address to set absolute color temperature brightness. *DPT 5.001*
+- `group_address_color_temperature_brightness_state` KNX group address for the current color temperature state. *DPT 5.001*
 
 - `group_address_switch_red` KNX group address to switch the red component. *DPT 1.001*
 - `group_address_switch_red_state` KNX group address for the state of the red component. *DPT 1.001*
@@ -71,7 +73,9 @@ light = Light(xknx,
               group_address_tunable_white='1/2/9',
               group_address_tunable_white_state='1/2/10',
               group_address_color_temperature='1/2/11',
-              group_address_color_temperature_state='1/2/12')
+              group_address_color_temperature_state='1/2/12',
+              group_address_color_temperature='1/2/13',
+              group_address_color_temperature_state='1/2/14')
 
 # Switching light on
 await light.set_on()
@@ -94,12 +98,16 @@ await set_tunable_white(25)
 # Set absolute color temperature (Kelvin)
 await set_color_temperature(3300)
 
+# Set color temperature brightness
+await light.set_color_temperature_brightness(23)
+
 # Accessing light via 'do'
 await light.do('on')
 await light.do('off')
 await light.do('brightness:80')
 await light.do('tunable_white:75')
 await light.do('color_temperature:5000')
+await light.do('color_temperature_brightness:80')
 
 # Update current state via KNX GroupValueRead
 await light.sync(wait_for_result=True)
@@ -115,6 +123,8 @@ print(light.supports_tunable_white)
 print(light.current_tunable_white)
 print(light.supports_color_temperature)
 print(light.current_color_temperature)
+print(light.supports_color_temperature_brightness)
+print(light.current_color_temperature_brightness)
 ```
 
 ## [](#header-2)Example: RGBW light with individual group addresses for red, green, blue and white


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This pull requests add support for color_temperature_brightness which some KNX dimmers have
additional to the brightness. In this case changing the brightness will bring the KNX dimmer into the color mode and changing the color_temperature_brightness switches the dimmer into the color_temperature mode.
So, this change is about adding a pair of additional group addresses, not changing the existing functions.

Target is to get full support for the KNX dimmers which support a mixed mode of RGBW+CT/TW.

The modifications for home assistant are also already written and tested (Incl. multi-mode KNX light),
but there is no chance of a pull request in home assistant if the library below (xknx) don't support the color_temperature_brightness.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [X] The documentation has been adjusted accordingly
- [X] Tests have been added that prove the fix is effective or that the feature works
- [X] The changes are documented in the changelog (docs/changelog.md)
