### PR TITLE
Return payload from DPTBase.to_knx instead of raw tuple[int]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - Handle empty list for group addresses in RemoteValue.
 
+### Internals
+
+- Return `DPTArray` or `DPTBinary` from `DPTBase.to_knx()` instead of `tuple[int, ...]`.
+
 # 2.7.0 IP Device Management 2023-03-15
 
 ### Protocol

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -226,7 +226,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/1"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(23))),
+            payload=GroupValueWrite(DPTTemperature.to_knx(23)),
         )
         await climate.process(telegram)
         after_update_callback.assert_called_with(climate)
@@ -234,7 +234,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(23))),
+            payload=GroupValueWrite(DPTTemperature.to_knx(23)),
         )
         await climate.process(telegram)
         after_update_callback.assert_called_with(climate)
@@ -242,7 +242,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTValue1Count.to_knx(-4))),
+            payload=GroupValueWrite(DPTValue1Count.to_knx(-4)),
         )
         await climate.process(telegram)
         after_update_callback.assert_called_with(climate)
@@ -286,7 +286,7 @@ class TestClimate:
             telegram = xknx.telegrams.get_nowait()
             assert telegram == Telegram(
                 destination_address=GroupAddress("1/2/4"),
-                payload=GroupValueWrite(DPTArray(DPTHVACMode.to_knx(operation_mode))),
+                payload=GroupValueWrite(DPTHVACMode.to_knx(operation_mode)),
             )
 
     async def test_set_controller_operation_mode(self):
@@ -302,9 +302,7 @@ class TestClimate:
             telegram = xknx.telegrams.get_nowait()
             assert telegram == Telegram(
                 destination_address=GroupAddress("1/2/4"),
-                payload=GroupValueWrite(
-                    DPTArray(DPTHVACContrMode.to_knx(controller_mode))
-                ),
+                payload=GroupValueWrite(DPTHVACContrMode.to_knx(controller_mode)),
             )
 
     async def test_set_operation_mode_not_supported(self):
@@ -336,9 +334,7 @@ class TestClimate:
             telegram = xknx.telegrams.get_nowait()
             assert telegram == Telegram(
                 destination_address=GroupAddress("1/2/4"),
-                payload=GroupValueWrite(
-                    DPTArray(DPTControllerStatus.to_knx(operation_mode))
-                ),
+                payload=GroupValueWrite(DPTControllerStatus.to_knx(operation_mode)),
             )
 
     async def test_set_operation_mode_with_separate_addresses(self):
@@ -457,7 +453,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTValue1Count.to_knx(-4))),
+            payload=GroupValueWrite(DPTValue1Count.to_knx(-4)),
         )
         await climate_dpt6.process(telegram)
         assert climate_dpt6.initialized_for_setpoint_shift_calculations
@@ -485,7 +481,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(-4))),
+            payload=GroupValueWrite(DPTTemperature.to_knx(-4)),
         )
         await climate_dpt9.process(telegram)
         assert climate_dpt9.initialized_for_setpoint_shift_calculations
@@ -495,7 +491,7 @@ class TestClimate:
         # DPTTemperature is used for outgoing
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature.to_knx(1))),
+            payload=GroupValueWrite(DPTTemperature.to_knx(1)),
         )
 
     #
@@ -573,7 +569,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(23.00)),
         )
         await xknx.devices.process(_telegram)
         assert climate.base_temperature == 20
@@ -590,7 +586,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(24.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(24.00)),
         )
         await xknx.devices.process(_telegram)
         assert climate.target_temperature.value == 24.00
@@ -607,7 +603,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.50))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(23.50)),
         )
         await xknx.devices.process(_telegram)
         assert climate.target_temperature.value == 23.50
@@ -651,7 +647,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(23.00)),
         )
         await xknx.devices.process(_telegram)
         assert climate.base_temperature == 22.0
@@ -668,7 +664,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(20.50))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(20.50)),
         )
         await xknx.devices.process(_telegram)
         assert climate.target_temperature.value == 20.50
@@ -685,7 +681,7 @@ class TestClimate:
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(19.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(19.00)),
         )
         await xknx.devices.process(_telegram)
         assert climate.target_temperature.value == 19.00
@@ -733,7 +729,7 @@ class TestClimate:
         await xknx.devices.process(_telegram)
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(23.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(23.00)),
         )
         assert climate.base_temperature == 20.00
         await climate.set_target_temperature(24.00)
@@ -748,7 +744,7 @@ class TestClimate:
         await xknx.devices.process(_telegram)
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(24.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(24.00)),
         )
         assert climate.target_temperature.value == 24.00
 
@@ -779,7 +775,7 @@ class TestClimate:
         await xknx.devices.process(_telegram)
         assert _telegram == Telegram(
             destination_address=GroupAddress("1/2/2"),
-            payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(21.00))),
+            payload=GroupValueWrite(DPT2ByteFloat().to_knx(21.00)),
         )
         assert not climate.initialized_for_setpoint_shift_calculations
         assert climate.base_temperature is None
@@ -832,7 +828,7 @@ class TestClimate:
         await climate.target_temperature.process(
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(20.00))),
+                payload=GroupValueWrite(DPT2ByteFloat().to_knx(20.00)),
             )
         )
         await climate.set_setpoint_shift(0)
@@ -858,7 +854,7 @@ class TestClimate:
         await climate.target_temperature.process(
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
-                payload=GroupValueWrite(DPTArray(DPT2ByteFloat().to_knx(19.40))),
+                payload=GroupValueWrite(DPT2ByteFloat().to_knx(19.40)),
             )
         )
         # + 3.5 °C = 23.5
@@ -1023,7 +1019,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature().to_knx(21.34))),
+            payload=GroupValueWrite(DPTTemperature().to_knx(21.34)),
         )
         await climate.process(telegram)
         assert climate.temperature.value == 21.34
@@ -1040,7 +1036,7 @@ class TestClimate:
         for operation_mode in DPT_20102_MODES:
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/5"),
-                payload=GroupValueWrite(DPTArray(DPTHVACMode.to_knx(operation_mode))),
+                payload=GroupValueWrite(DPTHVACMode.to_knx(operation_mode)),
             )
             await climate_mode.process(telegram)
             assert climate_mode.operation_mode == operation_mode
@@ -1049,9 +1045,7 @@ class TestClimate:
                 continue
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/3"),
-                payload=GroupValueWrite(
-                    DPTArray(DPTControllerStatus.to_knx(operation_mode))
-                ),
+                payload=GroupValueWrite(DPTControllerStatus.to_knx(operation_mode)),
             )
             await climate_mode.process(telegram)
             assert climate_mode.operation_mode == operation_mode
@@ -1065,9 +1059,7 @@ class TestClimate:
         for _, controller_mode in DPTHVACContrMode.SUPPORTED_MODES.items():
             telegram = Telegram(
                 destination_address=GroupAddress("1/2/5"),
-                payload=GroupValueWrite(
-                    DPTArray(DPTHVACContrMode.to_knx(controller_mode))
-                ),
+                payload=GroupValueWrite(DPTHVACContrMode.to_knx(controller_mode)),
             )
             await climate_mode.process(telegram)
             assert climate_mode.controller_mode == controller_mode
@@ -1162,7 +1154,7 @@ class TestClimate:
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTTemperature().to_knx(21.34))),
+            payload=GroupValueWrite(DPTTemperature().to_knx(21.34)),
         )
         await climate.process(telegram)
         after_update_callback.assert_called_with(climate)

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -36,14 +36,14 @@ class TestNotification:
         notification = Notification(xknx, "Warning", group_address="1/2/3")
         telegram_set = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
+            payload=GroupValueWrite(DPTString().to_knx("Ein Prosit!")),
         )
         await notification.process(telegram_set)
         assert notification.message == "Ein Prosit!"
 
         telegram_unset = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTString().to_knx(""))),
+            payload=GroupValueWrite(DPTString().to_knx("")),
         )
         await notification.process(telegram_unset)
         assert notification.message == ""
@@ -58,7 +58,7 @@ class TestNotification:
 
         telegram_set = Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
+            payload=GroupValueWrite(DPTString().to_knx("Ein Prosit!")),
         )
         await notification.process(telegram_set)
         after_update_callback.assert_called_with(notification)
@@ -166,7 +166,7 @@ class TestNotification:
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTString().to_knx("Ein Prosit!"))),
+            payload=GroupValueWrite(DPTString().to_knx("Ein Prosit!")),
         )
         # test if message longer than 14 chars gets cropped
         await notification.set("This is too long.")
@@ -175,7 +175,7 @@ class TestNotification:
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
-            payload=GroupValueWrite(DPTArray(DPTString().to_knx("This is too lo"))),
+            payload=GroupValueWrite(DPTString().to_knx("This is too lo")),
         )
 
     #

