### PR TITLE
Common interface for DPT transcoders with multi-value data

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ nav_order: 2
 
 # Changelog
 
+# Unreleased changes
+
+### DPT
+
+- DPTComplex: Common interface for DPT transcoders with multi-value data. Resulting dataclasses can be converted to and from a dict with DPT specific properties to be JSON compatible.
+
 # 2.12.2 Fix thread leak 2024-03-05
 
 ### Bugfixes

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -6,6 +6,7 @@ from xknx import XKNX
 from xknx.devices import Light
 from xknx.devices.light import ColorTemperatureType
 from xknx.dpt import DPTArray, DPTBinary
+from xknx.dpt.dpt_color import XYYColor
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 
@@ -1075,7 +1076,7 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_xyy_color="1/2/4",
         )
-        await light.set_xyy_color(((0.52, 0.31), 25))
+        await light.set_xyy_color(XYYColor((0.52, 0.31), 25))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -1083,7 +1084,7 @@ class TestLight:
             payload=GroupValueWrite(DPTArray((0x85, 0x1E, 0x4F, 0x5C, 0x19, 0x03))),
         )
         await xknx.devices.process(telegram)
-        assert light.current_xyy_color == ((0.52, 0.31), 25)
+        assert light.current_xyy_color == XYYColor((0.52, 0.31), 25)
 
     async def test_set_xyy_color_not_possible(self):
         """Test setting XYY value of a light not supporting it."""
@@ -1095,7 +1096,7 @@ class TestLight:
             group_address_color="1/2/4",
         )
         with patch("logging.Logger.warning") as mock_warn:
-            await light.set_xyy_color(((0.5, 0.3), 25))
+            await light.set_xyy_color(XYYColor((0.5, 0.3), 25))
 
             assert xknx.telegrams.qsize() == 0
             mock_warn.assert_called_with(
@@ -1582,7 +1583,7 @@ class TestLight:
                 payload=GroupValueWrite(DPTArray((0x2E, 0x14, 0x40, 0x00, 0x55, 0x02))),
             )
         )
-        assert light.current_xyy_color == ((0.18, 0.25), None)
+        assert light.current_xyy_color == XYYColor((0.18, 0.25), None)
         # add valid brightness
         await light.process(
             Telegram(
@@ -1590,7 +1591,7 @@ class TestLight:
                 payload=GroupValueWrite(DPTArray((0x2E, 0x14, 0x40, 0x00, 0x55, 0x03))),
             )
         )
-        assert light.current_xyy_color == ((0.18, 0.25), 85)
+        assert light.current_xyy_color == XYYColor((0.18, 0.25), 85)
         # invalid color
         await light.process(
             Telegram(
@@ -1598,7 +1599,7 @@ class TestLight:
                 payload=GroupValueWrite(DPTArray((0xD1, 0xEB, 0xB0, 0xA3, 0xA5, 0x01))),
             )
         )
-        assert light.current_xyy_color == ((0.18, 0.25), 165)
+        assert light.current_xyy_color == XYYColor((0.18, 0.25), 165)
         # both valid
         await light.process(
             Telegram(
@@ -1606,7 +1607,7 @@ class TestLight:
                 payload=GroupValueWrite(DPTArray((0xD1, 0xEB, 0xB0, 0xA3, 0xA5, 0x03))),
             )
         )
-        assert light.current_xyy_color == ((0.82, 0.69), 165)
+        assert light.current_xyy_color == XYYColor((0.82, 0.69), 165)
         # invalid brightness
         await light.process(
             Telegram(
@@ -1614,7 +1615,7 @@ class TestLight:
                 payload=GroupValueWrite(DPTArray((0x2E, 0x14, 0x40, 0x00, 0x00, 0x02))),
             )
         )
-        assert light.current_xyy_color == ((0.18, 0.25), 165)
+        assert light.current_xyy_color == XYYColor((0.18, 0.25), 165)
 
     async def test_process_tunable_white(self):
         """Test process / reading telegrams from telegram queue. Test if tunable white is processed."""

--- a/test/dpt_tests/dpt_color_test.py
+++ b/test/dpt_tests/dpt_color_test.py
@@ -9,92 +9,65 @@ from xknx.exceptions import ConversionError, CouldNotParseTelegram
 class TestDPTColorXYY:
     """Test class for KNX xyY-color objects."""
 
