### PR TITLE
Move Telegram handling from CEMIFrame to CEMILData

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ nav_order: 2
 ### Internals
 
 - Use CEMILData instead of CEMIFrame in DataSecure.
+- Move `init_from_telegram()` from CEMIFrame to CEMILData. `telegram()` is now a method of CEMILData instead of a property of CEMIFrame.
 
 # 2.6.0 Connection information 2023-02-27
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -186,42 +186,54 @@ def test_from_knx_individual_address():
 def test_telegram_group_address():
     """Test telegram conversion flags with a group address."""
     _telegram = Telegram(destination_address=GroupAddress(1))
-    frame = CEMIFrame.init_from_telegram(_telegram)
+    frame = CEMIFrame(
+        code=CEMIMessageCode.L_DATA_IND,
+        data=CEMILData.init_from_telegram(_telegram),
+    )
     assert isinstance(frame.data, CEMILData)
     assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_GROUP_ADDRESS
     assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_LOW
     # test CEMIFrame.telegram property
-    assert frame.telegram == _telegram
+    assert frame.data.telegram() == _telegram
 
 
 def test_telegram_broadcast():
     """Test telegram conversion flags with a group address."""
     _telegram = Telegram(destination_address=GroupAddress(0))
-    frame = CEMIFrame.init_from_telegram(_telegram)
+    frame = CEMIFrame(
+        code=CEMIMessageCode.L_DATA_IND,
+        data=CEMILData.init_from_telegram(_telegram),
+    )
     assert isinstance(frame.data, CEMILData)
     assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_GROUP_ADDRESS
     assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_SYSTEM
     assert frame.data.tpci == TDataBroadcast()
     # test CEMIFrame.telegram property
-    assert frame.telegram == _telegram
+    assert frame.data.telegram() == _telegram
 
 
 def test_telegram_individual_address():
     """Test telegram conversion flags with a individual address."""
     _telegram = Telegram(destination_address=IndividualAddress(0), tpci=TConnect())
-    frame = CEMIFrame.init_from_telegram(_telegram)
+    frame = CEMIFrame(
+        code=CEMIMessageCode.L_DATA_IND,
+        data=CEMILData.init_from_telegram(_telegram),
+    )
     assert isinstance(frame.data, CEMILData)
     assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
     assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_SYSTEM
     assert frame.data.flags & 0x0200 == CEMIFlags.NO_ACK_REQUESTED
     # test CEMIFrame.telegram property
-    assert frame.telegram == _telegram
+    assert frame.data.telegram() == _telegram
 
 
 def test_telegram_unsupported_address():
     """Test telegram conversion flags with an unsupported address."""
     with pytest.raises(TypeError):
-        CEMIFrame.init_from_telegram(Telegram(destination_address=object()))
+        CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(Telegram(destination_address=object())),
+        )
 
 
 def get_prop(code, obj_id, obj_inst, prop_id, num, six, payload):
@@ -259,8 +271,8 @@ def test_valid_read_req():
     assert frame.data.property_info.start_index == 1
     assert frame.calculated_length() == 7
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
+    with pytest.raises(AttributeError):
+        frame.data.telegram()
 
 
 def test_valid_read_con():
@@ -284,8 +296,6 @@ def test_valid_read_con():
     assert IndividualAddress.from_knx(frame.data.data) == IndividualAddress("1.2.3")
     assert frame.calculated_length() == 9
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
 
 
 def test_valid_error_read_con():
@@ -308,8 +318,6 @@ def test_valid_error_read_con():
     assert frame.data.error_code == CEMIErrorCode.CEMI_ERROR_VOID_DP
     assert frame.calculated_length() == 8
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
 
 
 def test_valid_write_req():
@@ -332,8 +340,6 @@ def test_valid_write_req():
     assert IndividualAddress.from_knx(frame.data.data) == IndividualAddress("1.2.3")
     assert frame.calculated_length() == 9
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
 
 
 def test_valid_empty_write_con():
@@ -356,8 +362,6 @@ def test_valid_empty_write_con():
     assert frame.data.error_code == None
     assert frame.calculated_length() == 7
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
 
 
 def test_valid_error_write_con():
@@ -380,8 +384,6 @@ def test_valid_error_write_con():
     assert frame.data.error_code == CEMIErrorCode.CEMI_ERROR_VOID_DP
     assert frame.calculated_length() == 8
     assert frame.to_knx() == raw
