### PR TITLE
Accept DPTArray or DPTBinary in DPTBase.from_knx() instead of raw tuple[int]

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -17,6 +17,7 @@ nav_order: 2
 - Refactor DPTBase transcoder classes
   - Accept `DPTArray` or `DPTBinary` in `DPTBase.from_knx()` instead of raw `tuple[int]`.
   - Return `DPTArray` or `DPTBinary` from `DPTBase.to_knx()` instead of `tuple[int, ...]`.
+  - Remove payload_valid() from RemoteValue and remove payload type form its generics parameters.
 
 # 2.7.0 IP Device Management 2023-03-15
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,9 @@ nav_order: 2
 
 ### Internals
 
-- Return `DPTArray` or `DPTBinary` from `DPTBase.to_knx()` instead of `tuple[int, ...]`.
+- Refactor DPTBase transcoder classes
+  - Accept `DPTArray` or `DPTBinary` in `DPTBase.from_knx()` instead of raw `tuple[int]`.
+  - Return `DPTArray` or `DPTBinary` from `DPTBase.to_knx()` instead of `tuple[int, ...]`.
 
 # 2.7.0 IP Device Management 2023-03-15
 

--- a/test/dpt_tests/dpt_1byte_signed_test.py
+++ b/test/dpt_tests/dpt_1byte_signed_test.py
@@ -8,53 +8,24 @@ from xknx.exceptions import ConversionError
 class TestDPTRelativeValue:
     """Test class for KNX DPT Relative Value."""
 
-    def test_from_knx_positive(self):
-        """Test positive value from KNX."""
-        assert DPTSignedRelativeValue.from_knx((0x00,)) == 0
-        assert DPTSignedRelativeValue.from_knx((0x01,)) == 1
-        assert DPTSignedRelativeValue.from_knx((0x02,)) == 2
-        assert DPTSignedRelativeValue.from_knx((0x64,)) == 100
-        assert DPTSignedRelativeValue.from_knx((0x7F,)) == 127
-
-    def test_from_knx_negative(self):
-        """Test negative value from KNX."""
-        assert DPTSignedRelativeValue.from_knx((0x80,)) == -128
-        assert DPTSignedRelativeValue.from_knx((0x9C,)) == -100
-        assert DPTSignedRelativeValue.from_knx((0xFE,)) == -2
-        assert DPTSignedRelativeValue.from_knx((0xFF,)) == -1
-
-    def test_to_knx_positive(self):
-        """Test positive value to KNX."""
-        assert DPTSignedRelativeValue.to_knx(0) == DPTArray(
-            0x00,
-        )
-        assert DPTSignedRelativeValue.to_knx(1) == DPTArray(
-            0x01,
-        )
-        assert DPTSignedRelativeValue.to_knx(2) == DPTArray(
-            0x02,
-        )
-        assert DPTSignedRelativeValue.to_knx(100) == DPTArray(
-            0x64,
-        )
-        assert DPTSignedRelativeValue.to_knx(127) == DPTArray(
-            0x7F,
-        )
-
-    def test_to_knx_negative(self):
-        """Test negative value to KNX."""
-        assert DPTSignedRelativeValue.to_knx(-128) == DPTArray(
-            0x80,
-        )
-        assert DPTSignedRelativeValue.to_knx(-100) == DPTArray(
-            0x9C,
-        )
-        assert DPTSignedRelativeValue.to_knx(-2) == DPTArray(
-            0xFE,
-        )
-        assert DPTSignedRelativeValue.to_knx(-1) == DPTArray(
-            0xFF,
-        )
+    @pytest.mark.parametrize(
+        ("raw", "value"),
+        [
+            ((0x00,), 0),
+            ((0x01,), 1),
+            ((0x02,), 2),
+            ((0x64,), 100),
+            ((0x7F,), 127),
+            ((0x80,), -128),
+            ((0x9C,), -100),
+            ((0xFE,), -2),
+            ((0xFF,), -1),
+        ],
+    )
+    def test_transcoder(self, raw, value):
+        """Test value from and to KNX."""
+        assert DPTSignedRelativeValue.from_knx(DPTArray(raw)) == value
+        assert DPTSignedRelativeValue.to_knx(value) == DPTArray(raw)
 
     def test_assert_min_exceeded(self):
         """Test initialization with wrong value (Underflow)."""

--- a/test/dpt_tests/dpt_1byte_uint_test.py
+++ b/test/dpt_tests/dpt_1byte_uint_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from xknx.dpt import DPTArray, DPTTariff, DPTValue1Ucount
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTValue1Ucount:
@@ -11,17 +11,17 @@ class TestDPTValue1Ucount:
     def test_value_50(self):
         """Test parsing and streaming of DPTValue1Ucount 50."""
         assert DPTValue1Ucount.to_knx(50) == DPTArray(0x32)
-        assert DPTValue1Ucount.from_knx((0x32,)) == 50
+        assert DPTValue1Ucount.from_knx(DPTArray((0x32,))) == 50
 
     def test_value_max(self):
         """Test parsing and streaming of DPTValue1Ucount 255."""
         assert DPTValue1Ucount.to_knx(255) == DPTArray(0xFF)
-        assert DPTValue1Ucount.from_knx((0xFF,)) == 255
+        assert DPTValue1Ucount.from_knx(DPTArray((0xFF,))) == 255
 
     def test_value_min(self):
         """Test parsing and streaming of DPTValue1Ucount 0."""
         assert DPTValue1Ucount.to_knx(0) == DPTArray(0x00)
-        assert DPTValue1Ucount.from_knx((0x00,)) == 0
+        assert DPTValue1Ucount.from_knx(DPTArray((0x00,))) == 0
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTValue1Ucount with wrong value (underflow)."""
@@ -40,17 +40,17 @@ class TestDPTValue1Ucount:
 
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPTValue1Ucount with wrong value (3 byte array)."""
-        with pytest.raises(ConversionError):
-            DPTValue1Ucount.from_knx((0x01, 0x02, 0x03))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTValue1Ucount.from_knx(DPTArray((0x01, 0x02, 0x03)))
 
     def test_from_knx_wrong_value(self):
         """Test parsing of DPTValue1Ucount with value which exceeds limits."""
         with pytest.raises(ConversionError):
-            DPTValue1Ucount.from_knx((0x256,))
+            DPTValue1Ucount.from_knx(DPTArray((0x256,)))
 
     def test_from_knx_wrong_parameter2(self):
         """Test parsing of DPTValue1Ucount with wrong value (array containing string)."""
-        with pytest.raises(ConversionError):
+        with pytest.raises(CouldNotParseTelegram):
             DPTValue1Ucount.from_knx("0x23")
 
 
@@ -60,4 +60,4 @@ class TestDPTTariff:
     def test_from_knx_max_exceeded(self):
         """Test parsing of DPTTariff with wrong value (overflow)."""
         with pytest.raises(ConversionError):
-            DPTTariff.from_knx((0xFF,))
+            DPTTariff.from_knx(DPTArray((0xFF,)))

--- a/test/dpt_tests/dpt_2byte_signed_test.py
+++ b/test/dpt_tests/dpt_2byte_signed_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from xknx.dpt import DPT2ByteSigned, DPTArray
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPT2ByteSigned:
@@ -29,29 +29,29 @@ class TestDPT2ByteSigned:
     def test_signed_value_max_value(self):
         """Test DPT2ByteSigned parsing and streaming."""
         assert DPT2ByteSigned.to_knx(32767) == DPTArray((0x7F, 0xFF))
-        assert DPT2ByteSigned.from_knx((0x7F, 0xFF)) == 32767
+        assert DPT2ByteSigned.from_knx(DPTArray((0x7F, 0xFF))) == 32767
 
     def test_signed_value_min_value(self):
         """Test DPT2ByteSigned parsing and streaming with null values."""
         assert DPT2ByteSigned.to_knx(-20480) == DPTArray((0xB0, 0x00))
-        assert DPT2ByteSigned.from_knx((0xB0, 0x00)) == -20480
+        assert DPT2ByteSigned.from_knx(DPTArray((0xB0, 0x00))) == -20480
 
     def test_signed_value_0123(self):
         """Test DPT2ByteSigned parsing and streaming."""
         assert DPT2ByteSigned.to_knx(291) == DPTArray((0x01, 0x23))
-        assert DPT2ByteSigned.from_knx((0x01, 0x23)) == 291
+        assert DPT2ByteSigned.from_knx(DPTArray((0x01, 0x23))) == 291
 
     def test_signed_wrong_value_from_knx(self):
         """Test DPT2ByteSigned parsing with wrong value."""
-        with pytest.raises(ConversionError):
-            DPT2ByteSigned.from_knx((0xFF, 0x4E, 0x12))
+        with pytest.raises(CouldNotParseTelegram):
+            DPT2ByteSigned.from_knx(DPTArray((0xFF, 0x4E, 0x12)))
 
     def test_from_knx_unpack_error(self):
         """Test DPT2ByteSigned parsing with unpack error."""
         with patch("struct.unpack") as unpack_mock:
             unpack_mock.side_effect = struct.error()
             with pytest.raises(ConversionError):
-                DPT2ByteSigned.from_knx((0x01, 0x23))
+                DPT2ByteSigned.from_knx(DPTArray((0x01, 0x23)))
 
     def test_to_knx_pack_error(self):
         """Test serializing DPT2ByteSigned with pack error."""

--- a/test/dpt_tests/dpt_2byte_uint_test.py
+++ b/test/dpt_tests/dpt_2byte_uint_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from xknx.dpt import DPTArray, DPTUElCurrentmA
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPT2byte:
@@ -31,29 +31,29 @@ class TestDPT2byte:
     def test_current_value_max_value(self):
         """Test DPTUElCurrentmA parsing and streaming."""
         assert DPTUElCurrentmA.to_knx(65535) == DPTArray((0xFF, 0xFF))
-        assert DPTUElCurrentmA.from_knx((0xFF, 0xFF)) == 65535
+        assert DPTUElCurrentmA.from_knx(DPTArray((0xFF, 0xFF))) == 65535
 
     def test_current_value_min_value(self):
         """Test DPTUElCurrentmA parsing and streaming with null values."""
         assert DPTUElCurrentmA.to_knx(0) == DPTArray((0x00, 0x00))
-        assert DPTUElCurrentmA.from_knx((0x00, 0x00)) == 0
+        assert DPTUElCurrentmA.from_knx(DPTArray((0x00, 0x00))) == 0
 
     def test_current_value_38(self):
         """Test DPTUElCurrentmA parsing and streaming 38mA."""
         assert DPTUElCurrentmA.to_knx(38) == DPTArray((0x00, 0x26))
-        assert DPTUElCurrentmA.from_knx((0x00, 0x26)) == 38
+        assert DPTUElCurrentmA.from_knx(DPTArray((0x00, 0x26))) == 38
 
     def test_current_value_78(self):
         """Test DPTUElCurrentmA parsing and streaming 78mA."""
         assert DPTUElCurrentmA.to_knx(78) == DPTArray((0x00, 0x4E))