--- a/test/dpt_tests/dpt_1byte_signed_test.py
+++ b/test/dpt_tests/dpt_1byte_signed_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX DPT 1 byte relative value  objects."""
 import pytest
 
-from xknx.dpt import DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count
+from xknx.dpt import DPTArray, DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count
 from xknx.exceptions import ConversionError
 
 
@@ -25,18 +25,36 @@ class TestDPTRelativeValue:
 
     def test_to_knx_positive(self):
         """Test positive value to KNX."""
-        assert DPTSignedRelativeValue.to_knx(0) == (0x00,)
-        assert DPTSignedRelativeValue.to_knx(1) == (0x01,)
-        assert DPTSignedRelativeValue.to_knx(2) == (0x02,)
-        assert DPTSignedRelativeValue.to_knx(100) == (0x64,)
-        assert DPTSignedRelativeValue.to_knx(127) == (0x7F,)
+        assert DPTSignedRelativeValue.to_knx(0) == DPTArray(
+            0x00,
+        )
+        assert DPTSignedRelativeValue.to_knx(1) == DPTArray(
+            0x01,
+        )
+        assert DPTSignedRelativeValue.to_knx(2) == DPTArray(
+            0x02,
+        )
+        assert DPTSignedRelativeValue.to_knx(100) == DPTArray(
+            0x64,
+        )
+        assert DPTSignedRelativeValue.to_knx(127) == DPTArray(
+            0x7F,
+        )
 
     def test_to_knx_negative(self):
         """Test negative value to KNX."""
-        assert DPTSignedRelativeValue.to_knx(-128) == (0x80,)
-        assert DPTSignedRelativeValue.to_knx(-100) == (0x9C,)
-        assert DPTSignedRelativeValue.to_knx(-2) == (0xFE,)
-        assert DPTSignedRelativeValue.to_knx(-1) == (0xFF,)
+        assert DPTSignedRelativeValue.to_knx(-128) == DPTArray(
+            0x80,
+        )
+        assert DPTSignedRelativeValue.to_knx(-100) == DPTArray(
+            0x9C,
+        )
+        assert DPTSignedRelativeValue.to_knx(-2) == DPTArray(
+            0xFE,
+        )
+        assert DPTSignedRelativeValue.to_knx(-1) == DPTArray(
+            0xFF,
+        )
 
     def test_assert_min_exceeded(self):
         """Test initialization with wrong value (Underflow)."""

--- a/test/dpt_tests/dpt_1byte_uint_test.py
+++ b/test/dpt_tests/dpt_1byte_uint_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX DPT 5.010 value."""
 import pytest
 
-from xknx.dpt import DPTTariff, DPTValue1Ucount
+from xknx.dpt import DPTArray, DPTTariff, DPTValue1Ucount
 from xknx.exceptions import ConversionError
 
 
@@ -10,17 +10,17 @@ class TestDPTValue1Ucount:
 
     def test_value_50(self):
         """Test parsing and streaming of DPTValue1Ucount 50."""
-        assert DPTValue1Ucount.to_knx(50) == (0x32,)
+        assert DPTValue1Ucount.to_knx(50) == DPTArray(0x32)
         assert DPTValue1Ucount.from_knx((0x32,)) == 50
 
     def test_value_max(self):
         """Test parsing and streaming of DPTValue1Ucount 255."""
-        assert DPTValue1Ucount.to_knx(255) == (0xFF,)
+        assert DPTValue1Ucount.to_knx(255) == DPTArray(0xFF)
         assert DPTValue1Ucount.from_knx((0xFF,)) == 255
 
     def test_value_min(self):
         """Test parsing and streaming of DPTValue1Ucount 0."""
-        assert DPTValue1Ucount.to_knx(0) == (0x00,)
+        assert DPTValue1Ucount.to_knx(0) == DPTArray(0x00)
         assert DPTValue1Ucount.from_knx((0x00,)) == 0
 
     def test_to_knx_min_exceeded(self):

--- a/test/dpt_tests/dpt_2byte_signed_test.py
+++ b/test/dpt_tests/dpt_2byte_signed_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from xknx.dpt import DPT2ByteSigned
+from xknx.dpt import DPT2ByteSigned, DPTArray
 from xknx.exceptions import ConversionError
 
 
@@ -28,17 +28,17 @@ class TestDPT2ByteSigned:
 
     def test_signed_value_max_value(self):
         """Test DPT2ByteSigned parsing and streaming."""
-        assert DPT2ByteSigned.to_knx(32767) == (0x7F, 0xFF)
+        assert DPT2ByteSigned.to_knx(32767) == DPTArray((0x7F, 0xFF))
         assert DPT2ByteSigned.from_knx((0x7F, 0xFF)) == 32767
 
     def test_signed_value_min_value(self):
         """Test DPT2ByteSigned parsing and streaming with null values."""
-        assert DPT2ByteSigned.to_knx(-20480) == (0xB0, 0x00)
+        assert DPT2ByteSigned.to_knx(-20480) == DPTArray((0xB0, 0x00))
         assert DPT2ByteSigned.from_knx((0xB0, 0x00)) == -20480
 
     def test_signed_value_0123(self):
         """Test DPT2ByteSigned parsing and streaming."""
-        assert DPT2ByteSigned.to_knx(291) == (0x01, 0x23)
+        assert DPT2ByteSigned.to_knx(291) == DPTArray((0x01, 0x23))
         assert DPT2ByteSigned.from_knx((0x01, 0x23)) == 291
 
     def test_signed_wrong_value_from_knx(self):

--- a/test/dpt_tests/dpt_2byte_uint_test.py
+++ b/test/dpt_tests/dpt_2byte_uint_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX 2 byte objects."""
 import pytest
 
-from xknx.dpt import DPTUElCurrentmA
+from xknx.dpt import DPTArray, DPTUElCurrentmA
 from xknx.exceptions import ConversionError
 
 
@@ -30,27 +30,27 @@ class TestDPT2byte:
 
     def test_current_value_max_value(self):
         """Test DPTUElCurrentmA parsing and streaming."""
-        assert DPTUElCurrentmA.to_knx(65535) == (0xFF, 0xFF)
+        assert DPTUElCurrentmA.to_knx(65535) == DPTArray((0xFF, 0xFF))
         assert DPTUElCurrentmA.from_knx((0xFF, 0xFF)) == 65535
 
     def test_current_value_min_value(self):
         """Test DPTUElCurrentmA parsing and streaming with null values."""
-        assert DPTUElCurrentmA.to_knx(0) == (0x00, 0x00)
+        assert DPTUElCurrentmA.to_knx(0) == DPTArray((0x00, 0x00))
         assert DPTUElCurrentmA.from_knx((0x00, 0x00)) == 0
 
     def test_current_value_38(self):
         """Test DPTUElCurrentmA parsing and streaming 38mA."""
-        assert DPTUElCurrentmA.to_knx(38) == (0x00, 0x26)
+        assert DPTUElCurrentmA.to_knx(38) == DPTArray((0x00, 0x26))
         assert DPTUElCurrentmA.from_knx((0x00, 0x26)) == 38
 
     def test_current_value_78(self):
         """Test DPTUElCurrentmA parsing and streaming 78mA."""
-        assert DPTUElCurrentmA.to_knx(78) == (0x00, 0x4E)
+        assert DPTUElCurrentmA.to_knx(78) == DPTArray((0x00, 0x4E))
         assert DPTUElCurrentmA.from_knx((0x00, 0x4E)) == 78
 
     def test_current_value_1234(self):
         """Test DPTUElCurrentmA parsing and streaming 4660mA."""
-        assert DPTUElCurrentmA.to_knx(4660) == (0x12, 0x34)
+        assert DPTUElCurrentmA.to_knx(4660) == DPTArray((0x12, 0x34))
         assert DPTUElCurrentmA.from_knx((0x12, 0x34)) == 4660
 
     def test_current_wrong_value_from_knx(self):

--- a/test/dpt_tests/dpt_4bit_control_test.py
+++ b/test/dpt_tests/dpt_4bit_control_test.py
@@ -2,6 +2,7 @@
 import pytest
 
 from xknx.dpt import (
+    DPTBinary,
     DPTControlStartStop,
     DPTControlStartStopBlinds,
     DPTControlStartStopDimming,
@@ -21,7 +22,7 @@ class TestDPTControlStepCode:
             raw = DPTControlStepCode.to_knx(
                 {"control": control, "step_code": rawref & 0x07}
             )
-            assert raw == (rawref,)
+            assert raw == DPTBinary(rawref)
 
     def test_to_knx_wrong_type(self):
         """Test serializing wrong type to DPTControlStepCode."""
@@ -78,21 +79,21 @@ class TestDPTControlStepwise:
 
     def test_to_knx(self):
         """Test serializing values to DPTControlStepwise."""
-        assert DPTControlStepwise.to_knx(1) == (0xF,)
-        assert DPTControlStepwise.to_knx(3) == (0xE,)
-        assert DPTControlStepwise.to_knx(6) == (0xD,)
-        assert DPTControlStepwise.to_knx(12) == (0xC,)
-        assert DPTControlStepwise.to_knx(25) == (0xB,)
-        assert DPTControlStepwise.to_knx(50) == (0xA,)
-        assert DPTControlStepwise.to_knx(100) == (0x9,)
-        assert DPTControlStepwise.to_knx(-1) == (0x7,)
-        assert DPTControlStepwise.to_knx(-3) == (0x6,)
-        assert DPTControlStepwise.to_knx(-6) == (0x5,)
-        assert DPTControlStepwise.to_knx(-12) == (0x4,)
-        assert DPTControlStepwise.to_knx(-25) == (0x3,)
-        assert DPTControlStepwise.to_knx(-50) == (0x2,)
-        assert DPTControlStepwise.to_knx(-100) == (0x1,)
-        assert DPTControlStepwise.to_knx(0) == (0x0,)
+        assert DPTControlStepwise.to_knx(1) == DPTBinary(0xF)
+        assert DPTControlStepwise.to_knx(3) == DPTBinary(0xE)
+        assert DPTControlStepwise.to_knx(6) == DPTBinary(0xD)
+        assert DPTControlStepwise.to_knx(12) == DPTBinary(0xC)
+        assert DPTControlStepwise.to_knx(25) == DPTBinary(0xB)
+        assert DPTControlStepwise.to_knx(50) == DPTBinary(0xA)
+        assert DPTControlStepwise.to_knx(100) == DPTBinary(0x9)
+        assert DPTControlStepwise.to_knx(-1) == DPTBinary(0x7)
+        assert DPTControlStepwise.to_knx(-3) == DPTBinary(0x6)
+        assert DPTControlStepwise.to_knx(-6) == DPTBinary(0x5)
+        assert DPTControlStepwise.to_knx(-12) == DPTBinary(0x4)
+        assert DPTControlStepwise.to_knx(-25) == DPTBinary(0x3)
+        assert DPTControlStepwise.to_knx(-50) == DPTBinary(0x2)
+        assert DPTControlStepwise.to_knx(-100) == DPTBinary(0x1)
+        assert DPTControlStepwise.to_knx(0) == DPTBinary(0x0)
 
     def test_to_knx_wrong_type(self):
         """Test serializing wrong type to DPTControlStepwise."""
@@ -135,13 +136,13 @@ class TestDPTControlStartStop:
         """Test serializing dimming commands to KNX."""
         assert DPTControlStartStopDimming.to_knx(
             DPTControlStartStopDimming.Direction.INCREASE
-        ) == (9,)
+        ) == DPTBinary(9)
         assert DPTControlStartStopDimming.to_knx(
             DPTControlStartStopDimming.Direction.DECREASE
-        ) == (1,)
+        ) == DPTBinary(1)
         assert DPTControlStartStopDimming.to_knx(
             DPTControlStartStopDimming.Direction.STOP
-        ) == (0,)
+        ) == DPTBinary(0)
 
     def test_mode_to_knx_wrong_value(self):
         """Test serializing invalid data type to KNX."""

--- a/test/dpt_tests/dpt_4byte_int_test.py
+++ b/test/dpt_tests/dpt_4byte_int_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from xknx.dpt import DPT4ByteSigned, DPT4ByteUnsigned
+from xknx.dpt import DPT4ByteSigned, DPT4ByteUnsigned, DPTArray
 from xknx.exceptions import ConversionError
 
 
@@ -31,17 +31,17 @@ class TestDPT4Byte:
 
     def test_unsigned_value_max_value(self):
         """Test DPT4ByteUnsigned parsing and streaming."""
-        assert DPT4ByteUnsigned.to_knx(4294967295) == (0xFF, 0xFF, 0xFF, 0xFF)
+        assert DPT4ByteUnsigned.to_knx(4294967295) == DPTArray((0xFF, 0xFF, 0xFF, 0xFF))
         assert DPT4ByteUnsigned.from_knx((0xFF, 0xFF, 0xFF, 0xFF)) == 4294967295
 
     def test_unsigned_value_min_value(self):
         """Test parsing and streaming with null values."""
-        assert DPT4ByteUnsigned.to_knx(0) == (0x00, 0x00, 0x00, 0x00)
+        assert DPT4ByteUnsigned.to_knx(0) == DPTArray((0x00, 0x00, 0x00, 0x00))
         assert DPT4ByteUnsigned.from_knx((0x00, 0x00, 0x00, 0x00)) == 0
 
     def test_unsigned_value_01234567(self):
         """Test DPT4ByteUnsigned parsing and streaming."""
-        assert DPT4ByteUnsigned.to_knx(19088743) == (0x01, 0x23, 0x45, 0x67)
+        assert DPT4ByteUnsigned.to_knx(19088743) == DPTArray((0x01, 0x23, 0x45, 0x67))
         assert DPT4ByteUnsigned.from_knx((0x01, 0x23, 0x45, 0x67)) == 19088743
 
     def test_unsigned_wrong_value_from_knx(self):
@@ -69,17 +69,17 @@ class TestDPT4Byte:
 
     def test_signed_value_max_value(self):
         """Test DPT4ByteSigned parsing and streaming."""
-        assert DPT4ByteSigned.to_knx(2147483647) == (0x7F, 0xFF, 0xFF, 0xFF)
+        assert DPT4ByteSigned.to_knx(2147483647) == DPTArray((0x7F, 0xFF, 0xFF, 0xFF))
         assert DPT4ByteSigned.from_knx((0x7F, 0xFF, 0xFF, 0xFF)) == 2147483647
 
     def test_signed_value_min_value(self):
         """Test DPT4ByteSigned parsing and streaming with null values."""
-        assert DPT4ByteSigned.to_knx(-2147483648) == (0x80, 0x00, 0x00, 0x00)
+        assert DPT4ByteSigned.to_knx(-2147483648) == DPTArray((0x80, 0x00, 0x00, 0x00))
         assert DPT4ByteSigned.from_knx((0x80, 0x00, 0x00, 0x00)) == -2147483648
 
     def test_signed_value_01234567(self):
         """Test DPT4ByteSigned parsing and streaming."""
-        assert DPT4ByteSigned.to_knx(19088743) == (0x01, 0x23, 0x45, 0x67)
+        assert DPT4ByteSigned.to_knx(19088743) == DPTArray((0x01, 0x23, 0x45, 0x67))
         assert DPT4ByteSigned.from_knx((0x01, 0x23, 0x45, 0x67)) == 19088743
 
     def test_signed_wrong_value_from_knx(self):

--- a/test/dpt_tests/dpt_color_test.py
+++ b/test/dpt_tests/dpt_color_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX color objects."""
 import pytest
 
