### PR TITLE
Don't ignore CEMIFrames from current xknx address

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ nav_order: 2
 
 - Add support for Device Management Configuration service.
 - Support CEMI M_Prop messages.
+- Don't ignore CEMIFrames with source address equal to `xknx.current_address`.
 
 ### Internals
 

--- a/test/cemi_tests/cemi_handler_test.py
+++ b/test/cemi_tests/cemi_handler_test.py
@@ -166,7 +166,7 @@ def test_unsupported_cemi(raw):
         assert xknx.connection_manager.cemi_count_incoming_error == 1
 
 
-def test_incoming_from_self():
+def test_incoming_from_own_ia():
     """Test incoming CEMI from own IA."""
     xknx = XKNX()
     xknx.current_address = IndividualAddress("1.1.22")
@@ -178,5 +178,6 @@ def test_incoming_from_self():
     ) as mock_telegram_received:
         xknx.cemi_handler.handle_raw_cemi(raw)
         mock_debug.assert_called_once()
-        mock_telegram_received.assert_not_called()
-        assert xknx.connection_manager.cemi_count_incoming_error == 1
+        mock_telegram_received.assert_called_once()
+        assert xknx.connection_manager.cemi_count_incoming == 1
+        assert xknx.connection_manager.cemi_count_incoming_error == 0

--- a/xknx/cemi/cemi_handler.py
+++ b/xknx/cemi/cemi_handler.py
@@ -118,14 +118,6 @@ class CEMIHandler:
             logger.warning("Received unexpected L_DATA_REQ frame: %s", cemi)
             self.xknx.connection_manager.cemi_count_incoming_error += 1
             return
-        if (
-            cemi.code is CEMIMessageCode.L_DATA_IND
-            and cemi.data.src_addr == self.xknx.current_address
-        ):
-            # L_DATA_IND frames from our own address should be ignored (may occur form routing)
-            logger.debug("Ignoring own CEMI: %s", cemi)
-            self.xknx.connection_manager.cemi_count_incoming_error += 1
-            return
         logger.debug("Incoming CEMI: %s", cemi)
 
         if self.data_secure is not None:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Don't ignore CEMIFrames from current xknx address.

Routing should be safe anyway since we have https://github.com/XKNX/xknx/blob/792864c5c8e6c9cd316af44012f8e261b5df9308/xknx/io/transport/udp_transport.py#L131

Fixes #1226
Fixes https://github.com/home-assistant/core/issues/89581

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)