-        assert DPTUElCurrentmA.from_knx((0x00, 0x4E)) == 78
+        assert DPTUElCurrentmA.from_knx(DPTArray((0x00, 0x4E))) == 78
 
     def test_current_value_1234(self):
         """Test DPTUElCurrentmA parsing and streaming 4660mA."""
         assert DPTUElCurrentmA.to_knx(4660) == DPTArray((0x12, 0x34))
-        assert DPTUElCurrentmA.from_knx((0x12, 0x34)) == 4660
+        assert DPTUElCurrentmA.from_knx(DPTArray((0x12, 0x34))) == 4660
 
     def test_current_wrong_value_from_knx(self):
         """Test DPTUElCurrentmA parsing with wrong value."""
-        with pytest.raises(ConversionError):
-            DPTUElCurrentmA.from_knx((0xFF, 0x4E, 0x12))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTUElCurrentmA.from_knx(DPTArray((0xFF, 0x4E, 0x12)))

--- a/test/dpt_tests/dpt_4byte_int_test.py
+++ b/test/dpt_tests/dpt_4byte_int_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from xknx.dpt import DPT4ByteSigned, DPT4ByteUnsigned, DPTArray
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPT4Byte:
@@ -32,22 +32,24 @@ class TestDPT4Byte:
     def test_unsigned_value_max_value(self):
         """Test DPT4ByteUnsigned parsing and streaming."""
         assert DPT4ByteUnsigned.to_knx(4294967295) == DPTArray((0xFF, 0xFF, 0xFF, 0xFF))
-        assert DPT4ByteUnsigned.from_knx((0xFF, 0xFF, 0xFF, 0xFF)) == 4294967295
+        assert (
+            DPT4ByteUnsigned.from_knx(DPTArray((0xFF, 0xFF, 0xFF, 0xFF))) == 4294967295
+        )
 
     def test_unsigned_value_min_value(self):
         """Test parsing and streaming with null values."""
         assert DPT4ByteUnsigned.to_knx(0) == DPTArray((0x00, 0x00, 0x00, 0x00))
-        assert DPT4ByteUnsigned.from_knx((0x00, 0x00, 0x00, 0x00)) == 0
+        assert DPT4ByteUnsigned.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00))) == 0
 
     def test_unsigned_value_01234567(self):
         """Test DPT4ByteUnsigned parsing and streaming."""
         assert DPT4ByteUnsigned.to_knx(19088743) == DPTArray((0x01, 0x23, 0x45, 0x67))
-        assert DPT4ByteUnsigned.from_knx((0x01, 0x23, 0x45, 0x67)) == 19088743
+        assert DPT4ByteUnsigned.from_knx(DPTArray((0x01, 0x23, 0x45, 0x67))) == 19088743
 
     def test_unsigned_wrong_value_from_knx(self):
         """Test DPT4ByteUnsigned parsing with wrong value."""
-        with pytest.raises(ConversionError):
-            DPT4ByteUnsigned.from_knx((0xFF, 0x4E, 0x12))
+        with pytest.raises(CouldNotParseTelegram):
+            DPT4ByteUnsigned.from_knx(DPTArray((0xFF, 0x4E, 0x12)))
 
     # ####################################################################
     # DPT4ByteSigned
@@ -70,29 +72,31 @@ class TestDPT4Byte:
     def test_signed_value_max_value(self):
         """Test DPT4ByteSigned parsing and streaming."""
         assert DPT4ByteSigned.to_knx(2147483647) == DPTArray((0x7F, 0xFF, 0xFF, 0xFF))
-        assert DPT4ByteSigned.from_knx((0x7F, 0xFF, 0xFF, 0xFF)) == 2147483647
+        assert DPT4ByteSigned.from_knx(DPTArray((0x7F, 0xFF, 0xFF, 0xFF))) == 2147483647
 
     def test_signed_value_min_value(self):
         """Test DPT4ByteSigned parsing and streaming with null values."""
         assert DPT4ByteSigned.to_knx(-2147483648) == DPTArray((0x80, 0x00, 0x00, 0x00))
-        assert DPT4ByteSigned.from_knx((0x80, 0x00, 0x00, 0x00)) == -2147483648
+        assert (
+            DPT4ByteSigned.from_knx(DPTArray((0x80, 0x00, 0x00, 0x00))) == -2147483648
+        )
 
     def test_signed_value_01234567(self):
         """Test DPT4ByteSigned parsing and streaming."""
         assert DPT4ByteSigned.to_knx(19088743) == DPTArray((0x01, 0x23, 0x45, 0x67))
-        assert DPT4ByteSigned.from_knx((0x01, 0x23, 0x45, 0x67)) == 19088743
+        assert DPT4ByteSigned.from_knx(DPTArray((0x01, 0x23, 0x45, 0x67))) == 19088743
 
     def test_signed_wrong_value_from_knx(self):
         """Test DPT4ByteSigned parsing with wrong value."""
-        with pytest.raises(ConversionError):
-            DPT4ByteSigned.from_knx((0xFF, 0x4E, 0x12))
+        with pytest.raises(CouldNotParseTelegram):
+            DPT4ByteSigned.from_knx(DPTArray((0xFF, 0x4E, 0x12)))
 
     def test_from_knx_unpack_error(self):
         """Test DPT4ByteSigned parsing with unpack error."""
         with patch("struct.unpack") as unpack_mock:
             unpack_mock.side_effect = struct.error()
             with pytest.raises(ConversionError):
-                DPT4ByteSigned.from_knx((0x01, 0x23, 0x45, 0x67))
+                DPT4ByteSigned.from_knx(DPTArray((0x01, 0x23, 0x45, 0x67)))
 
     def test_to_knx_pack_error(self):
         """Test serializing DPT4ByteSigned with pack error."""

--- a/test/dpt_tests/dpt_color_test.py
+++ b/test/dpt_tests/dpt_color_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from xknx.dpt.dpt_color import DPTArray, DPTColorXYY, XYYColor
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTColorXYY:
@@ -27,7 +27,7 @@ class TestDPTColorXYY:
         assert DPTColorXYY.to_knx(((1, 1), 255)) == DPTArray(
             (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)
         )
-        assert DPTColorXYY.from_knx((0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)) == (
+        assert DPTColorXYY.from_knx(DPTArray((0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03))) == (
             (1, 1),
             255,
         )
@@ -37,19 +37,25 @@ class TestDPTColorXYY:
         assert DPTColorXYY.to_knx(((0, 0), 0)) == DPTArray(
             (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)
         )
-        assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x03)) == ((0, 0), 0)
+        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x03))) == (
+            (0, 0),
+            0,
+        )
 
     def test_xyycolor_value_none_value(self):
         """Test DPTColorXYY parsing and streaming with null values."""
         assert DPTColorXYY.to_knx((None, 0)) == DPTArray(
             (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
         )
-        assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x01)) == (None, 0)
+        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x01))) == (
+            None,
+            0,
+        )
 
         assert DPTColorXYY.to_knx(((0, 0), None)) == DPTArray(
             (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)
         )
-        assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x02)) == (
+        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x02))) == (
             (0, 0),
             None,
         )
@@ -57,7 +63,7 @@ class TestDPTColorXYY:
         assert DPTColorXYY.to_knx((None, None)) == DPTArray(
             (0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
         )
-        assert DPTColorXYY.from_knx((0x00, 0x00, 0x00, 0x00, 0x00, 0x00)) == (
+        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x00))) == (
             None,
             None,
         )
@@ -67,16 +73,16 @@ class TestDPTColorXYY:
         assert DPTColorXYY.to_knx(((0.2, 0.2), 128)) == DPTArray(
             (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)
         )
