### PR TITLE
Fix conversion of rounded negative zero values to DPT 9

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ nav_order: 2
 
 # Changelog
 
+# Unreleased changes
+
+### Bugfixes
+
+- Fix DPT 9 handling of values < `0` and >= `-0.005`. These are now rounded to `0` instead of being sent as `-20.48`.
+
 # 2.11.1 DateTime fix 2023-06-26
 
 ### Bugfixes

--- a/test/dpt_tests/dpt_float_test.py
+++ b/test/dpt_tests/dpt_float_test.py
@@ -46,6 +46,24 @@ class TestDPTFloat:
         assert DPT2ByteFloat.to_knx(0.00) == DPTArray((0x00, 0x00))
         assert DPT2ByteFloat.from_knx(DPTArray((0x00, 0x00))) == 0.00
 
+    def test_near_zero_value(self):
+        """Test parsing and streaming of DPT2ByteFloat near zero value."""
+        assert DPT2ByteFloat.to_knx(0.0002) == DPTArray((0x00, 0x00))
+        assert DPT2ByteFloat.to_knx(0.005) == DPTArray((0x00, 0x00))
+        assert DPT2ByteFloat.to_knx(0.00501) == DPTArray((0x00, 0x01))
+
+        assert DPT2ByteFloat.to_knx(-0.0) == DPTArray((0x00, 0x00))
+        # ETS would convert values < 0 and >= -0.005 to 0x8000
+        # which is equivalent to -20.48 so we handle this differently
+        assert DPT2ByteFloat.to_knx(-0.0002) == DPTArray((0x00, 0x00))
+        assert DPT2ByteFloat.to_knx(-0.005) == DPTArray((0x00, 0x00))
+        assert DPT2ByteFloat.to_knx(-0.00501) == DPTArray(
+            (0x87, 0xFF)
+        )  # this is ETS-conform again
+
+        assert DPT2ByteFloat.from_knx(DPTArray((0x00, 0x01))) == 0.01
+        assert DPT2ByteFloat.from_knx(DPTArray((0x87, 0xFF))) == -0.01
+
     def test_room_temperature(self):
         """Test parsing and streaming of DPT2ByteFloat 21.00. Room temperature."""
         assert DPT2ByteFloat.to_knx(21.00) == DPTArray((0x0C, 0x1A))


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
We did handle converting values near 0 to DPT 9 just like ETS.
ETS would convert values < 0 and >= -0.005 to `0x8000` which is equivalent to `-20.48`. 
These values are now rounded to 0.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)