-from xknx.dpt.dpt_color import DPTColorXYY, XYYColor
+from xknx.dpt.dpt_color import DPTArray, DPTColorXYY, XYYColor
 from xknx.exceptions import ConversionError
 
 
@@ -24,7 +24,9 @@ class TestDPTColorXYY:
 
     def test_xyycolor_value_max_value(self):
         """Test DPTColorXYY parsing and streaming."""
-        assert DPTColorXYY.to_knx(((1, 1), 255)) == (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)
+        assert DPTColorXYY.to_knx(((1, 1), 255)) == DPTArray(
+            (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)
+        )
         assert DPTColorXYY.from_knx((0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)) == (
             (1, 1),
             255,
@@ -32,28 +34,29 @@ class TestDPTColorXYY:
 
     def test_xyycolor_value_min_value(self):
         """Test DPTColorXYY parsing and streaming with null values."""
-        assert DPTColorXYY.to_knx(((0, 0), 0)) == (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)
+        assert DPTColorXYY.to_knx(((0, 0), 0)) == DPTArray(
+            (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)
+        )
         assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x03)) == ((0, 0), 0)
 
     def test_xyycolor_value_none_value(self):
         """Test DPTColorXYY parsing and streaming with null values."""
-        assert DPTColorXYY.to_knx((None, 0)) == (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+        assert DPTColorXYY.to_knx((None, 0)) == DPTArray(
+            (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
+        )
         assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x01)) == (None, 0)
 
-        assert DPTColorXYY.to_knx(((0, 0), None)) == (
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x00,
-            0x02,
+        assert DPTColorXYY.to_knx(((0, 0), None)) == DPTArray(
+            (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)
         )
         assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x02)) == (
             (0, 0),
             None,
         )
 