-        assert DPTColorXYY.from_knx((0x33, 0x33, 0x33, 0x33, 0x80, 0x03)) == (
+        assert DPTColorXYY.from_knx(DPTArray((0x33, 0x33, 0x33, 0x33, 0x80, 0x03))) == (
             (0.2, 0.2),
             128,
         )
         assert DPTColorXYY.to_knx(
             XYYColor(color=(0.8, 0.8), brightness=204)
         ) == DPTArray((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03))
-        assert DPTColorXYY.from_knx((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03)) == XYYColor(
-            color=(0.8, 0.8), brightness=204
-        )
+        assert DPTColorXYY.from_knx(
+            DPTArray((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03))
+        ) == XYYColor(color=(0.8, 0.8), brightness=204)
 
     def test_xyycolor_wrong_value_to_knx(self):
         """Test DPTColorXYY parsing with wrong value."""
@@ -91,5 +97,5 @@ class TestDPTColorXYY:
 
     def test_xyycolor_wrong_value_from_knx(self):
         """Test DPTColorXYY parsing with wrong value."""
-        with pytest.raises(ConversionError):
-            DPTColorXYY.from_knx((0xFF, 0x4E, 0x12))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTColorXYY.from_knx(DPTArray((0xFF, 0x4E, 0x12)))

--- a/test/dpt_tests/dpt_date_test.py
+++ b/test/dpt_tests/dpt_date_test.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from xknx.dpt import DPTArray, DPTDate
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTDate:
@@ -12,19 +12,19 @@ class TestDPTDate:
 
     def test_from_knx(self):
         """Test parsing of DPTDate object from binary values. Example 1."""
-        assert DPTDate.from_knx((0x04, 0x01, 0x02)) == time.strptime(
+        assert DPTDate.from_knx(DPTArray((0x04, 0x01, 0x02))) == time.strptime(
             "2002-01-04", "%Y-%m-%d"
         )
 
     def test_from_knx_old_date(self):
         """Test parsing of DPTDate object from binary values. Example 2."""
-        assert DPTDate.from_knx((0x1F, 0x01, 0x5A)) == time.strptime(
+        assert DPTDate.from_knx(DPTArray((0x1F, 0x01, 0x5A))) == time.strptime(
             "1990-01-31", "%Y-%m-%d"
         )
 
     def test_from_knx_future_date(self):
         """Test parsing of DPTDate object from binary values. Example 3."""
-        assert DPTDate.from_knx((0x04, 0x0C, 0x59)) == time.strptime(
+        assert DPTDate.from_knx(DPTArray((0x04, 0x0C, 0x59))) == time.strptime(
             "2089-12-4", "%Y-%m-%d"
         )
 
@@ -45,8 +45,8 @@ class TestDPTDate:
 
     def test_from_knx_wrong_parameter(self):
         """Test parsing from DPTDate object from wrong binary values."""
-        with pytest.raises(ConversionError):
-            DPTDate.from_knx((0xF8, 0x23))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTDate.from_knx(DPTArray((0xF8, 0x23)))
 
     def test_to_knx_wrong_parameter(self):
         """Test parsing from DPTDate object from wrong string value."""
@@ -56,9 +56,9 @@ class TestDPTDate:
     def test_from_knx_wrong_range_month(self):
         """Test Exception when parsing DPTDAte from KNX with wrong month."""
         with pytest.raises(ConversionError):
-            DPTDate.from_knx((0x04, 0x00, 0x59))
+            DPTDate.from_knx(DPTArray((0x04, 0x00, 0x59)))
 
     def test_from_knx_wrong_range_year(self):
         """Test Exception when parsing DPTDate from KNX with wrong year."""
         with pytest.raises(ConversionError):
-            DPTDate.from_knx((0x04, 0x01, 0x64))
+            DPTDate.from_knx(DPTArray((0x04, 0x01, 0x64)))

--- a/test/dpt_tests/dpt_datetime_test.py
+++ b/test/dpt_tests/dpt_datetime_test.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from xknx.dpt import DPTArray, DPTDateTime
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTDateTime:
@@ -16,7 +16,7 @@ class TestDPTDateTime:
     def test_from_knx(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         assert DPTDateTime.from_knx(
-            (0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x20, 0x80)
+            DPTArray((0x75, 0x0B, 0x1C, 0x17, 0x07, 0x18, 0x20, 0x80))
         ) == time.strptime("2017-11-28 23:7:24", "%Y-%m-%d %H:%M:%S")
 
     def test_to_knx(self):
@@ -32,7 +32,7 @@ class TestDPTDateTime:
     def test_from_knx_date_in_past(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         assert DPTDateTime.from_knx(
-            (0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00)
+            DPTArray((0x00, 0x1, 0x1, 0x20, 0x00, 0x00, 0x00, 0x00))
         ) == time.strptime("1900 1 1 0 0 0", "%Y %m %d %H %M %S")
 
     def test_to_knx_date_in_past(self):
@@ -48,7 +48,7 @@ class TestDPTDateTime:
     def test_from_knx_date_in_future(self):
         """Test parsing of DPTDateTime object from binary values. Example 1."""
         assert DPTDateTime.from_knx(
-            (0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80)
+            DPTArray((0xFF, 0x0C, 0x1F, 0xF7, 0x3B, 0x3B, 0x20, 0x80))
         ) == time.strptime("2155-12-31 0 23:59:59", "%Y-%m-%d %w %H:%M:%S")
 
     def test_to_knx_date_in_future(self):
@@ -63,14 +63,16 @@ class TestDPTDateTime:
     #
     def test_from_knx_wrong_size(self):
         """Test parsing DPTDateTime from KNX with wrong binary values (wrong size)."""
-        with pytest.raises(ConversionError):
-            DPTDateTime.from_knx((0xF8, 0x23))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTDateTime.from_knx(DPTArray((0xF8, 0x23)))
 
     def test_from_knx_wrong_bytes(self):
         """Test parsing DPTDateTime from KNX with wrong binary values (wrong bytes)."""
         with pytest.raises(ConversionError):
             # (second byte exceeds value...)
-            DPTDateTime.from_knx((0xFF, 0x0D, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00))
+            DPTDateTime.from_knx(
+                DPTArray((0xFF, 0x0D, 0x1F, 0xF7, 0x3B, 0x3B, 0x00, 0x00))
+            )
 
     #
     # TEST WRONG PARAMETER

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -22,7 +22,7 @@ from xknx.dpt import (
     DPTTemperature,
     DPTVoltage,
 )
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTFloat:
@@ -34,35 +34,39 @@ class TestDPTFloat:
     def test_value_from_documentation(self):
         """Test parsing and streaming of DPT2ByteFloat -30.00. Example from the internet[tm]."""
         assert DPT2ByteFloat.to_knx(-30.00) == DPTArray((0x8A, 0x24))
-        assert DPT2ByteFloat.from_knx((0x8A, 0x24)) == -30.00
+        assert DPT2ByteFloat.from_knx(DPTArray((0x8A, 0x24))) == -30.00
 
     def test_value_taken_from_live_thermostat(self):
         """Test parsing and streaming of DPT2ByteFloat 19.96."""
         assert DPT2ByteFloat.to_knx(16.96) == DPTArray((0x06, 0xA0))
-        assert DPT2ByteFloat.from_knx((0x06, 0xA0)) == 16.96
+        assert DPT2ByteFloat.from_knx(DPTArray((0x06, 0xA0))) == 16.96
 
     def test_zero_value(self):
         """Test parsing and streaming of DPT2ByteFloat zero value."""
         assert DPT2ByteFloat.to_knx(0.00) == DPTArray((0x00, 0x00))
-        assert DPT2ByteFloat.from_knx((0x00, 0x00)) == 0.00
+        assert DPT2ByteFloat.from_knx(DPTArray((0x00, 0x00))) == 0.00
 
     def test_room_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 21.00. Room temperature."""
         assert DPT2ByteFloat.to_knx(21.00) == DPTArray((0x0C, 0x1A))
-        assert DPT2ByteFloat.from_knx((0x0C, 0x1A)) == 21.00
+        assert DPT2ByteFloat.from_knx(DPTArray((0x0C, 0x1A))) == 21.00
 
     def test_high_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 500.00, 499.84, 500.16. Testing rounding issues."""
         assert DPT2ByteFloat.to_knx(500.00) == DPTArray((0x2E, 0x1A))
-        assert round(abs(DPT2ByteFloat.from_knx((0x2E, 0x1A)) - 499.84), 7) == 0
-        assert round(abs(DPT2ByteFloat.from_knx((0x2E, 0x1B)) - 500.16), 7) == 0
+        assert (
+            round(abs(DPT2ByteFloat.from_knx(DPTArray((0x2E, 0x1A))) - 499.84), 7) == 0
+        )
+        assert (
+            round(abs(DPT2ByteFloat.from_knx(DPTArray((0x2E, 0x1B))) - 500.16), 7) == 0
+        )
         assert DPT2ByteFloat.to_knx(499.84) == DPTArray((0x2E, 0x1A))
         assert DPT2ByteFloat.to_knx(500.16) == DPTArray((0x2E, 0x1B))
 
     def test_minor_negative_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat -10.00. Testing negative values."""
         assert DPT2ByteFloat.to_knx(-10.00) == DPTArray((0x84, 0x18))
-        assert DPT2ByteFloat.from_knx((0x84, 0x18)) == -10.00
+        assert DPT2ByteFloat.from_knx(DPTArray((0x84, 0x18))) == -10.00
 
     def test_very_cold_temperature(self):
         """
@@ -71,37 +75,37 @@ class TestDPTFloat:
         Testing rounding issues of negative values.
         """
         assert DPT2ByteFloat.to_knx(-1000.00) == DPTArray((0xB1, 0xE6))
-        assert DPT2ByteFloat.from_knx((0xB1, 0xE6)) == -999.68
-        assert DPT2ByteFloat.from_knx((0xB1, 0xE5)) == -1000.32
+        assert DPT2ByteFloat.from_knx(DPTArray((0xB1, 0xE6))) == -999.68
+        assert DPT2ByteFloat.from_knx(DPTArray((0xB1, 0xE5))) == -1000.32
         assert DPT2ByteFloat.to_knx(-999.68) == DPTArray((0xB1, 0xE6))
         assert DPT2ByteFloat.to_knx(-1000.32) == DPTArray((0xB1, 0xE5))
 
     def test_max(self):
         """Test parsing and streaming of DPT2ByteFloat with maximum value."""
         assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_max) == DPTArray((0x7F, 0xFF))
-        assert DPT2ByteFloat.from_knx((0x7F, 0xFF)) == DPT2ByteFloat.value_max
+        assert DPT2ByteFloat.from_knx(DPTArray((0x7F, 0xFF))) == DPT2ByteFloat.value_max
 
     def test_close_to_limit(self):
         """Test parsing and streaming of DPT2ByteFloat with numeric limit."""
         assert DPT2ByteFloat.to_knx(20.48) == DPTArray((0x0C, 0x00))
-        assert DPT2ByteFloat.from_knx((0x0C, 0x00)) == 20.48
+        assert DPT2ByteFloat.from_knx(DPTArray((0x0C, 0x00))) == 20.48
         assert DPT2ByteFloat.to_knx(-20.48) == DPTArray((0x80, 0x00))
-        assert DPT2ByteFloat.from_knx((0x80, 0x00)) == -20.48
+        assert DPT2ByteFloat.from_knx(DPTArray((0x80, 0x00))) == -20.48
 
     def test_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value."""
         assert DPT2ByteFloat.to_knx(DPT2ByteFloat.value_min) == DPTArray((0xF8, 0x00))
-        assert DPT2ByteFloat.from_knx((0xF8, 0x00)) == DPT2ByteFloat.value_min
+        assert DPT2ByteFloat.from_knx(DPTArray((0xF8, 0x00))) == DPT2ByteFloat.value_min
 
     def test_close_to_max(self):
         """Test parsing and streaming of DPT2ByteFloat with maximum value -1."""
         assert DPT2ByteFloat.to_knx(670433.28) == DPTArray((0x7F, 0xFE))
-        assert DPT2ByteFloat.from_knx((0x7F, 0xFE)) == 670433.28
+        assert DPT2ByteFloat.from_knx(DPTArray((0x7F, 0xFE))) == 670433.28
 
     def test_close_to_min(self):
         """Test parsing and streaming of DPT2ByteFloat with minimum value +1."""
         assert DPT2ByteFloat.to_knx(-670760.96) == DPTArray((0xF8, 0x01))
-        assert DPT2ByteFloat.from_knx((0xF8, 0x01)) == -670760.96
+        assert DPT2ByteFloat.from_knx(DPTArray((0xF8, 0x01))) == -670760.96
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPT2ByteFloat with wrong value (underflow)."""
@@ -120,13 +124,8 @@ class TestDPTFloat:
 
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPT2ByteFloat with wrong value (wrong number of bytes)."""
-        with pytest.raises(ConversionError):
-            DPT2ByteFloat.from_knx((0xF8, 0x01, 0x23))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPT2ByteFloat with wrong value (second parameter is a string)."""
-        with pytest.raises(ConversionError):
-            DPT2ByteFloat.from_knx((0xF8, "0x23"))
+        with pytest.raises(CouldNotParseTelegram):
+            DPT2ByteFloat.from_knx(DPTArray((0xF8, 0x01, 0x23)))
 
     #
     # DPTTemperature
@@ -146,7 +145,7 @@ class TestDPTFloat:
     def test_temperature_assert_min_exceeded_from_knx(self):
         """Testing parsing of DPTTemperature with wrong value."""
         with pytest.raises(ConversionError):
-            DPTTemperature.from_knx((0xB1, 0xE6))  # -1000
+            DPTTemperature.from_knx(DPTArray((0xB1, 0xE6)))  # -1000
 
     #
     # DPTLux
@@ -211,9 +210,9 @@ class TestDPTFloat:
     #
     def test_4byte_float_values_from_power_meter(self):
         """Test parsing DPT4ByteFloat value from power meter."""
-        assert DPT4ByteFloat.from_knx((0x43, 0xC6, 0x80, 00)) == 397
+        assert DPT4ByteFloat.from_knx(DPTArray((0x43, 0xC6, 0x80, 00))) == 397
         assert DPT4ByteFloat.to_knx(397) == DPTArray((0x43, 0xC6, 0x80, 00))
-        assert DPT4ByteFloat.from_knx((0x42, 0x38, 0x00, 00)) == 46
+        assert DPT4ByteFloat.from_knx(DPTArray((0x42, 0x38, 0x00, 00))) == 46
         assert DPT4ByteFloat.to_knx(46) == DPTArray((0x42, 0x38, 0x00, 00))
 
     def test_14_033(self):
@@ -222,13 +221,13 @@ class TestDPTFloat:
 
     def test_14_055(self):
         """Test DPTPhaseAngleDeg object."""
-        assert DPT4ByteFloat.from_knx((0x42, 0xEF, 0x00, 0x00)) == 119.5
+        assert DPT4ByteFloat.from_knx(DPTArray((0x42, 0xEF, 0x00, 0x00))) == 119.5
         assert DPT4ByteFloat.to_knx(119.5) == DPTArray((0x42, 0xEF, 0x00, 0x00))
         assert DPTPhaseAngleDeg.unit == "°"
 
     def test_14_057(self):
         """Test DPT4ByteFloat object."""
-        assert DPT4ByteFloat.from_knx((0x3F, 0x71, 0xEB, 0x86)) == 0.9450001
+        assert DPT4ByteFloat.from_knx(DPTArray((0x3F, 0x71, 0xEB, 0x86))) == 0.9450001
         assert DPT4ByteFloat.to_knx(0.945000052452) == DPTArray(
             (0x3F, 0x71, 0xEB, 0x86)
         )
@@ -236,26 +235,28 @@ class TestDPTFloat:
 
     def test_4byte_float_values_from_voltage_meter(self):
         """Test parsing DPT4ByteFloat from voltage meter."""
-        assert DPT4ByteFloat.from_knx((0x43, 0x65, 0xE3, 0xD7)) == 229.89
+        assert DPT4ByteFloat.from_knx(DPTArray((0x43, 0x65, 0xE3, 0xD7))) == 229.89
         assert DPT4ByteFloat.to_knx(229.89) == DPTArray((0x43, 0x65, 0xE3, 0xD7))
 
     def test_4byte_float_zero_value(self):
         """Test parsing and streaming of DPT4ByteFloat zero value."""
-        assert DPT4ByteFloat.from_knx((0x00, 0x00, 0x00, 0x00)) == 0.00
+        assert DPT4ByteFloat.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00))) == 0.00
         assert DPT4ByteFloat.to_knx(0.00) == DPTArray((0x00, 0x00, 0x00, 0x00))
 
     def test_4byte_float_special_value(self):
         """Test parsing and streaming of DPT4ByteFloat special value."""
-        assert math.isnan(DPT4ByteFloat.from_knx((0x7F, 0xC0, 0x00, 0x00)))
+        assert math.isnan(DPT4ByteFloat.from_knx(DPTArray((0x7F, 0xC0, 0x00, 0x00))))
         assert DPT4ByteFloat.to_knx(float("nan")) == DPTArray((0x7F, 0xC0, 0x00, 0x00))
 
-        assert math.isinf(DPT4ByteFloat.from_knx((0x7F, 0x80, 0x00, 0x00)))
+        assert math.isinf(DPT4ByteFloat.from_knx(DPTArray((0x7F, 0x80, 0x00, 0x00))))
         assert DPT4ByteFloat.to_knx(float("inf")) == DPTArray((0x7F, 0x80, 0x00, 0x00))
 
-        assert DPT4ByteFloat.from_knx((0xFF, 0x80, 0x00, 0x00)) == float("-inf")
+        assert DPT4ByteFloat.from_knx(DPTArray((0xFF, 0x80, 0x00, 0x00))) == float(
+            "-inf"
+        )
         assert DPT4ByteFloat.to_knx(float("-inf")) == DPTArray((0xFF, 0x80, 0x00, 0x00))
 
-        assert DPT4ByteFloat.from_knx((0x80, 0x00, 0x00, 0x00)) == float("-0")
+        assert DPT4ByteFloat.from_knx(DPTArray((0x80, 0x00, 0x00, 0x00))) == float("-0")
         assert DPT4ByteFloat.to_knx(float("-0")) == DPTArray((0x80, 0x00, 0x00, 0x00))
 
     def test_4byte_float_to_knx_wrong_parameter(self):
@@ -265,20 +266,15 @@ class TestDPTFloat:
 
     def test_4byte_float_from_knx_wrong_parameter(self):
         """Test parsing of DPT4ByteFloat with wrong value (wrong number of bytes)."""
-        with pytest.raises(ConversionError):
-            DPT4ByteFloat.from_knx((0xF8, 0x01, 0x23))
-
-    def test_4byte_float_from_knx_wrong_parameter2(self):
-        """Test parsing of DPT4ByteFloat with wrong value (second parameter is a string)."""
-        with pytest.raises(ConversionError):
-            DPT4ByteFloat.from_knx((0xF8, "0x23", 0x00, 0x00))
+        with pytest.raises(CouldNotParseTelegram):
+            DPT4ByteFloat.from_knx(DPTArray((0xF8, 0x01, 0x23)))
 
     def test_4byte_flaot_from_knx_unpack_error(self):
         """Test DPT4ByteFloat parsing with unpack error."""
         with patch("struct.unpack") as unpack_mock:
             unpack_mock.side_effect = struct.error()
             with pytest.raises(ConversionError):
-                DPT4ByteFloat.from_knx((0x01, 0x23, 0x02, 0x02))
+                DPT4ByteFloat.from_knx(DPTArray((0x01, 0x23, 0x02, 0x02)))
 
     #
     # DPTElectricCurrent

--- a/test/dpt_tests/dpt_hvac_mode_test.py
+++ b/test/dpt_tests/dpt_hvac_mode_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from xknx.dpt import DPTArray, DPTControllerStatus, DPTHVACMode
 from xknx.dpt.dpt_hvac_mode import HVACOperationMode
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTControllerStatus:
@@ -26,11 +26,14 @@ class TestDPTControllerStatus:
 
     def test_mode_from_knx(self):
         """Test parsing DPTHVACMode from KNX."""
-        assert DPTHVACMode.from_knx((0x00,)) == HVACOperationMode.AUTO
-        assert DPTHVACMode.from_knx((0x01,)) == HVACOperationMode.COMFORT
-        assert DPTHVACMode.from_knx((0x02,)) == HVACOperationMode.STANDBY
-        assert DPTHVACMode.from_knx((0x03,)) == HVACOperationMode.NIGHT
-        assert DPTHVACMode.from_knx((0x04,)) == HVACOperationMode.FROST_PROTECTION
+        assert DPTHVACMode.from_knx(DPTArray((0x00,))) == HVACOperationMode.AUTO
+        assert DPTHVACMode.from_knx(DPTArray((0x01,))) == HVACOperationMode.COMFORT
+        assert DPTHVACMode.from_knx(DPTArray((0x02,))) == HVACOperationMode.STANDBY
+        assert DPTHVACMode.from_knx(DPTArray((0x03,))) == HVACOperationMode.NIGHT
+        assert (
+            DPTHVACMode.from_knx(DPTArray((0x04,)))
+            == HVACOperationMode.FROST_PROTECTION
+        )
 
     def test_controller_status_to_knx(self):
         """Test serializing DPTControllerStatus to KNX."""
@@ -54,38 +57,52 @@ class TestDPTControllerStatus:
 
     def test_controller_status_from_knx(self):
         """Test parsing DPTControllerStatus from KNX."""
-        assert DPTControllerStatus.from_knx((0x21,)) == HVACOperationMode.COMFORT
-        assert DPTControllerStatus.from_knx((0x22,)) == HVACOperationMode.STANDBY
-        assert DPTControllerStatus.from_knx((0x24,)) == HVACOperationMode.NIGHT
         assert (
-            DPTControllerStatus.from_knx((0x28,)) == HVACOperationMode.FROST_PROTECTION
+            DPTControllerStatus.from_knx(DPTArray((0x21,))) == HVACOperationMode.COMFORT
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x22,))) == HVACOperationMode.STANDBY
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x24,))) == HVACOperationMode.NIGHT
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x28,)))
+            == HVACOperationMode.FROST_PROTECTION
         )
 
     def test_controller_status_from_knx_other_bits_set(self):
         """Test parsing DPTControllerStatus from KNX."""
-        assert DPTControllerStatus.from_knx((0x21,)) == HVACOperationMode.COMFORT
-        assert DPTControllerStatus.from_knx((0x23,)) == HVACOperationMode.STANDBY
-        assert DPTControllerStatus.from_knx((0x27,)) == HVACOperationMode.NIGHT
         assert (
-            DPTControllerStatus.from_knx((0x2F,)) == HVACOperationMode.FROST_PROTECTION
+            DPTControllerStatus.from_knx(DPTArray((0x21,))) == HVACOperationMode.COMFORT
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x23,))) == HVACOperationMode.STANDBY
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x27,))) == HVACOperationMode.NIGHT
+        )
+        assert (
+            DPTControllerStatus.from_knx(DPTArray((0x2F,)))
+            == HVACOperationMode.FROST_PROTECTION
         )
 
     def test_mode_from_knx_wrong_value(self):
         """Test parsing of DPTControllerStatus with wrong value)."""
-        with pytest.raises(ConversionError):
-            DPTHVACMode.from_knx((1, 2))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTHVACMode.from_knx(DPTArray((1, 2)))
 
     def test_mode_from_knx_wrong_code(self):
         """Test parsing of DPTHVACMode with wrong code."""
         with pytest.raises(ConversionError):
-            DPTHVACMode.from_knx((0x05,))
+            DPTHVACMode.from_knx(DPTArray((0x05,)))
 
     def test_controller_status_from_knx_wrong_value(self):
         """Test parsing of DPTControllerStatus with wrong value)."""
-        with pytest.raises(ConversionError):
-            DPTControllerStatus.from_knx((1, 2))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTControllerStatus.from_knx(DPTArray((1, 2)))
 
     def test_controller_status_from_knx_wrong_code(self):
         """Test parsing of DPTControllerStatus with wrong code."""
         with pytest.raises(ConversionError):
-            DPTControllerStatus.from_knx((0x00,))
+            DPTControllerStatus.from_knx(DPTArray((0x00,)))

--- a/test/dpt_tests/dpt_scaling_test.py
+++ b/test/dpt_tests/dpt_scaling_test.py
@@ -2,31 +2,25 @@
 import pytest
 
 from xknx.dpt import DPTAngle, DPTArray, DPTScaling
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTScaling:
     """Test class for KNX scaling value."""
 
-    def test_value_30_pct(self):
-        """Test parsing and streaming of DPTScaling 30%."""
-        assert DPTScaling.to_knx(30) == DPTArray((0x4C,))
-        assert DPTScaling.from_knx((0x4C,)) == 30
-
-    def test_value_99_pct(self):
-        """Test parsing and streaming of DPTScaling 99%."""
-        assert DPTScaling.to_knx(99) == DPTArray((0xFC,))
-        assert DPTScaling.from_knx((0xFC,)) == 99
-
-    def test_value_max(self):
-        """Test parsing and streaming of DPTScaling 100%."""
-        assert DPTScaling.to_knx(100) == DPTArray((0xFF,))
-        assert DPTScaling.from_knx((0xFF,)) == 100
-
-    def test_value_min(self):
-        """Test parsing and streaming of DPTScaling 0."""
-        assert DPTScaling.to_knx(0) == DPTArray((0x00,))
-        assert DPTScaling.from_knx((0x00,)) == 0
+    @pytest.mark.parametrize(
+        ("raw", "value"),
+        [
+            ((0x4C,), 30),
+            ((0xFC,), 99),
+            ((0xFF,), 100),
+            ((0x00,), 0),
+        ],
+    )
+    def test_transcoder(self, raw, value):
+        """Test parsing and streaming of DPTScaling."""
+        assert DPTScaling.to_knx(value) == DPTArray(raw)
+        assert DPTScaling.from_knx(DPTArray(raw)) == value
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTScaling with wrong value (underflow)."""
@@ -45,42 +39,31 @@ class TestDPTScaling:
 
     def test_from_knx_wrong_parameter(self):
         """Test parsing of DPTScaling with wrong value (3 byte array)."""
-        with pytest.raises(ConversionError):
-            DPTScaling.from_knx((0x01, 0x02, 0x03))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTScaling.from_knx(DPTArray((0x01, 0x02, 0x03)))
 
     def test_from_knx_wrong_value(self):
         """Test parsing of DPTScaling with value which exceeds limits."""
         with pytest.raises(ConversionError):
-            DPTScaling.from_knx((0x256,))
-
-    def test_from_knx_wrong_parameter2(self):
-        """Test parsing of DPTScaling with wrong value (array containing string)."""
-        with pytest.raises(ConversionError):
-            DPTScaling.from_knx("0x23")
+            DPTScaling.from_knx(DPTArray((0x256,)))
 
 
 class TestDPTAngle:
     """Test class for KNX scaling value."""
 
-    def test_value_30_deg(self):
-        """Test parsing and streaming of DPTAngle 30°."""
-        assert DPTAngle.to_knx(30) == DPTArray((0x15,))
-        assert DPTAngle.from_knx((0x15,)) == 30
-
-    def test_value_270_deg(self):
-        """Test parsing and streaming of DPTAngle 270°."""
-        assert DPTAngle.to_knx(270) == DPTArray((0xBF,))
-        assert DPTAngle.from_knx((0xBF,)) == 270
-
-    def test_value_max(self):
-        """Test parsing and streaming of DPTAngle 360°."""
-        assert DPTAngle.to_knx(360) == DPTArray((0xFF,))
-        assert DPTAngle.from_knx((0xFF,)) == 360
-
-    def test_value_min(self):
-        """Test parsing and streaming of DPTAngle 0°."""
-        assert DPTAngle.to_knx(0) == DPTArray((0x00,))
-        assert DPTAngle.from_knx((0x00,)) == 0
+    @pytest.mark.parametrize(
+        ("raw", "value"),
+        [
+            ((0x15,), 30),
+            ((0xBF,), 270),
+            ((0xFF,), 360),
+            ((0x00,), 0),
+        ],
+    )
+    def test_transcoder(self, raw, value):
+        """Test parsing and streaming of DPTAngle."""
+        assert DPTAngle.to_knx(value) == DPTArray(raw)
+        assert DPTAngle.from_knx(DPTArray(raw)) == value
 
     def test_to_knx_min_exceeded(self):
         """Test parsing of DPTAngle with wrong value (underflow)."""

--- a/test/dpt_tests/dpt_string_test.py
+++ b/test/dpt_tests/dpt_string_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from xknx.dpt import DPTArray, DPTLatin1, DPTString
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTString:
@@ -33,7 +33,7 @@ class TestDPTString:
     def test_values(self, string, raw, test_dpt):
         """Test parsing and streaming strings."""
         assert test_dpt.to_knx(string) == DPTArray(raw)
-        assert test_dpt.from_knx(raw) == string
+        assert test_dpt.from_knx(DPTArray(raw)) == string
 
     @pytest.mark.parametrize(
         "string,knx_string,raw",
@@ -53,7 +53,7 @@ class TestDPTString:
     def test_to_knx_ascii_invalid_chars(self, string, knx_string, raw):
         """Test streaming ASCII string with invalid chars."""
         assert DPTString.to_knx(string) == DPTArray(raw)
-        assert DPTString.from_knx(raw) == knx_string
+        assert DPTString.from_knx(DPTArray(raw)) == knx_string
 
     @pytest.mark.parametrize(
         "string,raw",
@@ -71,7 +71,7 @@ class TestDPTString:
     def test_to_knx_latin_1(self, string, raw):
         """Test streaming Latin-1 strings."""
         assert DPTLatin1.to_knx(string) == DPTArray(raw)
-        assert DPTLatin1.from_knx(raw) == string
+        assert DPTLatin1.from_knx(DPTArray(raw)) == string
 
     def test_to_knx_too_long(self):
         """Test serializing DPTString to KNX with wrong value (to long)."""
@@ -87,8 +87,8 @@ class TestDPTString:
     )
     def test_from_knx_wrong_parameter_length(self, raw):
         """Test parsing of KNX string with wrong elements length."""
-        with pytest.raises(ConversionError):
-            DPTString.from_knx(raw)
+        with pytest.raises(CouldNotParseTelegram):
+            DPTString.from_knx(DPTArray(raw))
 
     def test_no_unit_of_measurement(self):
         """Test for no unit set for DPT 16"""

--- a/test/dpt_tests/dpt_time_test.py
+++ b/test/dpt_tests/dpt_time_test.py
@@ -4,7 +4,7 @@ import time
 import pytest
 
 from xknx.dpt import DPTArray, DPTTime
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
 class TestDPTTime:
@@ -15,7 +15,7 @@ class TestDPTTime:
     #
     def test_from_knx(self):
         """Test parsing of DPTTime object from binary values. Example 1."""
-        assert DPTTime.from_knx((0x4D, 0x17, 0x2A)) == time.strptime(
+        assert DPTTime.from_knx(DPTArray((0x4D, 0x17, 0x2A))) == time.strptime(
             "13 23 42 2", "%H %M %S %w"
         )
 
@@ -34,7 +34,7 @@ class TestDPTTime:
 
     def test_from_knx_max(self):
         """Test parsing of DPTTime object from binary values. Example 2."""
-        assert DPTTime.from_knx((0xF7, 0x3B, 0x3B)) == time.strptime(
+        assert DPTTime.from_knx(DPTArray((0xF7, 0x3B, 0x3B))) == time.strptime(
             "23 59 59 0", "%H %M %S %w"
         )
 
@@ -48,7 +48,9 @@ class TestDPTTime:
 
     def test_from_knx_min(self):
         """Test parsing of DPTTime object from binary values. Example 3."""
-        assert DPTTime.from_knx((0x0, 0x0, 0x0)) == time.strptime("0 0 0", "%H %M %S")
+        assert DPTTime.from_knx(DPTArray((0x0, 0x0, 0x0))) == time.strptime(
+            "0 0 0", "%H %M %S"
+        )
 
     #
     # TEST INITIALIZATION
@@ -59,19 +61,14 @@ class TestDPTTime:
 
     def test_from_knx_wrong_size(self):
         """Test parsing from DPTTime object from wrong binary values (wrong size)."""
-        with pytest.raises(ConversionError):
-            DPTTime.from_knx((0xF8, 0x23))
+        with pytest.raises(CouldNotParseTelegram):
+            DPTTime.from_knx(DPTArray((0xF8, 0x23)))
 
     def test_from_knx_wrong_bytes(self):
         """Test parsing from DPTTime object from wrong binary values (wrong bytes)."""
         with pytest.raises(ConversionError):
             # this parameter exceeds limit
-            DPTTime.from_knx((0xF7, 0x3B, 0x3C))
-
-    def test_from_knx_wrong_type(self):
-        """Test parsing from DPTTime object from wrong binary values (wrong type)."""
-        with pytest.raises(ConversionError):
-            DPTTime.from_knx((0xF8, "0x23"))
+            DPTTime.from_knx(DPTArray((0xF7, 0x3B, 0x3C)))
 
     def test_to_knx_wrong_parameter(self):
         """Test parsing from DPTTime object from wrong string value."""

--- a/test/dpt_tests/payload_test.py
+++ b/test/dpt_tests/payload_test.py
@@ -1,0 +1,76 @@
+"""Unit test for KNX payload objects."""
+import pytest
+
+from xknx.dpt import DPTArray, DPTBinary
+from xknx.exceptions import ConversionError
+
+
+class TestDPT:
+    """Test class for KNX binary/integer objects."""
+
+    def test_compare_binary(self):
+        """Test comparison of DPTBinary objects."""
+        assert DPTBinary(0) == DPTBinary(0)
+        assert DPTBinary(0) == DPTBinary(False)
+        assert DPTBinary(1) == DPTBinary(True)
+        assert DPTBinary(2) == DPTBinary(2)
+        assert DPTBinary(1) != DPTBinary(4)
+        assert DPTBinary(2) != DPTBinary(0)
+        assert DPTBinary(0) != DPTBinary(2)
+
+    def test_compare_array(self):
+        """Test comparison of DPTArray objects."""
+        assert DPTArray(()) == DPTArray(())
+        assert DPTArray([1]) == DPTArray((1,))
+        assert DPTArray([1, 2, 3]) == DPTArray([1, 2, 3])
+        assert DPTArray([1, 2, 3]) == DPTArray((1, 2, 3))
+        assert DPTArray((1, 2, 3)) == DPTArray([1, 2, 3])
+        assert DPTArray((1, 2, 3)) != DPTArray([1, 2, 3, 4])
+        assert DPTArray((1, 2, 3, 4)) != DPTArray([1, 2, 3])
+        assert DPTArray((1, 2, 3)) != DPTArray([1, 2, 4])
+
+    def test_compare_none(self):
+        """Test comparison DPTArray objects with None."""
+        assert DPTArray(()) is not None
+        assert None is not DPTArray(())
+        assert DPTBinary(0) is not None
+        assert None is not DPTBinary(0)
+        assert DPTArray((1, 2, 3)) is not None
+        assert None is not DPTArray((1, 2, 3))
+        assert DPTBinary(1) is not None
+        assert None is not DPTBinary(1)
+
+    def test_compare_array_binary(self):
+        """Test comparison of empty DPTArray objects with DPTBinary objects."""
+        assert DPTArray(()) != DPTBinary(0)
+        assert DPTBinary(0) != DPTArray(())
+        assert DPTBinary(0) != DPTArray(0)
+        assert DPTBinary(1) != DPTArray(1)
+        assert DPTArray((1, 2, 3)) != DPTBinary(2)
+        assert DPTBinary(2) != DPTArray((1, 2, 3))
+        assert DPTArray((2,)) != DPTBinary(2)
+        assert DPTBinary(2) != DPTArray((2,))
+
+    def test_dpt_binary_assign(self):
+        """Test initialization of DPTBinary objects."""
+        assert DPTBinary(8).value == 8
+
+    def test_dpt_binary_assign_limit_exceeded(self):
+        """Test initialization of DPTBinary objects with wrong value (value exceeded)."""
+        with pytest.raises(ConversionError):
+            DPTBinary(DPTBinary.APCI_BITMASK + 1)
+
+    def test_dpt_init_with_string(self):
+        """Teest initialization of DPTBinary object with wrong value (wrong type)."""
+        with pytest.raises(TypeError):
+            DPTBinary("bla")
+
+    def test_dpt_array_init_with_string(self):
+        """Test initialization of DPTArray object with wrong value (wrong type)."""
+        with pytest.raises(TypeError):
+            DPTArray("bla")
+
+    def test_dpt_representation(self):
+        """Test representation of DPTBinary and DPTArray."""
+        assert DPTBinary(True).__repr__() == "DPTBinary(0x1)"
+        assert DPTArray((5, 15)).__repr__() == "DPTArray((0x5, 0xf))"

--- a/test/remote_value_tests/remote_value_datetime_test.py
+++ b/test/remote_value_tests/remote_value_datetime_test.py
@@ -35,19 +35,9 @@ class TestRemoteValueDateTime:
         )
         assert array.value == (0x75, 0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80)
 
-    def test_payload_valid(self):
-        """Testing KNX/Byte representation of DPTDateTime object."""
-        xknx = XKNX()
-        rv_datetime = RemoteValueDateTime(xknx, value_type="datetime")
-        assert rv_datetime.payload_valid(
-            DPTArray((0x75, 0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
-        )
-
     def test_payload_invalid(self):
         """Testing KNX/Byte representation of DPTDateTime object."""
         xknx = XKNX()
         rv_datetime = RemoteValueDateTime(xknx, value_type="datetime")
         with pytest.raises(CouldNotParseTelegram):
-            rv_datetime.payload_valid(
-                DPTArray((0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80))
-            )
+            rv_datetime.from_knx(DPTArray((0x0B, 0x1C, 0x57, 0x07, 0x18, 0x20, 0x80)))

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -39,20 +39,18 @@ class TestRemoteValueSensor:
         for dpt_class in DPTBase.__recursive_subclasses__():
             assert isinstance(dpt_class.payload_length, int)
 
-    def test_payload_valid(self):
-        """Test payload_valid method."""
+    def test_payload_invalid(self):
+        """Test invalid payloads."""
         xknx = XKNX()
         remote_value = RemoteValueSensor(xknx=xknx, value_type="pulse")
-        valid_payload = DPTValue1Ucount.to_knx(1)
 
         assert remote_value.dpt_class == DPTValue1Ucount
         with pytest.raises(CouldNotParseTelegram):
-            remote_value.payload_valid(None)
+            remote_value.from_knx(None)
         with pytest.raises(CouldNotParseTelegram):
-            remote_value.payload_valid(DPTArray((1, 2, 3, 4)))
+            remote_value.from_knx(DPTArray((1, 2, 3, 4)))
         with pytest.raises(CouldNotParseTelegram):
-            remote_value.payload_valid(DPTBinary(1))
-        assert remote_value.payload_valid(valid_payload) == valid_payload
+            remote_value.from_knx(DPTBinary(1))
 
 
 class TestRemoteValueNumeric:

--- a/xknx/core/state_updater.py
+++ b/xknx/core/state_updater.py
@@ -126,7 +126,7 @@ class StateUpdater:
 
     def register_remote_value(
         self,
-        remote_value: RemoteValue[Any, Any],
+        remote_value: RemoteValue[Any],
         tracker_options: TrackerOptionType = True,
     ) -> None:
         """Register a RemoteValue to initialize its state and/or track for expiration."""
@@ -162,11 +162,11 @@ class StateUpdater:
         if self.started:
             tracker.start()
 
-    def unregister_remote_value(self, remote_value: RemoteValue[Any, Any]) -> None:
+    def unregister_remote_value(self, remote_value: RemoteValue[Any]) -> None:
         """Unregister a RemoteValue from StateUpdater."""
         self._workers.pop(id(remote_value)).stop()
 
-    def update_received(self, remote_value: RemoteValue[Any, Any]) -> None:
+    def update_received(self, remote_value: RemoteValue[Any]) -> None:
         """Reset the timer when a state update was received."""
         if self.started and id(remote_value) in self._workers:
             self._workers[id(remote_value)].update_received()

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -136,7 +136,7 @@ class Climate(Device):
 
         self.mode = mode
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.temperature
         yield self.target_temperature

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -174,7 +174,7 @@ class ClimateMode(Device):
 
     def _iter_remote_values(
         self,
-    ) -> Iterator[RemoteValue[Any, Any]]:
+    ) -> Iterator[RemoteValue[Any]]:
         """Iterate climate mode RemoteValue classes."""
         return chain(
             self._iter_operation_remote_values(),
@@ -183,7 +183,7 @@ class ClimateMode(Device):
 
     def _iter_operation_remote_values(
         self,
-    ) -> Iterator[RemoteValueClimateModeBase[Any, HVACOperationMode]]:
+    ) -> Iterator[RemoteValueClimateModeBase[HVACOperationMode]]:
         return chain(
             self._iter_binary_operation_modes(),
             self._iter_byte_operation_modes(),
@@ -191,7 +191,7 @@ class ClimateMode(Device):
 
     def _iter_binary_operation_modes(
         self,
-    ) -> Iterator[RemoteValueClimateModeBase[Any, HVACOperationMode]]:
+    ) -> Iterator[RemoteValueClimateModeBase[HVACOperationMode]]:
         """Iterate DPT 1 binary operation modes."""
         yield from (
             self.remote_value_operation_mode_comfort,
@@ -202,7 +202,7 @@ class ClimateMode(Device):
 
     def _iter_byte_operation_modes(
         self,
-    ) -> Iterator[RemoteValueClimateModeBase[Any, HVACOperationMode]]:
+    ) -> Iterator[RemoteValueClimateModeBase[HVACOperationMode]]:
         """Iterate normal DPT 20.102 operation mode remote values."""
         yield from (
             self.remote_value_operation_mode,
@@ -211,7 +211,7 @@ class ClimateMode(Device):
 
     def _iter_controller_remote_values(
         self,
-    ) -> Iterator[RemoteValueClimateModeBase[Any, HVACControllerMode]]:
+    ) -> Iterator[RemoteValueClimateModeBase[HVACControllerMode]]:
         """Iterate DPT 20.105 controller remote values."""
         yield self.remote_value_controller_mode
         yield self.remote_value_heat_cool
@@ -242,7 +242,7 @@ class ClimateMode(Device):
                 "operation (preset) mode not supported", str(operation_mode)
             )
 
-        rv_operation: RemoteValueClimateModeBase[Any, HVACOperationMode]
+        rv_operation: RemoteValueClimateModeBase[HVACOperationMode]
         for rv_operation in self._iter_operation_remote_values():
             if (
                 rv_operation.writable
@@ -262,7 +262,7 @@ class ClimateMode(Device):
                 "controller (HVAC) mode not supported", str(controller_mode)
             )
 
-        rv_controller: RemoteValueClimateModeBase[Any, HVACControllerMode]
+        rv_controller: RemoteValueClimateModeBase[HVACControllerMode]
         for rv_controller in self._iter_controller_remote_values():
             if (
                 rv_controller.writable

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -143,7 +143,7 @@ class Cover(Device):
         self._periodic_update_task: Task | None = None
         self._travel_direction_tilt: TravelStatus | None = None
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.updown
         yield self.step

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -62,7 +62,7 @@ class Device(ABC):
                 self.xknx.task_registry.unregister(task.name)
 
     @abstractmethod
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         # yield self.remote_value
         # yield from (<list all used RemoteValue instances>)

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -75,7 +75,7 @@ class ExposeSensor(Device):
         self._cooldown_latest_value = self.sensor_value.value
         await super().after_update()
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -109,7 +109,7 @@ class Fan(Device):
             after_update_cb=self.after_update,
         )
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         yield from (self.switch, self.speed, self.oscillation)
 

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -317,14 +317,14 @@ class Light(Device):
         self._individual_color_debounce_telegram_counter: int
         self._reset_individual_color_debounce_telegrams()
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         return chain(
             self._iter_instant_remote_values(),
             self._iter_debounce_remote_values(),
         )
 
-    def _iter_instant_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_instant_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes calling after_update_cb immediately."""
         yield self.switch
         yield self.brightness
@@ -336,7 +336,7 @@ class Light(Device):
         yield self.tunable_white
         yield self.color_temperature
 
-    def _iter_debounce_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_debounce_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes debouncing after_update_cb."""
         for color in self._iter_individual_colors():
             yield color.switch

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -67,7 +67,7 @@ class Sensor(Device):
             )
         self.always_callback = always_callback
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -230,7 +230,7 @@ class Weather(Device):
             after_update_cb=self.after_update,
         )
 
-    def _iter_remote_values(self) -> Iterator[RemoteValue[Any, Any]]:
+    def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices remote values."""
         yield self._temperature
         yield self._brightness_south

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -189,4 +189,4 @@ from .dpt_hvac_mode import DPTControllerStatus, DPTHVACContrMode, DPTHVACMode
 from .dpt_scaling import DPTAngle, DPTScaling
 from .dpt_string import DPTLatin1, DPTString
 from .dpt_time import DPTTime
-from .payload import DPTArray, DPTBinary, DPTPayloadT
+from .payload import DPTArray, DPTBinary

--- a/xknx/dpt/dpt_1byte_signed.py
+++ b/xknx/dpt/dpt_1byte_signed.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTSignedRelativeValue(DPTNumeric):
@@ -24,9 +24,9 @@ class DPTSignedRelativeValue(DPTNumeric):
     resolution = 1
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         if raw[0] > cls.value_max:
             return raw[0] - 0x100
         return raw[0]

--- a/xknx/dpt/dpt_1byte_uint.py
+++ b/xknx/dpt/dpt_1byte_uint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTValue1ByteUnsigned(DPTNumeric):
@@ -24,15 +24,13 @@ class DPTValue1ByteUnsigned(DPTNumeric):
     resolution = 1
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
-
-        value = raw[0]
+        value = cls.validate_payload(payload)[0]
 
         if not cls._test_boundaries(value):
             raise ConversionError(
-                f"Could not parse {cls.__name__}", value=value, raw=raw
+                f"Could not parse {cls.__name__}", value=value, payload=payload
             )
 
         return value
@@ -120,15 +118,13 @@ class DPTSceneNumber(DPTValue1ByteUnsigned):
     value_max = 64
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
-
-        value = raw[0] + 1
+        value = cls.validate_payload(payload)[0] + 1
 
         if not cls._test_boundaries(value):
             raise ConversionError(
-                f"Could not parse {cls.__name__}", value=value, raw=raw
+                f"Could not parse {cls.__name__}", value=value, payload=payload
             )
 
         return value

--- a/xknx/dpt/dpt_2byte_float.py
+++ b/xknx/dpt/dpt_2byte_float.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPT2ByteFloat(DPTNumeric):
@@ -28,9 +28,9 @@ class DPT2ByteFloat(DPTNumeric):
     resolution = 0.01
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> float:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> float:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         data = (raw[0] * 256) + raw[1]
         exponent = (data >> 11) & 0x0F
         significand = data & 0x7FF

--- a/xknx/dpt/dpt_2byte_signed.py
+++ b/xknx/dpt/dpt_2byte_signed.py
@@ -11,7 +11,7 @@ import struct
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPT2ByteSigned(DPTNumeric):
@@ -33,12 +33,12 @@ class DPT2ByteSigned(DPTNumeric):
     _struct_format = ">h"
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         try:
-            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore
+            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore[no-any-return]
         except struct.error:
             raise ConversionError(f"Could not parse {cls.__name__}", raw=raw)
 

--- a/xknx/dpt/dpt_2byte_uint.py
+++ b/xknx/dpt/dpt_2byte_uint.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPT2ByteUnsigned(DPTNumeric):
@@ -26,9 +26,9 @@ class DPT2ByteUnsigned(DPTNumeric):
     resolution = 1
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         return (raw[0] * 256) + raw[1]
 
     @classmethod

--- a/xknx/dpt/dpt_4bit_control.py
+++ b/xknx/dpt/dpt_4bit_control.py
@@ -82,8 +82,10 @@ class DPTControlStepCode(DPTBase, ABC):
     def from_knx(cls, payload: DPTArray | DPTBinary) -> Any:
         """Parse/deserialize from KNX/IP raw data."""
         raw = cls.validate_payload(payload)[0]
-        control, step_code = cls._decode(raw)
+        if raw > cls.APCI_MAX_VALUE:
+            raise ConversionError(f"Can't parse {cls.__name__}", raw=raw)
 
+        control, step_code = cls._decode(raw)
         return {"control": control, "step_code": step_code}
 
 

--- a/xknx/dpt/dpt_4byte_float.py
+++ b/xknx/dpt/dpt_4byte_float.py
@@ -12,7 +12,7 @@ from typing import cast
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPT4ByteFloat(DPTNumeric):
@@ -37,9 +37,9 @@ class DPT4ByteFloat(DPTNumeric):
     resolution = 0.0000001
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> float:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> float:
         """Parse/deserialize from KNX/IP raw data (big endian)."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         try:
             raw_float = cast(float, struct.unpack(">f", bytes(raw))[0])
         except struct.error:

--- a/xknx/dpt/dpt_4byte_int.py
+++ b/xknx/dpt/dpt_4byte_int.py
@@ -12,7 +12,7 @@ import struct
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPT4ByteUnsigned(DPTNumeric):
@@ -34,12 +34,12 @@ class DPT4ByteUnsigned(DPTNumeric):
     _struct_format = ">I"
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         try:
-            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore
+            return struct.unpack(cls._struct_format, bytes(raw))[0]  # type: ignore[no-any-return]
         except struct.error:
             raise ConversionError(f"Could not parse {cls.__name__}", raw=raw)
 

--- a/xknx/dpt/dpt_color.py
+++ b/xknx/dpt/dpt_color.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class XYYColor(NamedTuple):
@@ -25,12 +25,13 @@ class XYYColor(NamedTuple):
 class DPTColorXYY(DPTBase):
     """Abstraction for KNX 6 octet color xyY (DPT 242.600)."""
 
+    payload_type = DPTArray
     payload_length = 6
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> XYYColor:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> XYYColor:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         x_axis_int = raw[0] << 8 | raw[1]
         y_axis_int = raw[2] << 8 | raw[3]

--- a/xknx/dpt/dpt_date.py
+++ b/xknx/dpt/dpt_date.py
@@ -6,18 +6,19 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTDate(DPTBase):
     """Abstraction for KNX 3 octet date (DPT 11.001)."""
 
+    payload_type = DPTArray
     payload_length = 3
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> time.struct_time:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         day = raw[0] & 0x1F
         month = raw[1] & 0x0F

--- a/xknx/dpt/dpt_datetime.py
+++ b/xknx/dpt/dpt_datetime.py
@@ -6,18 +6,19 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTDateTime(DPTBase):
     """Abstraction for KNX 8 octet datetime (DPT 19.001)."""
 
+    payload_type = DPTArray
     payload_length = 8
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> time.struct_time:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         year = raw[0] + 1900
         month = raw[1] & 0x0F

--- a/xknx/dpt/dpt_hvac_mode.py
+++ b/xknx/dpt/dpt_hvac_mode.py
@@ -7,7 +7,7 @@ from typing import Generic, TypeVar
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 HVACModeT = TypeVar("HVACModeT", "HVACControllerMode", "HVACOperationMode")
 
@@ -46,12 +46,13 @@ class _DPTClimateMode(DPTBase, Generic[HVACModeT]):
 
     SUPPORTED_MODES: dict[int, HVACModeT] = {}
 
+    payload_type = DPTArray
     payload_length = 1
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> HVACModeT:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> HVACModeT:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         try:
             return cls.SUPPORTED_MODES[raw[0]]
         except KeyError:
@@ -126,9 +127,9 @@ class DPTControllerStatus(_DPTClimateMode[HVACOperationMode]):
     }
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> HVACOperationMode:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> HVACOperationMode:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         if raw[0] & 8 > 0:
             return HVACOperationMode.FROST_PROTECTION
         if raw[0] & 4 > 0:

--- a/xknx/dpt/dpt_scaling.py
+++ b/xknx/dpt/dpt_scaling.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTNumeric
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTScaling(DPTNumeric):
@@ -25,19 +25,16 @@ class DPTScaling(DPTNumeric):
     resolution = 1
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> int:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> int:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
-
-        knx_value = raw[0]
+        knx_value = cls.validate_payload(payload)[0]
         delta = cls.value_max - cls.value_min
         value = round((knx_value / 255) * delta) + cls.value_min
 
         if not cls._test_boundaries(value):
             raise ConversionError(
-                f"Could not parse {cls.__name__}", value=value, raw=raw
+                f"Could not parse {cls.__name__}", value=value, payload=payload
             )
-
         return value
 
     @classmethod

--- a/xknx/dpt/dpt_string.py
+++ b/xknx/dpt/dpt_string.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTString(DPTBase):
@@ -14,6 +14,7 @@ class DPTString(DPTBase):
     DPT 16.000
     """
 
+    payload_type = DPTArray
     payload_length = 14
     dpt_main_number = 16
     dpt_sub_number = 0
@@ -23,9 +24,9 @@ class DPTString(DPTBase):
     _encoding = "ascii"
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> str:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> str:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
         return bytes(byte for byte in raw if byte != 0x00).decode(
             cls._encoding, errors="replace"
         )

--- a/xknx/dpt/dpt_time.py
+++ b/xknx/dpt/dpt_time.py
@@ -6,7 +6,7 @@ import time
 from xknx.exceptions import ConversionError
 
 from .dpt import DPTBase
-from .payload import DPTArray
+from .payload import DPTArray, DPTBinary
 
 
 class DPTTime(DPTBase):
@@ -16,12 +16,13 @@ class DPTTime(DPTBase):
     DPT 10.001
     """
 
+    payload_type = DPTArray
     payload_length = 3
 
     @classmethod
-    def from_knx(cls, raw: tuple[int, ...]) -> time.struct_time:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> time.struct_time:
         """Parse/deserialize from KNX/IP raw data."""
-        cls.test_bytesarray(raw)
+        raw = cls.validate_payload(payload)
 
         weekday = (raw[0] & 0xE0) >> 5
         hours = raw[0] & 0x1F

--- a/xknx/dpt/payload.py
+++ b/xknx/dpt/payload.py
@@ -1,8 +1,6 @@
 """Implementation of KNX raw payload abstractions."""
 from __future__ import annotations
 
-from typing import TypeVar, Union
-
 from xknx.exceptions import ConversionError
 
 
@@ -65,6 +63,3 @@ class DPTArray:
     def __str__(self) -> str:
         """Return object as readable string."""
         return f'<DPTArray value="[{",".join(hex(b) for b in self.value)}]" />'
-
-
-DPTPayloadT = TypeVar("DPTPayloadT", bound=Union[DPTArray, DPTBinary])

--- a/xknx/remote_value/remote_value_1count.py
+++ b/xknx/remote_value/remote_value_1count.py
@@ -6,24 +6,17 @@ DPT 6.010.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTValue1Count
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
 
-class RemoteValue1Count(RemoteValue[DPTArray, int]):
+class RemoteValue1Count(RemoteValue[int]):
     """Abstraction for remote value of KNX 6.010 (DPT_Value_1_Count)."""
-
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 1:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
         return DPTValue1Count.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> int:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> int:
         """Convert current payload to value."""
-        return DPTValue1Count.from_knx(payload.value)
+        return DPTValue1Count.from_knx(payload)

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueColorRGB(RemoteValue[DPTArray, tuple[int, int, int]]):
+class RemoteValueColorRGB(RemoteValue[tuple[int, int, int]]):
     """Abstraction for remote value of KNX DPT 232.600 (DPT_Color_RGB)."""
 
     def __init__(
@@ -40,12 +40,6 @@ class RemoteValueColorRGB(RemoteValue[DPTArray, tuple[int, int, int]]):
             feature_name=feature_name,
             after_update_cb=after_update_cb,
         )
-
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 3:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: Sequence[int]) -> DPTArray:
         """Convert value to payload."""
@@ -72,6 +66,9 @@ class RemoteValueColorRGB(RemoteValue[DPTArray, tuple[int, int, int]]):
 
         return DPTArray(list(value))
 
-    def from_knx(self, payload: DPTArray) -> tuple[int, int, int]:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> tuple[int, int, int]:
         """Convert current payload to value."""
+        if not (isinstance(payload, DPTArray) and len(payload.value) == 3):
+            raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
+
         return payload.value[0], payload.value[1], payload.value[2]

--- a/xknx/remote_value/remote_value_color_xyy.py
+++ b/xknx/remote_value/remote_value_color_xyy.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.dpt.dpt_color import DPTColorXYY, XYYColor
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -17,10 +16,8 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueColorXYY(RemoteValue[DPTArray, XYYColor]):
+class RemoteValueColorXYY(RemoteValue[XYYColor]):
     """Abstraction for remote value of KNX DPT 242.600 (DPT_Colour_xyY)."""
-
-    PAYLOAD_LENGTH = 6
 
     def __init__(
         self,
@@ -43,16 +40,10 @@ class RemoteValueColorXYY(RemoteValue[DPTArray, XYYColor]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == self.PAYLOAD_LENGTH:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: XYYColor) -> DPTArray:
         """Convert value to payload."""
         return DPTColorXYY.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> XYYColor:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> XYYColor:
         """Convert current payload to value."""
-        return DPTColorXYY.from_knx(payload.value)
+        return DPTColorXYY.from_knx(payload)

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from xknx.dpt import DPTArray, DPTBinary, DPTControlStepCode
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueControl(RemoteValue[DPTBinary, Any]):
+class RemoteValueControl(RemoteValue[Any]):
     """Abstraction for remote value used for controlling."""
 
     def __init__(
@@ -50,20 +50,13 @@ class RemoteValueControl(RemoteValue[DPTBinary, Any]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTBinary):
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: Any) -> DPTBinary:
         """Convert value to payload."""
         return self.dpt_class.to_knx(value)
 
-    def from_knx(self, payload: DPTBinary) -> Any:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> Any:
         """Convert current payload to value."""
-        # TODO: DPTBinary.value is int - DPTBase.from_knx requires Tuple[int, ...] - maybe use bytes
-        return self.dpt_class.from_knx((payload.value,))
+        return self.dpt_class.from_knx(payload)
 
     @property
     def unit_of_measurement(self) -> str | None:

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -10,7 +10,7 @@ import time
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary, DPTDate, DPTDateTime, DPTTime
-from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.exceptions import ConversionError
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -26,7 +26,7 @@ class DateTimeType(Enum):
     TIME = DPTTime
 
 
-class RemoteValueDateTime(RemoteValue[DPTArray, time.struct_time]):
+class RemoteValueDateTime(RemoteValue[time.struct_time]):
     """Abstraction for remote value of KNX 10.001, 11.001 and 19.001 time and date objects."""
 
     def __init__(
@@ -62,19 +62,10 @@ class RemoteValueDateTime(RemoteValue[DPTArray, time.struct_time]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if (
-            isinstance(payload, DPTArray)
-            and len(payload.value) == self.dpt_class.payload_length
-        ):
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: time.struct_time) -> DPTArray:
         """Convert value to payload."""
         return self.dpt_class.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> time.struct_time:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> time.struct_time:
         """Convert current payload to value."""
-        return self.dpt_class.from_knx(payload.value)
+        return self.dpt_class.from_knx(payload)

--- a/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
+++ b/xknx/remote_value/remote_value_dpt_2_byte_unsigned.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPT2ByteUnsigned, DPTArray, DPTBinary
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
 
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray, int]):
+class RemoteValueDpt2ByteUnsigned(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 7.001."""
 
     def __init__(
@@ -40,16 +39,10 @@ class RemoteValueDpt2ByteUnsigned(RemoteValue[DPTArray, int]):
             after_update_cb=after_update_cb,
         )
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 2:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
         return DPT2ByteUnsigned.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> int:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> int:
         """Convert current payload to value."""
-        return DPT2ByteUnsigned.from_knx(payload.value)
+        return DPT2ByteUnsigned.from_knx(payload)

--- a/xknx/remote_value/remote_value_dpt_value_1_ucount.py
+++ b/xknx/remote_value/remote_value_dpt_value_1_ucount.py
@@ -6,24 +6,17 @@ DPT 5.010.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTValue1Ucount
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
 
-class RemoteValueDptValue1Ucount(RemoteValue[DPTArray, int]):
+class RemoteValueDptValue1Ucount(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 5.010."""
-
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 1:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
         return DPTValue1Ucount.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> int:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> int:
         """Convert current payload to value."""
-        return DPTValue1Ucount.from_knx(payload.value)
+        return DPTValue1Ucount.from_knx(payload)

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueScaling(RemoteValue[DPTArray, int]):
+class RemoteValueScaling(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 5.001 (DPT_Scaling)."""
 
     def __init__(
@@ -44,20 +44,16 @@ class RemoteValueScaling(RemoteValue[DPTArray, int]):
         self.range_from = range_from
         self.range_to = range_to
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 1:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: float) -> DPTArray:
         """Convert value to payload."""
         knx_value = self._calc_to_knx(self.range_from, self.range_to, value)
         return DPTArray(knx_value)
 
-    def from_knx(self, payload: DPTArray) -> int:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> int:
         """Convert current payload to value."""
-        return self._calc_from_knx(self.range_from, self.range_to, payload.value[0])
+        if isinstance(payload, DPTArray) and len(payload.value) == 1:
+            return self._calc_from_knx(self.range_from, self.range_to, payload.value[0])
+        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     @property
     def unit_of_measurement(self) -> str | None:

--- a/xknx/remote_value/remote_value_scene_number.py
+++ b/xknx/remote_value/remote_value_scene_number.py
@@ -6,24 +6,17 @@ DPT 17.001.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTSceneNumber
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
 
-class RemoteValueSceneNumber(RemoteValue[DPTArray, int]):
+class RemoteValueSceneNumber(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 17.001 (DPT_Scene_Number)."""
-
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 1:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: int) -> DPTArray:
         """Convert value to payload."""
         return DPTSceneNumber.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> int:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> int:
         """Convert current payload to value."""
-        return DPTSceneNumber.from_knx(payload.value)
+        return DPTSceneNumber.from_knx(payload)

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueStep(RemoteValue[DPTBinary, "RemoteValueStep.Direction"]):
+class RemoteValueStep(RemoteValue["RemoteValueStep.Direction"]):
     """Abstraction for remote value of KNX DPT 1.007 / DPT_Step."""
 
     class Direction(Enum):
@@ -47,12 +47,6 @@ class RemoteValueStep(RemoteValue[DPTBinary, "RemoteValueStep.Direction"]):
         )
         self.invert = invert
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTBinary):
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     # from KNX Association System Specifications AS v1.5.00:
     # 1.007 DPT_Step   0 = Decrease 1 = Increase
     # 1.008 DPT_UpDown 0 = Up       1 = Down
@@ -70,14 +64,14 @@ class RemoteValueStep(RemoteValue[DPTBinary, "RemoteValueStep.Direction"]):
             feature_name=self.feature_name,
         )
 