-    with pytest.raises(TypeError):
-        frame.telegram
 
 
 @pytest.mark.parametrize(

--- a/test/io_tests/request_response_tests/tunnelling_test.py
+++ b/test/io_tests/request_response_tests/tunnelling_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX/IP Tunnelling Request/Response."""
 from unittest.mock import patch
 
-from xknx.cemi import CEMIFrame
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTArray
 from xknx.io.request_response import Tunnelling
 from xknx.io.transport import UDPTransport
@@ -24,11 +24,14 @@ class TestTunnelling:
         """Test tunnelling from KNX bus."""
         data_endpoint = ("192.168.1.2", 4567)
         udp_transport = UDPTransport(("192.168.1.1", 0), ("192.168.1.2", 1234))
-        raw_cemi = CEMIFrame.init_from_telegram(
-            Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
-            )
+        raw_cemi = CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(
+                Telegram(
+                    destination_address=GroupAddress("1/2/3"),
+                    payload=GroupValueWrite(DPTArray((0x1, 0x2, 0x3))),
+                )
+            ),
         ).to_knx()
         tunnelling_request = TunnellingRequest(
             communication_channel_id=23,

--- a/test/io_tests/secure_group_test.py
+++ b/test/io_tests/secure_group_test.py
@@ -2,7 +2,7 @@
 import asyncio
 from unittest.mock import Mock, patch
 
-from xknx.cemi import CEMIFrame
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.io.const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT, XKNX_SERIAL_NUMBER
 from xknx.io.ip_secure import SecureGroup
 from xknx.knxip import HPAI, KNXIPFrame, RoutingIndication, SecureWrapper, TimerNotify
@@ -442,11 +442,14 @@ class TestSecureGroup:
         secure_timer = secure_group.secure_timer
         secure_timer.timer_authenticated = True
 
-        raw_test_cemi = CEMIFrame.init_from_telegram(
-            Telegram(
-                destination_address=GroupAddress("1/2/3"),
-                payload=apci.GroupValueRead(),
-            )
+        raw_test_cemi = CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(
+                Telegram(
+                    destination_address=GroupAddress("1/2/3"),
+                    payload=apci.GroupValueRead(),
+                )
+            ),
         ).to_knx()
 
         with patch.object(

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -1,11 +1,11 @@
 """Unit test for KNX/IP RountingIndication objects."""
 import time
 
-from xknx.cemi import CEMIFrame, CEMILData
-from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTTime
-from xknx.knxip import KNXIPFrame, KNXIPServiceType, RoutingIndication
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.dpt import DPTArray, DPTTime
+from xknx.knxip import KNXIPFrame, RoutingIndication
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
-from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
+from xknx.telegram.apci import GroupValueWrite
 
 
 class TestKNXIPRountingIndication:
@@ -37,9 +37,12 @@ class TestKNXIPRountingIndication:
                 DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S")))
             ),
         )
-        cemi = CEMIFrame.init_from_telegram(
-            telegram,
-            src_addr=IndividualAddress("1.2.2"),
+        cemi = CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(
+                telegram,
+                src_addr=IndividualAddress("1.2.2"),
+            ),
         )
         assert isinstance(cemi.data, CEMILData)
         cemi.data.hops = 5

--- a/test/knxip_tests/tunnelling_request_test.py
+++ b/test/knxip_tests/tunnelling_request_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX/IP TunnellingRequest objects."""
 import pytest
 
-from xknx.cemi import CEMIFrame, CEMIMessageCode
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTBinary
 from xknx.exceptions import CouldNotParseKNXIP
 from xknx.knxip import KNXIPFrame, TunnellingRequest
@@ -25,17 +25,19 @@ class TestKNXIPTunnellingRequest:
         assert isinstance(knxipframe.body.raw_cemi, bytes)
 
         incoming_cemi = CEMIFrame.from_knx(knxipframe.body.raw_cemi)
-        assert incoming_cemi.telegram == Telegram(
+        assert incoming_cemi.data.telegram() == Telegram(
             destination_address=GroupAddress("9/0/8"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
 
-        outgoing_cemi = CEMIFrame.init_from_telegram(
-            Telegram(
-                destination_address=GroupAddress("9/0/8"),
-                payload=GroupValueWrite(DPTBinary(1)),
-            ),
+        outgoing_cemi = CEMIFrame(
             code=CEMIMessageCode.L_DATA_REQ,
+            data=CEMILData.init_from_telegram(
+                Telegram(
+                    destination_address=GroupAddress("9/0/8"),
+                    payload=GroupValueWrite(DPTBinary(1)),
+                ),
+            ),
         )
         tunnelling_request = TunnellingRequest(
             communication_channel_id=1,

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -2,7 +2,13 @@
 from unittest.mock import patch
 
 from xknx import XKNX
-from xknx.cemi import CEMIFrame, CEMIMessageCode, CEMIMPropInfo, CEMIMPropReadResponse
+from xknx.cemi import (
+    CEMIFrame,
+    CEMILData,
+    CEMIMessageCode,
+    CEMIMPropInfo,
+    CEMIMPropReadResponse,
+)
 from xknx.devices import (
     BinarySensor,
     Climate,
@@ -645,12 +651,15 @@ class TestStringRepresentations:
 
     def test_cemi_ldata_frame(self):
         """Test string representation of KNX/IP CEMI Frame."""
-        cemi_frame = CEMIFrame.init_from_telegram(
-            Telegram(
-                destination_address=GroupAddress("1/2/5"),
-                payload=GroupValueWrite(DPTBinary(7)),
+        cemi_frame = CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(
+                telegram=Telegram(
+                    destination_address=GroupAddress("1/2/5"),
+                    payload=GroupValueWrite(DPTBinary(7)),
+                ),
+                src_addr=IndividualAddress("1.2.3"),
             ),
-            src_addr=IndividualAddress("1.2.3"),
         )
         assert (
             str(cemi_frame)

--- a/xknx/secure/data_secure.py
+++ b/xknx/secure/data_secure.py
@@ -233,7 +233,7 @@ class DataSecure:
             plain_apdu_raw = cemi_data.payload.to_knx()
         else:
             # TODO: test if this is correct
-            plain_apdu_raw = b""  # used ein point-to-point eg. TConnect
+            plain_apdu_raw = b""  # used in point-to-point eg. TConnect
         secure_asdu = SecureData.init_from_plain_apdu(
             key=key,
             apdu=plain_apdu_raw,


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Move `init_from_telegram()` from CEMIFrame to CEMILData. 
- `telegram()` is now a method of CEMILData instead of a property of CEMIFrame.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)