-        assert DPTColorXYY.to_knx((None, None)) == (0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        assert DPTColorXYY.to_knx((None, None)) == DPTArray(
+            (0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+        )
         assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x00)) == (
             None,
             None,
@@ -61,26 +64,16 @@ class TestDPTColorXYY:
 
     def test_xyycolor_value(self):
         """Test DPTColorXYY parsing and streaming with valid value."""
-        assert DPTColorXYY.to_knx(((0.2, 0.2), 128)) == (
-            0x33,
-            0x33,
-            0x33,
-            0x33,
-            0x80,
-            0x03,
+        assert DPTColorXYY.to_knx(((0.2, 0.2), 128)) == DPTArray(
+            (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)
         )
         assert DPTColorXYY.from_knx((0x33, 0x33, 0x33, 0x33, 0x80, 0x03)) == (
             (0.2, 0.2),
             128,
         )
-        assert DPTColorXYY.to_knx(XYYColor(color=(0.8, 0.8), brightness=204)) == (
-            0xCC,
-            0xCC,
-            0xCC,
-            0xCC,
-            0xCC,
-            0x03,
-        )
+        assert DPTColorXYY.to_knx(
+            XYYColor(color=(0.8, 0.8), brightness=204)
+        ) == DPTArray((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03))
         assert DPTColorXYY.from_knx((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03)) == XYYColor(
             color=(0.8, 0.8), brightness=204
         )

--- a/test/dpt_tests/dpt_date_test.py
+++ b/test/dpt_tests/dpt_date_test.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from xknx.dpt import DPTDate
+from xknx.dpt import DPTArray, DPTDate
 from xknx.exceptions import ConversionError
 
 
@@ -31,17 +31,17 @@ class TestDPTDate:
     def test_to_knx(self):
         """Testing KNX/Byte representation of DPTDate object. Example 1."""
         raw = DPTDate.to_knx(time.strptime("2002-1-04", "%Y-%m-%d"))
-        assert raw == (0x04, 0x01, 0x02)
+        assert raw == DPTArray((0x04, 0x01, 0x02))
 
     def test_to_knx_old_date(self):
         """Testing KNX/Byte representation of DPTDate object. Example 2."""
         raw = DPTDate.to_knx(time.strptime("1990-01-31", "%Y-%m-%d"))
-        assert raw == (0x1F, 0x01, 0x5A)
+        assert raw == DPTArray((0x1F, 0x01, 0x5A))
 
     def test_to_knx_future_date(self):
         """Testing KNX/Byte representation of DPTDate object. Example 3."""
         raw = DPTDate.to_knx(time.strptime("2089-12-04", "%Y-%m-%d"))
-        assert raw == (0x04, 0x0C, 0x59)
+        assert raw == DPTArray((0x04, 0x0C, 0x59))
 
     def test_from_knx_wrong_parameter(self):
         """Test parsing from DPTDate object from wrong binary values."""

--- a/test/dpt_tests/dpt_datetime_test.py
+++ b/test/dpt_tests/dpt_datetime_test.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from xknx.dpt import DPTDateTime
+from xknx.dpt import DPTArray, DPTDateTime
 from xknx.exceptions import ConversionError
 
 
@@ -24,7 +24,7 @@ class TestDPTDateTime:
         raw = DPTDateTime.to_knx(
             time.strptime("2017-11-28 23:7:24", "%Y-%m-%d %H:%M:%S")
         )
-        assert raw == (0x75, 0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80)
+        assert raw == DPTArray((0x75, 0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
 
     #
     # TEST EARLIEST DATE POSSIBLE
@@ -40,7 +40,7 @@ class TestDPTDateTime:
         raw = DPTDateTime.to_knx(
             time.strptime("1900-1-1 1 0:0:0", "%Y-%m-%d %w %H:%M:%S")
         )
-        assert raw == (0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x20, 0x80)
+        assert raw == DPTArray((0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x20, 0x80))
 
     #
     # TEST LATEST DATE IN THE FUTURE
@@ -56,7 +56,7 @@ class TestDPTDateTime:
         raw = DPTDateTime.to_knx(
             time.strptime("2155-12-31 0 23:59:59", "%Y-%m-%d %w %H:%M:%S")
         )
-        assert raw == (0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80)
+        assert raw == DPTArray((0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80))
 
     #
     # TEST WRONG KNX

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -9,6 +9,7 @@ from xknx.dpt import (
     DPT2ByteFloat,
     DPT4ByteFloat,
     DPTAirFlow,
+    DPTArray,
     DPTElectricCurrent,
     DPTElectricPotential,
     DPTEnthalpy,
@@ -32,35 +33,35 @@ class TestDPTFloat:
     #
     def test_value_from_documentation(self):
         """Test parsing and streaming of DPT2ByteFloat -30.00. Example from the internet[tm]."""
-        assert DPT2ByteFloat.to_knx(-30.00) == (0x8A, 0x24)
+        assert DPT2ByteFloat.to_knx(-30.00) == DPTArray((0x8A, 0x24))
         assert DPT2ByteFloat.from_knx((0x8A, 0x24)) == -30.00
 
     def test_value_taken_from_live_thermostat(self):
         """Test parsing and streaming of DPT2ByteFloat 19.96."""
-        assert DPT2ByteFloat.to_knx(16.96) == (0x06, 0xA0)
+        assert DPT2ByteFloat.to_knx(16.96) == DPTArray((0x06, 0xA0))
         assert DPT2ByteFloat.from_knx((0x06, 0xA0)) == 16.96
 
     def test_zero_value(self):
         """Test parsing and streaming of DPT2ByteFloat zero value."""
-        assert DPT2ByteFloat.to_knx(0.00) == (0x00, 0x00)
+        assert DPT2ByteFloat.to_knx(0.00) == DPTArray((0x00, 0x00))
         assert DPT2ByteFloat.from_knx((0x00, 0x00)) == 0.00
 
     def test_room_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 21.00. Room temperature."""
-        assert DPT2ByteFloat.to_knx(21.00) == (0x0C, 0x1A)
+        assert DPT2ByteFloat.to_knx(21.00) == DPTArray((0x0C, 0x1A))
         assert DPT2ByteFloat.from_knx((0x0C, 0x1A)) == 21.00
 
     def test_high_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 500.00, 499.84, 500.16. Testing rounding issues."""
-        assert DPT2ByteFloat.to_knx(500.00) == (0x2E, 0x1A)
+        assert DPT2ByteFloat.to_knx(500.00) == DPTArray((0x2E, 0x1A))
         assert round(abs(DPT2ByteFloat.from_knx((0x2E, 0x1A)) - 499.84), 7) == 0
         assert round(abs(DPT2ByteFloat.from_knx((0x2E, 0x1B)) - 500.16), 7) == 0
-        assert DPT2ByteFloat.to_knx(499.84) == (0x2E, 0x1A)
-        assert DPT2ByteFloat.to_knx(500.16) == (0x2E, 0x1B)
+        assert DPT2ByteFloat.to_knx(499.84) == DPTArray((0x2E, 0x1A))
+        assert DPT2ByteFloat.to_knx(500.16) == DPTArray((0x2E, 0x1B))
 
     def test_minor_negative_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat -10.00. Testing negative values."""
-        assert DPT2ByteFloat.to_knx(-10.00) == (0x84, 0x18)
+        assert DPT2ByteFloat.to_knx(-10.00) == DPTArray((0x84, 0x18))
         assert DPT2ByteFloat.from_knx((0x84, 0x18)) == -10.00
 
     def test_very_cold_temperature(self):
@@ -69,37 +70,37 @@ class TestDPTFloat:
 
         Testing rounding issues of negative values.
         """
-        assert DPT2ByteFloat.to_knx(-1000.00) == (0xB1, 0xE6)
+        assert DPT2ByteFloat.to_knx(-1000.00) == DPTArray((0xB1, 0xE6))
         assert DPT2ByteFloat.from_knx((0xB1, 0xE6)) == -999.68
         assert DPT2ByteFloat.from_knx((0xB1, 0xE5)) == -1000.32
-        assert DPT2ByteFloat.to_knx(-999.68) == (0xB1, 0xE6)
-        assert DPT2ByteFloat.to_knx(-1000.32) == (0xB1, 0xE5)
+        assert DPT2ByteFloat.to_knx(-999.68) == DPTArray((0xB1, 0xE6))
+        assert DPT2ByteFloat.to_knx(-1000.32) == DPTArray((0xB1, 0xE5))
 
     def test_max(self):
         """Test parsing and streaming of DPT2ByteFloat with maximum value."""
-        assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_max) == (0x7F, 0xFF)
+        assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_max) == DPTArray((0x7F, 0xFF))
         assert DPT2ByteFloat.from_knx((0x7F, 0xFF)) == DPT2ByteFloat.value_max
 
     def test_close_to_limit(self):
         """Test parsing and streaming of DPT2ByteFloat with numeric limit."""
-        assert DPT2ByteFloat.to_knx(20.48) == (0x0C, 0x00)
+        assert DPT2ByteFloat.to_knx(20.48) == DPTArray((0x0C, 0x00))
         assert DPT2ByteFloat.from_knx((0x0C, 0x00)) == 20.48
-        assert DPT2ByteFloat.to_knx(-20.48) == (0x80, 0x00)
+        assert DPT2ByteFloat.to_knx(-20.48) == DPTArray((0x80, 0x00))
         assert DPT2ByteFloat.from_knx((0x80, 0x00)) == -20.48
 
     def test_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value."""
-        assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_min) == (0xF8, 0x00)
+        assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_min) == DPTArray((0xF8, 0x00))
         assert DPT2ByteFloat.from_knx((0xF8, 0x00)) == DPT2ByteFloat.value_min
 
     def test_close_to_max(self):
         """Test parsing and streaming of DPT2ByteFloat with maximum value -1."""
-        assert DPT2ByteFloat.to_knx(670433.28) == (0x7F, 0xFE)
+        assert DPT2ByteFloat.to_knx(670433.28) == DPTArray((0x7F, 0xFE))
         assert DPT2ByteFloat.from_knx((0x7F, 0xFE)) == 670433.28
 
     def test_close_to_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value +1."""
-        assert DPT2ByteFloat.to_knx(-670760.96) == (0xF8, 0x01)
+        assert DPT2ByteFloat.to_knx(-670760.96) == DPTArray((0xF8, 0x01))
         assert DPT2ByteFloat.from_knx((0xF8, 0x01)) == -670760.96
 
     def test_to_knx_min_exceeded(self):
@@ -211,9 +212,9 @@ class TestDPTFloat:
     def test_4byte_float_values_from_power_meter(self):
         """Test parsing DPT4ByteFloat value from power meter."""
         assert DPT4ByteFloat.from_knx((0x43, 0xC6, 0x80, 00)) == 397
-        assert DPT4ByteFloat.to_knx(397) == (0x43, 0xC6, 0x80, 00)
+        assert DPT4ByteFloat.to_knx(397) == DPTArray((0x43, 0xC6, 0x80, 00))
         assert DPT4ByteFloat.from_knx((0x42, 0x38, 0x00, 00)) == 46
-        assert DPT4ByteFloat.to_knx(46) == (0x42, 0x38, 0x00, 00)
+        assert DPT4ByteFloat.to_knx(46) == DPTArray((0x42, 0x38, 0x00, 00))
 
     def test_14_033(self):
         """Test parsing DPTFrequency unit."""
@@ -222,38 +223,40 @@ class TestDPTFloat:
     def test_14_055(self):
         """Test DPTPhaseAngleDeg object."""
         assert DPT4ByteFloat.from_knx((0x42, 0xEF, 0x00, 0x00)) == 119.5
-        assert DPT4ByteFloat.to_knx(119.5) == (0x42, 0xEF, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(119.5) == DPTArray((0x42, 0xEF, 0x00, 0x00))
         assert DPTPhaseAngleDeg.unit == "°"
 
     def test_14_057(self):
         """Test DPT4ByteFloat object."""
         assert DPT4ByteFloat.from_knx((0x3F, 0x71, 0xEB, 0x86)) == 0.9450001
-        assert DPT4ByteFloat.to_knx(0.945000052452) == (0x3F, 0x71, 0xEB, 0x86)
+        assert DPT4ByteFloat.to_knx(0.945000052452) == DPTArray(
+            (0x3F, 0x71, 0xEB, 0x86)
+        )
         assert DPT4ByteFloat.unit is None
 
     def test_4byte_float_values_from_voltage_meter(self):
         """Test parsing DPT4ByteFloat from voltage meter."""
         assert DPT4ByteFloat.from_knx((0x43, 0x65, 0xE3, 0xD7)) == 229.89
-        assert DPT4ByteFloat.to_knx(229.89) == (0x43, 0x65, 0xE3, 0xD7)
+        assert DPT4ByteFloat.to_knx(229.89) == DPTArray((0x43, 0x65, 0xE3, 0xD7))
 
     def test_4byte_float_zero_value(self):
         """Test parsing and streaming of DPT4ByteFloat zero value."""
         assert DPT4ByteFloat.from_knx((0x00, 0x00, 0x00, 0x00)) == 0.00
-        assert DPT4ByteFloat.to_knx(0.00) == (0x00, 0x00, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(0.00) == DPTArray((0x00, 0x00, 0x00, 0x00))
 
     def test_4byte_float_special_value(self):
         """Test parsing and streaming of DPT4ByteFloat special value."""
         assert math.isnan(DPT4ByteFloat.from_knx((0x7F, 0xC0, 0x00, 0x00)))
-        assert DPT4ByteFloat.to_knx(float("nan")) == (0x7F, 0xC0, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(float("nan")) == DPTArray((0x7F, 0xC0, 0x00, 0x00))
 
         assert math.isinf(DPT4ByteFloat.from_knx((0x7F, 0x80, 0x00, 0x00)))
-        assert DPT4ByteFloat.to_knx(float("inf")) == (0x7F, 0x80, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(float("inf")) == DPTArray((0x7F, 0x80, 0x00, 0x00))
 
         assert DPT4ByteFloat.from_knx((0xFF, 0x80, 0x00, 0x00)) == float("-inf")
-        assert DPT4ByteFloat.to_knx(float("-inf")) == (0xFF, 0x80, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(float("-inf")) == DPTArray((0xFF, 0x80, 0x00, 0x00))
 
         assert DPT4ByteFloat.from_knx((0x80, 0x00, 0x00, 0x00)) == float("-0")
-        assert DPT4ByteFloat.to_knx(float("-0")) == (0x80, 0x00, 0x00, 0x00)
+        assert DPT4ByteFloat.to_knx(float("-0")) == DPTArray((0x80, 0x00, 0x00, 0x00))
 
     def test_4byte_float_to_knx_wrong_parameter(self):
         """Test parsing of DPT4ByteFloat with wrong value (string)."""

--- a/test/dpt_tests/dpt_hvac_mode_test.py
+++ b/test/dpt_tests/dpt_hvac_mode_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX DPT HVAC Operation modes."""
 import pytest
 
-from xknx.dpt import DPTControllerStatus, DPTHVACMode
+from xknx.dpt import DPTArray, DPTControllerStatus, DPTHVACMode
 from xknx.dpt.dpt_hvac_mode import HVACOperationMode
 from xknx.exceptions import ConversionError
 
@@ -11,11 +11,13 @@ class TestDPTControllerStatus:
 
     def test_mode_to_knx(self):
         """Test parsing DPTHVACMode to KNX."""
-        assert DPTHVACMode.to_knx(HVACOperationMode.AUTO) == (0x00,)
-        assert DPTHVACMode.to_knx(HVACOperationMode.COMFORT) == (0x01,)
-        assert DPTHVACMode.to_knx(HVACOperationMode.STANDBY) == (0x02,)
-        assert DPTHVACMode.to_knx(HVACOperationMode.NIGHT) == (0x03,)
-        assert DPTHVACMode.to_knx(HVACOperationMode.FROST_PROTECTION) == (0x04,)
+        assert DPTHVACMode.to_knx(HVACOperationMode.AUTO) == DPTArray((0x00,))
+        assert DPTHVACMode.to_knx(HVACOperationMode.COMFORT) == DPTArray((0x01,))
+        assert DPTHVACMode.to_knx(HVACOperationMode.STANDBY) == DPTArray((0x02,))
+        assert DPTHVACMode.to_knx(HVACOperationMode.NIGHT) == DPTArray((0x03,))
+        assert DPTHVACMode.to_knx(HVACOperationMode.FROST_PROTECTION) == DPTArray(
+            (0x04,)
+        )
 
     def test_mode_to_knx_wrong_value(self):
         """Test serializing DPTHVACMode to KNX with wrong value."""
@@ -34,10 +36,16 @@ class TestDPTControllerStatus:
         """Test serializing DPTControllerStatus to KNX."""
         with pytest.raises(ConversionError):
             DPTControllerStatus.to_knx(HVACOperationMode.AUTO)
-        assert DPTControllerStatus.to_knx(HVACOperationMode.COMFORT) == (0x21,)
-        assert DPTControllerStatus.to_knx(HVACOperationMode.STANDBY) == (0x22,)
-        assert DPTControllerStatus.to_knx(HVACOperationMode.NIGHT) == (0x24,)
-        assert DPTControllerStatus.to_knx(HVACOperationMode.FROST_PROTECTION) == (0x28,)
+        assert DPTControllerStatus.to_knx(HVACOperationMode.COMFORT) == DPTArray(
+            (0x21,)
+        )
+        assert DPTControllerStatus.to_knx(HVACOperationMode.STANDBY) == DPTArray(
+            (0x22,)
+        )
+        assert DPTControllerStatus.to_knx(HVACOperationMode.NIGHT) == DPTArray((0x24,))
+        assert DPTControllerStatus.to_knx(
+            HVACOperationMode.FROST_PROTECTION
+        ) == DPTArray((0x28,))
 
     def test_controller_status_to_knx_wrong_value(self):
         """Test serializing DPTControllerStatus to KNX with wrong value."""

--- a/test/dpt_tests/dpt_scaling_test.py
+++ b/test/dpt_tests/dpt_scaling_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX DPT 5.001 and 5.003 value."""
 import pytest
 
-from xknx.dpt import DPTAngle, DPTScaling
+from xknx.dpt import DPTAngle, DPTArray, DPTScaling
 from xknx.exceptions import ConversionError
 
 
@@ -10,22 +10,22 @@ class TestDPTScaling:
 
     def test_value_30_pct(self):
         """Test parsing and streaming of DPTScaling 30%."""
-        assert DPTScaling.to_knx(30) == (0x4C,)
+        assert DPTScaling.to_knx(30) == DPTArray((0x4C,))
         assert DPTScaling.from_knx((0x4C,)) == 30
 
     def test_value_99_pct(self):
         """Test parsing and streaming of DPTScaling 99%."""
-        assert DPTScaling.to_knx(99) == (0xFC,)
+        assert DPTScaling.to_knx(99) == DPTArray((0xFC,))
         assert DPTScaling.from_knx((0xFC,)) == 99
 
     def test_value_max(self):
         """Test parsing and streaming of DPTScaling 100%."""
-        assert DPTScaling.to_knx(100) == (0xFF,)
+        assert DPTScaling.to_knx(100) == DPTArray((0xFF,))
         assert DPTScaling.from_knx((0xFF,)) == 100
 
     def test_value_min(self):
         """Test parsing and streaming of DPTScaling 0."""
-        assert DPTScaling.to_knx(0) == (0x00,)
+        assert DPTScaling.to_knx(0) == DPTArray((0x00,))
         assert DPTScaling.from_knx((0x00,)) == 0
 
     def test_to_knx_min_exceeded(self):
@@ -64,22 +64,22 @@ class TestDPTAngle:
 
     def test_value_30_deg(self):
         """Test parsing and streaming of DPTAngle 30°."""
-        assert DPTAngle.to_knx(30) == (0x15,)
+        assert DPTAngle.to_knx(30) == DPTArray((0x15,))
         assert DPTAngle.from_knx((0x15,)) == 30
 
     def test_value_270_deg(self):
         """Test parsing and streaming of DPTAngle 270°."""
-        assert DPTAngle.to_knx(270) == (0xBF,)
+        assert DPTAngle.to_knx(270) == DPTArray((0xBF,))
         assert DPTAngle.from_knx((0xBF,)) == 270
 
     def test_value_max(self):
         """Test parsing and streaming of DPTAngle 360°."""
-        assert DPTAngle.to_knx(360) == (0xFF,)
+        assert DPTAngle.to_knx(360) == DPTArray((0xFF,))
         assert DPTAngle.from_knx((0xFF,)) == 360
 
     def test_value_min(self):
         """Test parsing and streaming of DPTAngle 0°."""
-        assert DPTAngle.to_knx(0) == (0x00,)
+        assert DPTAngle.to_knx(0) == DPTArray((0x00,))
         assert DPTAngle.from_knx((0x00,)) == 0
 
     def test_to_knx_min_exceeded(self):

--- a/test/dpt_tests/dpt_scene_number_test.py
+++ b/test/dpt_tests/dpt_scene_number_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX scene number."""
 import pytest
 
-from xknx.dpt import DPTSceneNumber
+from xknx.dpt import DPTArray, DPTSceneNumber
 from xknx.exceptions import ConversionError
 
 
@@ -10,17 +10,17 @@ class TestDPTSceneNumber:
 
     def test_value_50(self):
         """Test parsing and streaming of DPTSceneNumber 50."""
-        assert DPTSceneNumber.to_knx(50) == (0x31,)
+        assert DPTSceneNumber.to_knx(50) == DPTArray((0x31,))
         assert DPTSceneNumber.from_knx((0x31,)) == 50
 
     def test_value_max(self):
         """Test parsing and streaming of DPTSceneNumber 64."""
-        assert DPTSceneNumber.to_knx(64) == (0x3F,)
+        assert DPTSceneNumber.to_knx(64) == DPTArray((0x3F,))
         assert DPTSceneNumber.from_knx((0x3F,)) == 64
 
     def test_value_min(self):
         """Test parsing and streaming of DPTSceneNumber 0."""
-        assert DPTSceneNumber.to_knx(1) == (0x00,)
+        assert DPTSceneNumber.to_knx(1) == DPTArray((0x00,))
         assert DPTSceneNumber.from_knx((0x00,)) == 1
 
     def test_to_knx_min_exceeded(self):

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -1,7 +1,7 @@
 """Unit test for KNX string object."""
 import pytest
 
-from xknx.dpt import DPTLatin1, DPTString
+from xknx.dpt import DPTArray, DPTLatin1, DPTString
 from xknx.exceptions import ConversionError
 
 
@@ -32,7 +32,7 @@ class TestDPTString:
     @pytest.mark.parametrize("test_dpt", [DPTString, DPTLatin1])
     def test_values(self, string, raw, test_dpt):
         """Test parsing and streaming strings."""
-        assert test_dpt.to_knx(string) == raw
+        assert test_dpt.to_knx(string) == DPTArray(raw)
         assert test_dpt.from_knx(raw) == string
 
     @pytest.mark.parametrize(
@@ -52,7 +52,7 @@ class TestDPTString:
     )
     def test_to_knx_ascii_invalid_chars(self, string, knx_string, raw):
         """Test streaming ASCII string with invalid chars."""
-        assert DPTString.to_knx(string) == raw
+        assert DPTString.to_knx(string) == DPTArray(raw)
         assert DPTString.from_knx(raw) == knx_string
 
     @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ class TestDPTString:
     )
     def test_to_knx_latin_1(self, string, raw):
         """Test streaming Latin-1 strings."""
-        assert DPTLatin1.to_knx(string) == raw
+        assert DPTLatin1.to_knx(string) == DPTArray(raw)
         assert DPTLatin1.from_knx(raw) == string
 
     def test_to_knx_too_long(self):

--- a/test/dpt_tests/dpt_time_test.py
+++ b/test/dpt_tests/dpt_time_test.py
@@ -3,7 +3,7 @@ import time
 
 import pytest
 
-from xknx.dpt import DPTTime
+from xknx.dpt import DPTArray, DPTTime
 from xknx.exceptions import ConversionError
 
 
@@ -22,7 +22,7 @@ class TestDPTTime:
     def test_to_knx(self):
         """Testing KNX/Byte representation of DPTTime object."""
         raw = DPTTime.to_knx(time.strptime("13 23 42 2", "%H %M %S %w"))
-        assert raw == (0x4D, 0x17, 0x2A)
+        assert raw == DPTArray((0x4D, 0x17, 0x2A))
 
     #
     # TEST MAXIMUM TIME
@@ -30,7 +30,7 @@ class TestDPTTime:
     def test_to_knx_max(self):
         """Testing KNX/Byte representation of DPTTime object. Maximum values."""
         raw = DPTTime.to_knx(time.strptime("23 59 59 0", "%H %M %S %w"))
-        assert raw == (0xF7, 0x3B, 0x3B)
+        assert raw == DPTArray((0xF7, 0x3B, 0x3B))
 
     def test_from_knx_max(self):
         """Test parsing of DPTTime object from binary values. Example 2."""
@@ -44,7 +44,7 @@ class TestDPTTime:
     def test_to_knx_min(self):
         """Testing KNX/Byte representation of DPTTime object. Minimum values."""
         raw = DPTTime.to_knx(time.strptime("0 0 0", "%H %M %S"))
-        assert raw == (0x0, 0x0, 0x0)
+        assert raw == DPTArray((0x0, 0x0, 0x0))
 
     def test_from_knx_min(self):
         """Test parsing of DPTTime object from binary values. Example 3."""
@@ -55,7 +55,7 @@ class TestDPTTime:
     #
     def test_to_knx_default(self):
         """Testing default initialization of DPTTime object."""
-        assert DPTTime.to_knx(time.strptime("", "")) == (0x0, 0x0, 0x0)
+        assert DPTTime.to_knx(time.strptime("", "")) == DPTArray((0x0, 0x0, 0x0))
 
     def test_from_knx_wrong_size(self):
         """Test parsing from DPTTime object from wrong binary values (wrong size)."""

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -34,7 +34,7 @@ class TestKNXIPRountingIndication:
         telegram = Telegram(
             destination_address=GroupAddress(337),
             payload=GroupValueWrite(
-                DPTArray(DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S")))
+                DPTTime().to_knx(time.strptime("13:23:42", "%H:%M:%S"))
             ),
         )
         cemi = CEMIFrame(

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -43,7 +43,7 @@ class TestRemoteValueSensor:
         """Test payload_valid method."""
         xknx = XKNX()
         remote_value = RemoteValueSensor(xknx=xknx, value_type="pulse")
-        valid_payload = DPTArray(DPTValue1Ucount.to_knx(1))
+        valid_payload = DPTValue1Ucount.to_knx(1)
 
         assert remote_value.dpt_class == DPTValue1Ucount
         with pytest.raises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_setepoint_shift_test.py
+++ b/test/remote_value_tests/remote_value_setepoint_shift_test.py
@@ -17,8 +17,8 @@ class TestRemoteValueSetpointShift:
         """Test if setpoint_shift_mode is assigned properly by payload length."""
         xknx = XKNX()
         remote_value = RemoteValueSetpointShift(xknx=xknx)
-        dpt_6_payload = DPTArray(DPTValue1Count.to_knx(1))
-        dpt_9_payload = DPTArray(DPTTemperature.to_knx(1))
+        dpt_6_payload = DPTValue1Count.to_knx(1)
+        dpt_9_payload = DPTTemperature.to_knx(1)
 
         with pytest.raises(CouldNotParseTelegram):
             remote_value.payload_valid(DPTBinary(0))
@@ -50,8 +50,8 @@ class TestRemoteValueSetpointShift:
         remote_value_9 = RemoteValueSetpointShift(
             xknx=xknx, setpoint_shift_mode=SetpointShiftMode.DPT9002
         )
-        dpt_6_payload = DPTArray(DPTValue1Count.to_knx(1))
-        dpt_9_payload = DPTArray(DPTTemperature.to_knx(1))
+        dpt_6_payload = DPTValue1Count.to_knx(1)
+        dpt_9_payload = DPTTemperature.to_knx(1)
 
         assert remote_value_6.dpt_class == DPTValue1Count
         with pytest.raises(CouldNotParseTelegram):

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -19,7 +19,7 @@ class TestRemoteValue:
         """Test value getter and setter."""
         xknx = XKNX()
         remote_value = RemoteValue(xknx)
-        remote_value.to_knx = lambda value: DPTArray(DPT2ByteFloat.to_knx(value))
+        remote_value.to_knx = lambda value: DPT2ByteFloat.to_knx(value)
         remote_value.after_update_cb = AsyncMock()
 
         assert remote_value.value is None
@@ -42,7 +42,7 @@ class TestRemoteValue:
         """Test set_value awaitable."""
         xknx = XKNX()
         remote_value = RemoteValue(xknx)
-        remote_value.to_knx = lambda value: DPTArray(DPT2ByteFloat.to_knx(value))
+        remote_value.to_knx = lambda value: DPT2ByteFloat.to_knx(value)
         remote_value.after_update_cb = AsyncMock()
 
         await remote_value.update_value(3.3)

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -5,7 +5,7 @@ Module for encoding and decoding KNX datatypes.
 * Derived KNX Values like Scaling, Temperature
 """
 # flake8: noqa
-from .dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric
+from .dpt import DPTBase, DPTNumeric
 from .dpt_1byte_signed import DPTPercentV8, DPTSignedRelativeValue, DPTValue1Count
 from .dpt_1byte_uint import (
     DPTDecimalFactor,
@@ -189,3 +189,4 @@ from .dpt_hvac_mode import DPTControllerStatus, DPTHVACContrMode, DPTHVACMode
 from .dpt_scaling import DPTAngle, DPTScaling
 from .dpt_string import DPTLatin1, DPTString
 from .dpt_time import DPTTime
+from .payload import DPTArray, DPTBinary, DPTPayloadT

--- a/xknx/dpt/dpt_1byte_signed.py
+++ b/xknx/dpt/dpt_1byte_signed.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPTSignedRelativeValue(DPTNumeric):
@@ -31,7 +32,7 @@ class DPTSignedRelativeValue(DPTNumeric):
         return raw[0]
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
@@ -39,7 +40,7 @@ class DPTSignedRelativeValue(DPTNumeric):
                 raise ValueError
             if knx_value < 0:
                 knx_value += 0x100
-            return (knx_value & 0xFF,)
+            return DPTArray(knx_value & 0xFF)
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_1byte_uint.py
+++ b/xknx/dpt/dpt_1byte_uint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPTValue1ByteUnsigned(DPTNumeric):
@@ -37,13 +38,13 @@ class DPTValue1ByteUnsigned(DPTNumeric):
         return value
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
             if not cls._test_boundaries(knx_value):
                 raise ValueError
-            return (knx_value,)
+            return DPTArray(knx_value)
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 
@@ -133,12 +134,12 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
         return value
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value) - 1
             if not cls._test_boundaries(knx_value + 1):
                 raise ValueError
-            return (knx_value,)
+            return DPTArray(knx_value)
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPT2ByteFloat(DPTNumeric):
@@ -46,7 +47,7 @@ class DPT2ByteFloat(DPTNumeric):
         return value
 
     @classmethod
-    def to_knx(cls, value: float) -> tuple[int, int]:
+    def to_knx(cls, value: float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = float(value)
@@ -64,7 +65,7 @@ class DPT2ByteFloat(DPTNumeric):
             if value < 0:
                 msb |= 0x80
 
-            return msb, mantisse & 0xFF
+            return DPTArray((msb, mantisse & 0xFF))
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -11,6 +11,7 @@ import struct
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPT2ByteSigned(DPTNumeric):
@@ -42,13 +43,13 @@ class DPT2ByteSigned(DPTNumeric):
             raise ConversionError(f"Could not parse {cls.__name__}", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int, ...]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
             if not cls._test_boundaries(knx_value):
                 raise ValueError
-            return tuple(struct.pack(cls._struct_format, knx_value))
+            return DPTArray(struct.pack(cls._struct_format, knx_value))
         except (ValueError, struct.error):
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPT2ByteUnsigned(DPTNumeric):
@@ -31,13 +32,13 @@ class DPT2ByteUnsigned(DPTNumeric):
         return (raw[0] * 256) + raw[1]
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int, int]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
             if not cls._test_boundaries(knx_value):
                 raise ValueError
-            return knx_value >> 8, knx_value & 0xFF
+            return DPTArray((knx_value >> 8, knx_value & 0xFF))
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_4bit_control.py
+++ b/xknx/dpt/dpt_4bit_control.py
@@ -20,6 +20,7 @@ from typing import Any
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTBinary
 
 
 class DPTControlStepCode(DPTBase, ABC):
@@ -59,7 +60,7 @@ class DPTControlStepCode(DPTBase, ABC):
         return False
 
     @classmethod
-    def to_knx(cls, value: Any) -> tuple[int]:
+    def to_knx(cls, value: Any) -> DPTBinary:
         """Serialize to KNX/IP raw data."""
         # TODO: use Tuple or Named Tuple instead of Dict[str, int] to account for bool control
         if not isinstance(value, dict):
@@ -80,7 +81,7 @@ class DPTControlStepCode(DPTBase, ABC):
                 f"Can't serialize {cls.__name__}; invalid values", value=value
             )
 
-        return (cls._encode(control, step_code),)
+        return DPTBinary(cls._encode(control, step_code))
 
     @classmethod
     def from_knx(cls, raw: tuple[int, ...]) -> Any:
@@ -136,7 +137,7 @@ class DPTControlStepwise(DPTControlStepCode):
         return inc if value["control"] == 1 else -inc
 
     @classmethod
-    def to_knx(cls, value: int | dict[str, int]) -> tuple[int]:
+    def to_knx(cls, value: int | dict[str, int]) -> DPTBinary:
         """Serialize to KNX/IP raw data."""
         if not isinstance(value, int):
             raise ConversionError(f"Can't serialize {cls.__name__}", value=value)
@@ -189,7 +190,7 @@ class DPTControlStartStop(DPTControlStepCode):
         STOP = 2
 
     @classmethod
-    def to_knx(cls, value: Direction) -> tuple[int]:
+    def to_knx(cls, value: Direction) -> DPTBinary:
         """Convert value to payload."""
         control = 0
         step_code = 0

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -12,6 +12,7 @@ from typing import cast
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPT4ByteFloat(DPTNumeric):
@@ -53,11 +54,11 @@ class DPT4ByteFloat(DPTNumeric):
             return raw_float
 
     @classmethod
-    def to_knx(cls, value: float) -> tuple[int, ...]:
+    def to_knx(cls, value: float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = float(value)
-            return tuple(struct.pack(">f", knx_value))
+            return DPTArray(struct.pack(">f", knx_value))
         except (ValueError, struct.error):
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -12,6 +12,7 @@ import struct
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPT4ByteUnsigned(DPTNumeric):
@@ -43,13 +44,13 @@ class DPT4ByteUnsigned(DPTNumeric):
             raise ConversionError(f"Could not parse {cls.__name__}", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: int | float) -> tuple[int, ...]:
+    def to_knx(cls, value: int | float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = int(value)
             if not cls._test_boundaries(knx_value):
                 raise ValueError
-            return tuple(struct.pack(cls._struct_format, knx_value))
+            return DPTArray(struct.pack(cls._struct_format, knx_value))
         except (ValueError, struct.error):
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_color.py
+++ b/xknx/dpt/dpt_color.py
@@ -6,6 +6,7 @@ from typing import NamedTuple
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 
 class XYYColor(NamedTuple):
@@ -52,7 +53,7 @@ class DPTColorXYY(DPTBase):
     @classmethod
     def to_knx(
         cls, value: XYYColor | tuple[tuple[float, float] | None, int | None]
-    ) -> tuple[int, int, int, int, int, int]:
+    ) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             if not isinstance(value, XYYColor):
@@ -73,13 +74,15 @@ class DPTColorXYY(DPTBase):
                 brightness_valid = True
                 brightness = int(value.brightness)
 
-            return (
-                x_axis >> 8,
-                x_axis & 0xFF,
-                y_axis >> 8,
-                y_axis & 0xFF,
-                brightness,
-                color_valid << 1 | brightness_valid,
+            return DPTArray(
+                (
+                    x_axis >> 8,
+                    x_axis & 0xFF,
+                    y_axis >> 8,
+                    y_axis & 0xFF,
+                    brightness,
+                    color_valid << 1 | brightness_valid,
+                )
             )
         except (ValueError, TypeError):
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)

--- a/xknx/dpt/dpt_date.py
+++ b/xknx/dpt/dpt_date.py
@@ -6,6 +6,7 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 
 class DPTDate(DPTBase):
@@ -37,7 +38,7 @@ class DPTDate(DPTBase):
             raise ConversionError("Could not parse DPTDate", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time) -> tuple[int, int, int]:
+    def to_knx(cls, value: time.struct_time) -> DPTArray:
         """Serialize to KNX/IP raw data from time.struct_time."""
 
         def _knx_year(year: int) -> int:
@@ -50,7 +51,13 @@ class DPTDate(DPTBase):
         if not isinstance(value, time.struct_time):
             raise ConversionError("Could not serialize DPTDate", value=value)
 
-        return (value.tm_mday, value.tm_mon, _knx_year(value.tm_year))
+        return DPTArray(
+            (
+                value.tm_mday,
+                value.tm_mon,
+                _knx_year(value.tm_year),
+            )
+        )
 
     @staticmethod
     def _test_range(day: int, month: int, year: int) -> bool:

--- a/xknx/dpt/dpt_datetime.py
+++ b/xknx/dpt/dpt_datetime.py
@@ -6,6 +6,7 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 
 class DPTDateTime(DPTBase):
@@ -67,7 +68,7 @@ class DPTDateTime(DPTBase):
             raise ConversionError("Could not parse DPTDateTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time) -> tuple[int, ...]:
+    def to_knx(cls, value: time.struct_time) -> DPTArray:
         """Serialize to KNX/IP raw data from time.struct_time."""
         if not isinstance(value, time.struct_time):
             raise ConversionError("Could not serialize DPTDateTime", value=value)
@@ -81,13 +82,15 @@ class DPTDateTime(DPTBase):
         seconds = value.tm_sec
         dst = value.tm_isdst == 1  # tm_isdst can be -1
 
-        return (
-            knx_year,
-            month,
-            day,
-            weekday << 5 | hours,
-            minutes,
-            seconds,
-            0x20 | dst,  # 0x20 working day not valid
-            0x80,  # assume clock with ext. sync signal
+        return DPTArray(
+            (
+                knx_year,
+                month,
+                day,
+                weekday << 5 | hours,
+                minutes,
+                seconds,
+                0x20 | dst,  # 0x20 working day not valid
+                0x80,  # assume clock with ext. sync signal
+            )
         )

--- a/xknx/dpt/dpt_hvac_mode.py
+++ b/xknx/dpt/dpt_hvac_mode.py
@@ -7,6 +7,7 @@ from typing import Generic, TypeVar
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 HVACModeT = TypeVar("HVACModeT", "HVACControllerMode", "HVACOperationMode")
 
@@ -57,11 +58,11 @@ class _DPTClimateMode(DPTBase, Generic[HVACModeT]):
             raise ConversionError(f"Payload not supported for {cls.__name__}", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: HVACModeT) -> tuple[int]:
+    def to_knx(cls, value: HVACModeT) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         for knx_value, mode in cls.SUPPORTED_MODES.items():
             if mode == value:
-                return (knx_value,)
+                return DPTArray(knx_value)
         raise ConversionError(f"Value not supported for {cls.__name__}", value=value)
 
 

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
+from .payload import DPTArray
 
 
 class DPTScaling(DPTNumeric):
@@ -40,7 +41,7 @@ class DPTScaling(DPTNumeric):
         return value
 
     @classmethod
-    def to_knx(cls, value: float) -> tuple[int]:
+    def to_knx(cls, value: float) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             percent_value = float(value)
@@ -49,7 +50,7 @@ class DPTScaling(DPTNumeric):
             delta = cls.value_max - cls.value_min
             knx_value = round((percent_value - cls.value_min) / delta * 255)
 
-            return (knx_value,)
+            return DPTArray(knx_value)
         except ValueError:
             raise ConversionError(f"Could not serialize {cls.__name__}", value=value)
 

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 
 class DPTString(DPTBase):
@@ -30,7 +31,7 @@ class DPTString(DPTBase):
         )
 
     @classmethod
-    def to_knx(cls, value: str) -> tuple[int, ...]:
+    def to_knx(cls, value: str) -> DPTArray:
         """Serialize to KNX/IP raw data."""
         try:
             knx_value = str(value)
@@ -41,7 +42,7 @@ class DPTString(DPTBase):
         # replace invalid characters with question marks
         raw_bytes = knx_value.encode(cls._encoding, errors="replace")
         padding = bytes(cls.payload_length - len(raw_bytes))
-        return tuple(raw_bytes + padding)
+        return DPTArray(raw_bytes + padding)
 
     @classmethod
     def _test_boundaries(cls, value: str) -> bool:

--- a/xknx/dpt/dpt_time.py
+++ b/xknx/dpt/dpt_time.py
@@ -6,6 +6,7 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
+from .payload import DPTArray
 
 
 class DPTTime(DPTBase):
@@ -45,7 +46,7 @@ class DPTTime(DPTBase):
             raise ConversionError("Could not parse DPTTime", raw=raw)
 
     @classmethod
-    def to_knx(cls, value: time.struct_time) -> tuple[int, int, int]:
+    def to_knx(cls, value: time.struct_time) -> DPTArray:
         """Serialize to KNX/IP raw data from dict with elements weekday,hours,minutes,seconds."""
         if not isinstance(value, time.struct_time):
             raise ConversionError(
@@ -60,7 +61,13 @@ class DPTTime(DPTBase):
                 weekday = value.tm_wday + 1
                 break
 
-        return (weekday << 5 | value.tm_hour, value.tm_min, value.tm_sec)
+        return DPTArray(
+            (
+                weekday << 5 | value.tm_hour,
+                value.tm_min,
+                value.tm_sec,
+            )
+        )
 
     @staticmethod
     def _test_range(weekday: int, hours: int, minutes: int, seconds: int) -> bool:

--- a/xknx/dpt/payload.py
+++ b/xknx/dpt/payload.py
@@ -1,0 +1,70 @@
+"""Implementation of KNX raw payload abstractions."""
+from __future__ import annotations
+
+from typing import TypeVar, Union
+
+from xknx.exceptions import ConversionError
+
+
+class DPTBinary:
+    """The DPTBinary is a base class for all datatypes encoded directly into the last 6 bit of the APCI/data octet."""
+
+    APCI_BITMASK = 0x3F  # APCI uses first 2 bits
+
+    def __init__(self, value: int | tuple[int]) -> None:
+        """Initialize DPTBinary class."""
+        if isinstance(value, tuple):
+            value = value[0]
+        if not isinstance(value, int):
+            raise TypeError()
+        if not 0 <= value <= DPTBinary.APCI_BITMASK:
+            raise ConversionError("Could not init DPTBinary", value=str(value))
+
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        """Equal operator."""
+        if isinstance(other, DPTBinary):
+            return self.value == other.value
+        return False
+
+    def __repr__(self) -> str:
+        """Return object representation."""
+        return f"DPTBinary({hex(self.value)})"
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return f'<DPTBinary value="{self.value}" />'
+
+
+class DPTArray:
+    """The DPTArray is a base class for all datatypes appended to the KNX telegram."""
+
+    def __init__(self, value: int | bytes | tuple[int, ...] | list[int]) -> None:
+        """Initialize DPTArray class."""
+        self.value: tuple[int, ...]
+        if isinstance(value, int):
+            self.value = (value,)
+        elif isinstance(value, (list, bytes)):
+            self.value = tuple(value)
+        elif isinstance(value, tuple):
+            self.value = value
+        else:
+            raise TypeError()
+
+    def __eq__(self, other: object) -> bool:
+        """Equal operator."""
+        if isinstance(other, DPTArray):
+            return self.value == other.value
+        return False
+
+    def __repr__(self) -> str:
+        """Return object representation."""
+        return f"DPTArray(({', '.join(hex(b) for b in self.value)}))"
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return f'<DPTArray value="[{",".join(hex(b) for b in self.value)}]" />'
+
+
+DPTPayloadT = TypeVar("DPTPayloadT", bound=Union[DPTArray, DPTBinary])

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -13,7 +13,7 @@ from collections.abc import Awaitable, Iterator
 import logging
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar, Union
 
-from xknx.dpt.dpt import DPTArray, DPTBinary
+from xknx.dpt import DPTArray, DPTBinary, DPTPayloadT
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.address import (
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger("xknx.log")
 
 AsyncCallbackType = Callable[[], Awaitable[None]]
-DPTPayloadT = TypeVar("DPTPayloadT", DPTArray, DPTBinary, Union[DPTArray, DPTBinary])
 GroupAddressesType = Union["DeviceAddressableType", list["DeviceAddressableType"]]
 ValueT = TypeVar("ValueT")
 
@@ -61,7 +60,7 @@ class RemoteValue(ABC, Generic[DPTPayloadT, ValueT]):
             if not isinstance(addresses, list):
                 return parse_device_group_address(addresses)
             active, *passive = map(parse_device_group_address, addresses)
-            self.passive_group_addresses.extend(passive)  # type: ignore
+            self.passive_group_addresses.extend(passive)
             return active
 
         self.group_address = unpack_group_addresses(group_address)

--- a/xknx/remote_value/remote_value_1count.py
+++ b/xknx/remote_value/remote_value_1count.py
@@ -22,7 +22,7 @@ class RemoteValue1Count(RemoteValue[DPTArray, int]):
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTValue1Count.to_knx(value))
+        return DPTValue1Count.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> int:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -15,16 +15,12 @@ from xknx.dpt import (
     DPTControllerStatus,
     DPTHVACContrMode,
     DPTHVACMode,
+    DPTPayloadT,
 )
 from xknx.dpt.dpt_hvac_mode import HVACControllerMode, HVACModeT, HVACOperationMode
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
-from .remote_value import (
-    AsyncCallbackType,
-    DPTPayloadT,
-    GroupAddressesType,
-    RemoteValue,
-)
+from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -93,7 +89,7 @@ class RemoteValueOperationMode(RemoteValueClimateModeBase[DPTArray, HVACOperatio
 
     def to_knx(self, value: Any) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(self._climate_mode_transcoder.to_knx(value))
+        return self._climate_mode_transcoder.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> HVACOperationMode | None:
         """Convert current payload to value."""
@@ -138,7 +134,7 @@ class RemoteValueControllerMode(
 
     def to_knx(self, value: Any) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTHVACContrMode.to_knx(value))
+        return DPTHVACContrMode.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> HVACControllerMode | None:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_color_xyy.py
+++ b/xknx/remote_value/remote_value_color_xyy.py
@@ -51,7 +51,7 @@ class RemoteValueColorXYY(RemoteValue[DPTArray, XYYColor]):
 
     def to_knx(self, value: XYYColor) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTColorXYY.to_knx(value))
+        return DPTColorXYY.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> XYYColor:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -58,7 +58,7 @@ class RemoteValueControl(RemoteValue[DPTBinary, Any]):
 
     def to_knx(self, value: Any) -> DPTBinary:
         """Convert value to payload."""
-        return DPTBinary(self.dpt_class.to_knx(value))
+        return self.dpt_class.to_knx(value)
 
     def from_knx(self, payload: DPTBinary) -> Any:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -73,7 +73,7 @@ class RemoteValueDateTime(RemoteValue[DPTArray, time.struct_time]):
 
     def to_knx(self, value: time.struct_time) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(self.dpt_class.to_knx(value))
+        return self.dpt_class.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> time.struct_time:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -48,7 +48,7 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray, int]):
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPT2ByteUnsigned.to_knx(value))
+        return DPT2ByteUnsigned.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> int:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_dpt_value_1_ucount.py
+++ b/xknx/remote_value/remote_value_dpt_value_1_ucount.py
@@ -22,7 +22,7 @@ class RemoteValueDptValue1Ucount(RemoteValue[DPTArray, int]):
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTValue1Ucount.to_knx(value))
+        return DPTValue1Ucount.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> int:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_scene_number.py
+++ b/xknx/remote_value/remote_value_scene_number.py
@@ -22,7 +22,7 @@ class RemoteValueSceneNumber(RemoteValue[DPTArray, int]):
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTSceneNumber.to_knx(value))
+        return DPTSceneNumber.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> int:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -71,7 +71,7 @@ class _RemoteValueGeneric(RemoteValue[DPTArray, ValueT]):
 
     def to_knx(self, value: ValueT) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(self.dpt_class.to_knx(value))
+        return self.dpt_class.to_knx(value)  # type: ignore[return-value]
 
     @abstractmethod
     def from_knx(self, payload: DPTArray) -> ValueT:

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -77,8 +77,8 @@ class RemoteValueSetpointShift(RemoteValue[DPTArray, float]):
             )
         if self.dpt_class == DPTValue1Count:
             converted_value = int(value / self.setpoint_shift_step)
-            return DPTArray(DPTValue1Count.to_knx(converted_value))
-        return DPTArray(DPTTemperature.to_knx(value))
+            return DPTValue1Count.to_knx(converted_value)
+        return DPTTemperature.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> float:
         """Convert current payload to value."""

--- a/xknx/remote_value/remote_value_temp.py
+++ b/xknx/remote_value/remote_value_temp.py
@@ -22,7 +22,7 @@ class RemoteValueTemp(RemoteValue[DPTArray, float]):
 
     def to_knx(self, value: float) -> DPTArray:
         """Convert value to payload."""
-        return DPTArray(DPTTemperature.to_knx(value))
+        return DPTTemperature.to_knx(value)
 
     def from_knx(self, payload: DPTArray) -> float:
         """Convert current payload to value."""

--- a/xknx/tools/group_communication.py
+++ b/xknx/tools/group_communication.py
@@ -110,7 +110,7 @@ def _parse_payload(
     if isinstance(value, (DPTArray, DPTBinary)):
         return value
     if transcoder := _parse_dpt(value_type):
-        return DPTArray(transcoder.to_knx(value))
+        return transcoder.to_knx(value)
     if isinstance(value, int):
         return DPTBinary(value)
     return DPTArray(value)


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Return `DPTArray` or `DPTBinary` from `DPTBase.to_knx()` instead of `tuple[int, ...]`.

Since the DPT definitions have fixed payload types (DPTBinary or DPTArray) they should handle packing the raw values. 
Previously this was done in RemoteValue (with help of Generics, which may be refactored out later) or by manually packing the `tuple[int]` in the appropriate DPT-Payload container.

This is a first step of refactoring DPTBase and RemoteValue to pave the way for more flexible DPT value handling (eg. using dicts / Typeddict) and to separate concerns of DPTBase and RemoteValue classes.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)