-    def from_knx(self, payload: DPTBinary) -> RemoteValueStep.Direction:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> RemoteValueStep.Direction:
         """Convert current payload to value."""
-        if payload == DPTBinary(1):
+        if payload.value == 1:
             return self.Direction.DECREASE if self.invert else self.Direction.INCREASE
-        if payload == DPTBinary(0):
+        if payload.value == 0:
             return self.Direction.INCREASE if self.invert else self.Direction.DECREASE
         raise CouldNotParseTelegram(
-            "payload invalid",
+            "Payload invalid",
             payload=payload,
             device_name=self.device_name,
             feature_name=self.feature_name,

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueSwitch(RemoteValue[DPTBinary, bool]):
+class RemoteValueSwitch(RemoteValue[bool]):
     """Abstraction for remote value of KNX DPT 1.001 / DPT_Switch."""
 
     def __init__(
@@ -42,12 +42,6 @@ class RemoteValueSwitch(RemoteValue[DPTBinary, bool]):
         )
         self.invert = bool(invert)
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTBinary):
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: bool) -> DPTBinary:
         """Convert value to payload."""
         if isinstance(value, bool):
@@ -59,14 +53,14 @@ class RemoteValueSwitch(RemoteValue[DPTBinary, bool]):
             feature_name=self.feature_name,
         )
 
