### PR TITLE
Use ruff isort plugin instead of isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,12 @@ repos:
     hooks:
       - id: flake8
         files: ^(xknx|examples|docs)/.+\.py$
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        args:
-          - --resolve-all-configs
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    # Ruff version.
     rev: 'v0.0.292'
     hooks:
       - id: ruff
+        # in CI it is directly run by tox to allow dependency upgrade checks
+        stages: [pre-commit]
         args: [ --fix, --exit-non-zero-on-fix ]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - Parse `project_name` from an ETS Keyring.
 
+### Internal
+
+- Use ruff isort plugin, remove isort from requirements.
+
 # 2.11.2 DPT 9 small negative fix 2023-07-24
 
 ### Bugfixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ version = {attr = "xknx.__version__.__version__"}
 include = ["xknx*"]
 
 [tool.black]
-target-version = ["py39", "py310", "py311", "py312"]
 exclude = "generated"
 
 
@@ -50,13 +49,6 @@ exclude = "generated"
 skip = '*.min.js,docs/config-converter/lib/*,*.lock'
 ignore-words-list = 'hass'
 quiet-level = 2
-
-
-[tool.isort]
-profile = "black"
-# will group `import x` and `from x import` of the same module.
-force_sort_within_sections = true
-combine_as_imports = true
 
 
 [tool.mypy]
@@ -142,6 +134,7 @@ select = [
   "D",   # pydocstyle
   "E",   # pycodestyle
   "F",   # pyflakes
+  "I",   # isort
   "RUF", # ruff specific
   "T20", # print
   "UP",  # pyupgrade
@@ -156,6 +149,10 @@ ignore = [
 extend-exclude = [
   "script",
 ]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+combine-as-imports = true
 
 [tool.ruff.per-file-ignores]
 "examples/*" = ["T20"]  # print-used

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -9,4 +9,5 @@ pytest-icdiff==0.8
 ruff==0.1.3
 setuptools==68.2.2
 tox==4.11.3
+tox-gh-actions==3.1.3
 mypy==1.6.1

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,6 +1,5 @@
 -r production.txt
 pre-commit==3.5.0
-isort==5.12.0
 flake8==6.1.0
 pylint==3.0.2
 pytest==7.4.3

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,13 @@
 envlist = py39, py310, py311, py312, ruff, typing, lint, pylint
 skip_missing_interpreters = True
 
+[gh-actions]
+python =
+    3.9: py39
+    3.10: py310
+    3.11: py310, ruff, typing, lint, pylint
+    3.12: py312
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, typing, lint, pylint
+envlist = py39, py310, py311, py312, ruff, typing, lint, pylint
 skip_missing_interpreters = True
 
 [testenv]
@@ -14,20 +14,23 @@ wheel_build_env = .pkg
 [testenv:lint]
 basepython = python3
 commands =
-    ruff check {posargs:.}
     pre-commit run codespell {posargs: --all-files}
     pre-commit run flake8 {posargs: --all-files}
     pre-commit run pyupgrade {posargs: --all-files}
     pre-commit run black {posargs: --all-files}
-    pre-commit run isort {posargs: --all-files}
     pre-commit run check-json {posargs: --all-files}
     pre-commit run trailing-whitespace {posargs: --all-files}
 
 [testenv:pylint]
 basepython = python3
 commands =
-     pylint --jobs=0 xknx examples
-     pylint --jobs=0 --disable=protected-access,abstract-class-instantiated test
+    pylint --jobs=0 xknx examples
+    pylint --jobs=0 --disable=protected-access,abstract-class-instantiated test
+
+[testenv:ruff]
+basepython = python3
+commands =
+    ruff check {posargs:.}
 
 [testenv:typing]
 basepython = python3


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Use ruff isort plugin instead of isort
- Move ruff to separate tox env (so dependabot updates can trigger a run - which doesn't work for `update pre-commit hooks` script)
- Run ruff in pre-commit only on `pre-commit`
- Remove isort from requirements
- Remove black `target_version` as it is now inferred from `project.requires-python`
- Only run tests for specified python version, only lint in one CI runner

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)