-    def test_xyycolor_assert_min_exceeded(self):
-        """Test initialization of DPTColorXYY with wrong value (Underflow)."""
-        with pytest.raises(ConversionError):
-            DPTColorXYY.to_knx(((-0.1, 0), 0))
-            DPTColorXYY.to_knx(((0, -0.1), 0))
-            DPTColorXYY.to_knx(((0, 0), -1))
-
-    def test_xyycolor_to_knx_exceed_limits(self):
-        """Test initialization of DPTColorXYY with wrong value (Overflow)."""
-        with pytest.raises(ConversionError):
-            DPTColorXYY.to_knx(((1.1, 0), 0))
-            DPTColorXYY.to_knx(((0, 1.1), 0))
-            DPTColorXYY.to_knx(((0, 0), 256))
-
-    def test_xyycolor_value_max_value(self):
+    @pytest.mark.parametrize(
+        ("color", "brightness", "raw"),
+        [
+            ((0, 0), 0, (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)),  # min values
+            ((1, 1), 255, (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)),  # max values
+            (None, 0, (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)),  # color None
+            ((0, 0), None, (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)),  # brightness None
+            (
+                None,
+                None,
+                (0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
+            ),  # color and brightness None
+            ((0.2, 0.2), 128, (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)),
+            ((0.8, 0.8), 204, (0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03)),
+        ],
+    )
+    def test_xyycolor_value(self, color, brightness, raw):
         """Test DPTColorXYY parsing and streaming."""
-        assert DPTColorXYY.to_knx(((1, 1), 255)) == DPTArray(
-            (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03))) == (
-            (1, 1),
-            255,
-        )
+        value = XYYColor(color=color, brightness=brightness)
+        knx_value = DPTColorXYY.to_knx(value)
+        assert knx_value == DPTArray(raw)
+        assert DPTColorXYY.from_knx(knx_value) == value
 
-    def test_xyycolor_value_min_value(self):
-        """Test DPTColorXYY parsing and streaming with null values."""
-        assert DPTColorXYY.to_knx(((0, 0), 0)) == DPTArray(
-            (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x03))) == (
-            (0, 0),
-            0,
-        )
+    @pytest.mark.parametrize(
+        ("color", "brightness"),
+        [
+            ((-0.1, 0), 0),
+            ((0, -0.1), 0),
+            ((0, 0), -1),
+            ((1.1, 0), 0),
+            ((0, 1.1), 0),
+            ((0, 0), 256),
+        ],
+    )
+    def test_xyycolor_to_knx_limits(self, color, brightness):
+        """Test initialization of DPTColorXYY with wrong value."""
+        value = XYYColor(color=color, brightness=brightness)
+        with pytest.raises(ConversionError):
+            DPTColorXYY.to_knx(value)
 
-    def test_xyycolor_value_none_value(self):
-        """Test DPTColorXYY parsing and streaming with null values."""
-        assert DPTColorXYY.to_knx((None, 0)) == DPTArray(
-            (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x01))) == (
+    @pytest.mark.parametrize(
+        "value",
+        [
             None,
-            0,
-        )
-
-        assert DPTColorXYY.to_knx(((0, 0), None)) == DPTArray(
-            (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x02))) == (
-            (0, 0),
-            None,
-        )
-
-        assert DPTColorXYY.to_knx((None, None)) == DPTArray(
-            (0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0x00, 0x00, 0x00, 0x00, 0x00, 0x00))) == (
-            None,
-            None,
-        )
-
-    def test_xyycolor_value(self):
-        """Test DPTColorXYY parsing and streaming with valid value."""
-        assert DPTColorXYY.to_knx(((0.2, 0.2), 128)) == DPTArray(
-            (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)
-        )
-        assert DPTColorXYY.from_knx(DPTArray((0x33, 0x33, 0x33, 0x33, 0x80, 0x03))) == (
-            (0.2, 0.2),
-            128,
-        )
-        assert DPTColorXYY.to_knx(
-            XYYColor(color=(0.8, 0.8), brightness=204)
-        ) == DPTArray((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03))
-        assert DPTColorXYY.from_knx(
-            DPTArray((0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03))
-        ) == XYYColor(color=(0.8, 0.8), brightness=204)
-
-    def test_xyycolor_wrong_value_to_knx(self):
+            (0xFF, 0x4E, 0x12),
+            1,
+            ((0x00, 0xFF, 0x4E), 0x12),
+            ((0xFF, 0x4E), (0x12, 0x00)),
+            ((0, 0), "a"),
+            ((0, 0), 0.4),
+            XYYColor(color=(0, 0), brightness="a"),
+            XYYColor(color=4, brightness=4),
+            XYYColor(color=("a", 0), brightness=1),
+        ],
+    )
+    def test_xyycolor_wrong_value_to_knx(self, value):
         """Test DPTColorXYY parsing with wrong value."""
         with pytest.raises(ConversionError):