-    def from_knx(self, payload: DPTBinary) -> bool:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> bool:
         """Convert current payload to value."""
-        if payload == DPTBinary(0):
+        if payload.value == 0:
             return self.invert
-        if payload == DPTBinary(1):
+        if payload.value == 1:
             return not self.invert
         raise CouldNotParseTelegram(
-            "payload invalid",
+            "Payload invalid",
             payload=payload,
             device_name=self.device_name,
             feature_name=self.feature_name,

--- a/xknx/remote_value/remote_value_temp.py
+++ b/xknx/remote_value/remote_value_temp.py
@@ -6,24 +6,17 @@ DPT 9.001.
 from __future__ import annotations
 
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature
-from xknx.exceptions import CouldNotParseTelegram
 
 from .remote_value import RemoteValue
 
 
-class RemoteValueTemp(RemoteValue[DPTArray, float]):
+class RemoteValueTemp(RemoteValue[float]):
     """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
-
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTArray:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTArray) and len(payload.value) == 2:
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
 
     def to_knx(self, value: float) -> DPTArray:
         """Convert value to payload."""
         return DPTTemperature.to_knx(value)
 
-    def from_knx(self, payload: DPTArray) -> float:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> float:
         """Convert current payload to value."""
-        return DPTTemperature.from_knx(payload.value)
+        return DPTTemperature.from_knx(payload)

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 
 
-class RemoteValueUpDown(RemoteValue[DPTBinary, "RemoteValueUpDown.Direction"]):
+class RemoteValueUpDown(RemoteValue["RemoteValueUpDown.Direction"]):
     """Abstraction for remote value of KNX DPT 1.008 / DPT_UpDown."""
 
     class Direction(Enum):
@@ -47,12 +47,6 @@ class RemoteValueUpDown(RemoteValue[DPTBinary, "RemoteValueUpDown.Direction"]):
         )
         self.invert = invert
 
-    def payload_valid(self, payload: DPTArray | DPTBinary | None) -> DPTBinary:
-        """Test if telegram payload may be parsed."""
-        if isinstance(payload, DPTBinary):
-            return payload
-        raise CouldNotParseTelegram("Payload invalid", payload=str(payload))
-
     def to_knx(self, value: RemoteValueUpDown.Direction) -> DPTBinary:
         """Convert value to payload."""
         if value == self.Direction.UP:
@@ -66,14 +60,14 @@ class RemoteValueUpDown(RemoteValue[DPTBinary, "RemoteValueUpDown.Direction"]):
             feature_name=self.feature_name,
         )
 
-    def from_knx(self, payload: DPTBinary) -> RemoteValueUpDown.Direction:
+    def from_knx(self, payload: DPTArray | DPTBinary) -> RemoteValueUpDown.Direction:
         """Convert current payload to value."""
-        if payload == DPTBinary(0):
+        if payload.value == 0:
             return self.Direction.DOWN if self.invert else self.Direction.UP
-        if payload == DPTBinary(1):
+        if payload.value == 1:
             return self.Direction.UP if self.invert else self.Direction.DOWN
         raise CouldNotParseTelegram(
-            "payload invalid",
+            "Payload invalid",
             payload=payload,
             device_name=self.device_name,
             feature_name=self.feature_name,

--- a/xknx/tools/group_communication.py
+++ b/xknx/tools/group_communication.py
@@ -75,7 +75,7 @@ async def read_group_value(
     xknx: XKNX,
     group_address: DeviceAddressableType,
     value_type: int | str | type[DPTBase] | None = None,
-) -> DPTArray | DPTBinary | Any | None:
+) -> int | tuple[int, ...] | Any | None:
     """Read a value from a KNX group address."""
     transcoder = _parse_dpt(value_type)
     value_reader = ValueReader(xknx, parse_device_group_address(group_address))
@@ -83,7 +83,7 @@ async def read_group_value(
     if response is not None:
         assert isinstance(response.payload, (GroupValueWrite, GroupValueResponse))
         if transcoder is not None:
-            return transcoder.from_knx(response.payload.value.value)  # type: ignore[arg-type]
+            return transcoder.from_knx(response.payload.value)
         return response.payload.value.value
     return None
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Accept `DPTArray` or `DPTBinary` in `DPTBase.from_knx()` instead of raw `tuple[int]`.
- Remove payload_valid() from RemoteValue and remove payload type form its generics parameters.

Second part or #1231

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)