-            DPTColorXYY.to_knx(None)
-            DPTColorXYY.to_knx((0xFF, 0x4E, 0x12))
-            DPTColorXYY.to_knx(1)
-            DPTColorXYY.to_knx(((0x00, 0xFF, 0x4E), 0x12))
-            DPTColorXYY.to_knx(((0xFF, 0x4E), (0x12, 0x00)))
-            DPTColorXYY.to_knx(((0, 0), "a"))
-            DPTColorXYY.to_knx(((0, 0), 0.4))
+            DPTColorXYY.to_knx(value)
 
     def test_xyycolor_wrong_value_from_knx(self):
         """Test DPTColorXYY parsing with wrong value."""

--- a/test/dpt_tests/dpt_color_test.py
+++ b/test/dpt_tests/dpt_color_test.py
@@ -6,31 +6,85 @@ from xknx.dpt.dpt_color import DPTArray, DPTColorXYY, XYYColor
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
 
 
+class TestXYYColor:
+    """Test XYYColor class."""
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {"x_axis": 0.1, "y_axis": 0.2, "brightness": 128},
+            {"x_axis": 0.5, "y_axis": 0.5, "brightness": 255},
+            {"x_axis": 0.9, "y_axis": 0.8},
+            {"brightness": 50},
+            {},
+        ],
+    )
+    def test_dict(self, data):
+        """Test from_dict and as_dict methods."""
+        value = XYYColor.from_dict(data)
+        assert value
+        # fields default to `None`
+        default_dict = {"x_axis": None, "y_axis": None, "brightness": None}
+        assert value.as_dict() == default_dict | data
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            # incomplete data
+            {"x_axis": 0.1},
+            {"y_axis": 0.1},
+            {"x_axis": 0.1, "brightness": 128},
+            {"y_axis": 0.1, "brightness": 128},
+            # invalid data
+            {"x_axis": "a", "y_axis": 0.1, "brightness": 128},
+            {"x_axis": 0.1, "y_axis": "a", "brightness": 128},
+            {"x_axis": 0.1, "y_axis": 0.1, "brightness": "a"},
+        ],
+    )
+    def test_dict_invalid(self, data):
+        """Test from_dict and as_dict methods."""
+        with pytest.raises(ValueError):
+            XYYColor.from_dict(data)
+
+
 class TestDPTColorXYY:
     """Test class for KNX xyY-color objects."""
 
     @pytest.mark.parametrize(
-        ("color", "brightness", "raw"),
+        ("value", "raw"),
         [
-            ((0, 0), 0, (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)),  # min values
-            ((1, 1), 255, (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)),  # max values
-            (None, 0, (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)),  # color None
-            ((0, 0), None, (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)),  # brightness None
-            (
-                None,
-                None,
-                (0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
-            ),  # color and brightness None
-            ((0.2, 0.2), 128, (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)),
-            ((0.8, 0.8), 204, (0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03)),
+            (XYYColor((0, 0), 0), (0x00, 0x00, 0x00, 0x00, 0x00, 0x03)),  # min values
+            (XYYColor((1, 1), 255), (0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x03)),  # max values
+            (XYYColor(None, 0), (0x00, 0x00, 0x00, 0x00, 0x00, 0x01)),  # color None
+            (XYYColor((0, 0), None), (0x00, 0x00, 0x00, 0x00, 0x00, 0x02)),
+            (XYYColor(None, None), (0x00, 0x00, 0x00, 0x00, 0x00, 0x00)),
+            (XYYColor((0.2, 0.2), 128), (0x33, 0x33, 0x33, 0x33, 0x80, 0x03)),
+            (XYYColor((0.8, 0.8), 204), (0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0x03)),
         ],
     )
-    def test_xyycolor_value(self, color, brightness, raw):
+    def test_xyycolor_value(self, value, raw):
         """Test DPTColorXYY parsing and streaming."""
-        value = XYYColor(color=color, brightness=brightness)
         knx_value = DPTColorXYY.to_knx(value)
         assert knx_value == DPTArray(raw)
         assert DPTColorXYY.from_knx(knx_value) == value
+
+    @pytest.mark.parametrize(
+        ("value", "raw"),
+        [
+            (
+                {"x_axis": 0.2, "y_axis": 0.2, "brightness": 128},
+                (0x33, 0x33, 0x33, 0x33, 0x80, 0x03),
+            ),
+            (
+                {"x_axis": 0.8, "y_axis": 0.8},
+                (0xCC, 0xCC, 0xCC, 0xCC, 0x00, 0x02),
+            ),
+        ],
+    )
+    def test_xyycolor_to_knx_from_dict(self, value, raw):
+        """Test DPTColorXYY parsing from a dict."""
+        knx_value = DPTColorXYY.to_knx(value)
+        assert knx_value == DPTArray(raw)
 
     @pytest.mark.parametrize(
         ("color", "brightness"),

--- a/test/dpt_tests/dpt_color_test.py
+++ b/test/dpt_tests/dpt_color_test.py
@@ -17,6 +17,10 @@ class TestXYYColor:
             {"x_axis": 0.9, "y_axis": 0.8},
             {"brightness": 50},
             {},
+            {"x_axis": None, "y_axis": None, "brightness": 255},
+            {"x_axis": 0.5, "y_axis": 0.5, "brightness": None},
+            {"x_axis": None, "brightness": 255},
+            {"y_axis": None, "brightness": 255},
         ],
     )
     def test_dict(self, data):

--- a/test/remote_value_tests/remote_value_color_xyy_test.py
+++ b/test/remote_value_tests/remote_value_color_xyy_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from xknx import XKNX
 from xknx.dpt import DPTArray, DPTBinary
+from xknx.dpt.dpt_color import XYYColor
 from xknx.exceptions import ConversionError
 from xknx.remote_value import RemoteValueColorXYY
 from xknx.telegram import GroupAddress, Telegram
@@ -17,10 +18,10 @@ class TestRemoteValueColorXYY:
         """Test to_knx function with normal operation."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx)
-        assert remote_value.to_knx(((1, 0.9), 102)) == DPTArray(
+        assert remote_value.to_knx(XYYColor((1, 0.9), 102)) == DPTArray(
             (0xFF, 0xFF, 0xE6, 0x66, 0x66, 0x03)
         )
-        assert remote_value.to_knx(((1, 0), 102)) == DPTArray(
+        assert remote_value.to_knx(XYYColor((1, 0), 102)) == DPTArray(
             (0xFF, 0xFF, 0x00, 0x00, 0x66, 0x03)
         )
 
@@ -30,37 +31,37 @@ class TestRemoteValueColorXYY:
         remote_value = RemoteValueColorXYY(xknx)
         assert remote_value.from_knx(
             DPTArray((0x99, 0x99, 0x99, 0x99, 0x66, 0x03))
-        ) == ((0.6, 0.6), 102)
+        ) == XYYColor((0.6, 0.6), 102)
 
     def test_to_knx_error(self):
         """Test to_knx function with wrong parametern."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx)
         with pytest.raises(ConversionError):
-            remote_value.to_knx(((2, 1), 1))
+            remote_value.to_knx(XYYColor((2, 1), 1))
         with pytest.raises(ConversionError):
-            remote_value.to_knx(((-1, 1), 2))
+            remote_value.to_knx(XYYColor((-1, 1), 2))
         with pytest.raises(ConversionError):
-            remote_value.to_knx(((0.3, 0.5), 256))
+            remote_value.to_knx(XYYColor((0.3, 0.5), 256))
         with pytest.raises(ConversionError):
-            remote_value.to_knx((("0.4", 0), 102))
+            remote_value.to_knx(XYYColor(("0.4", 0), 102))
         with pytest.raises(ConversionError):
-            remote_value.to_knx(((1, 1), "102"))
+            remote_value.to_knx(XYYColor((1, 1), "102"))
         with pytest.raises(ConversionError):
-            remote_value.to_knx(((1,), 1))
+            remote_value.to_knx(XYYColor((1,), 1))
 
     async def test_set(self):
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(((1, 0.9), 102))
+        await remote_value.set(XYYColor((1, 0.9), 102))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0xFF, 0xFF, 0xE6, 0x66, 0x66, 0x03))),
         )
-        await remote_value.set(((1, 0.9), 255))
+        await remote_value.set(XYYColor((1, 0.9), 255))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -77,7 +78,7 @@ class TestRemoteValueColorXYY:
             payload=GroupValueWrite(DPTArray((0xFF, 0xFF, 0x66, 0x66, 0xFA, 0x03))),
         )
         await remote_value.process(telegram)
-        assert remote_value.value == ((1, 0.4), 250)
+        assert remote_value.value == XYYColor((1, 0.4), 250)
 
     async def test_to_process_error(self):
         """Test process erroneous telegram."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -552,7 +552,8 @@ class Light(Device):
         if new_xyy is None or self._xyy_color_valid is None:
             self._xyy_color_valid = new_xyy
         else:
-            new_color, new_brightness = new_xyy
+            new_color = new_xyy.color
+            new_brightness = new_xyy.brightness
             if new_color is None:
                 new_color = self._xyy_color_valid.color
             if new_brightness is None:

--- a/xknx/dpt/dpt_color.py
+++ b/xknx/dpt/dpt_color.py
@@ -26,19 +26,19 @@ class XYYColor(DPTComplexData):
     def from_dict(cls, data: Mapping[str, Any]) -> XYYColor:
         """Init from a dictionary."""
         color = None
-        brightness = None
+        brightness = data.get("brightness")
+        x_axis = data.get("x_axis")
+        y_axis = data.get("y_axis")
 
-        if (x_axis := data.get("x_axis")) is not None and (
-            (y_axis := data.get("y_axis")) is not None
-        ):
+        if x_axis is not None and y_axis is not None:
             try:
                 color = (float(x_axis), float(y_axis))
             except ValueError as err:
                 raise ValueError(f"Invalid value for color axis: {err}") from err
-        elif ("x_axis" in data) or ("y_axis" in data):
+        elif x_axis is not None or y_axis is not None:
             raise ValueError("Both x_axis and y_axis must be provided")
 
-        if (brightness := data.get("brightness")) is not None:
+        if brightness is not None:
             try:
                 brightness = int(brightness)
             except ValueError as err:

--- a/xknx/dpt/dpt_color.py
+++ b/xknx/dpt/dpt_color.py
@@ -35,6 +35,9 @@ class XYYColor(DPTComplexData):
                 color = (float(x_axis), float(y_axis))
             except ValueError as err:
                 raise ValueError(f"Invalid value for color axis: {err}") from err
+        elif ("x_axis" in data) or ("y_axis" in data):
+            raise ValueError("Both x_axis and y_axis must be provided")
+
         if (brightness := data.get("brightness")) is not None:
             try:
                 brightness = int(brightness)

--- a/xknx/dpt/dpt_color.py
+++ b/xknx/dpt/dpt_color.py
@@ -61,6 +61,9 @@ class DPTColorXYY(DPTComplex[XYYColor]):
     data_type = XYYColor
     payload_type = DPTArray
     payload_length = 6
+    dpt_main_number = 242
+    dpt_sub_number = 600
+    value_type = "color_xyy"
 
     @classmethod
     def from_knx(cls, payload: DPTArray | DPTBinary) -> XYYColor:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Use Dataclasses as container for complex DPT values.
Resulting dataclasses can be converted to and from a dict with DPT specific properties to be JSON compatible.

As an example `XYYColor` is migrated in this PR.

Pros (compared to TypedDict):

- properly typed, any type supported
- default values supported
- lightweight (in py3.10 we can even set it `slots=True`)
- useable with data validation libraries - maybe outsource dict / json serialisation to external library or just use `__post_init__` to move validation to the dataclass if needed
- decoupled internal data schema (for use in xknx Devices) from user-visible (HA events etc.)

Cons:

- extra conversion step needed to get from user input (dict / json) to data
- extra step needed to get displayable data (eg. for group monitor) - `.as_dict()` is implemented for this. This is directly compatible with current HA json encoder https://github.com/home-assistant/core/blob/6a10e89f6de73623711d8add796864e29fa34c6d/homeassistant/helpers/json.py#L38 
- extra documentation effort required

Closes #1453

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)