### PR TITLE
`management.send_broadcast` accept APCI instead of Telegram

### DIFF
--- a/xknx/management/management.py
+++ b/xknx/management/management.py
@@ -14,7 +14,7 @@ from xknx.exceptions import (
     ManagementConnectionRefused,
     ManagementConnectionTimeout,
 )
-from xknx.telegram import IndividualAddress, Telegram
+from xknx.telegram import GroupAddress, IndividualAddress, Telegram
 from xknx.telegram.apci import APCI
 from xknx.telegram.tpci import (
     TAck,
@@ -128,15 +128,15 @@ class Management:
         finally:
             await self.disconnect(address)
 
-    async def send_broadcast(self, telegram: Telegram) -> None:
+    async def send_broadcast(self, payload: APCI) -> None:
         """Send a broadcast message."""
-
-        if isinstance(telegram.tpci, TDataBroadcast):
-            await self.xknx.cemi_handler.send_telegram(telegram)
-        else:
-            raise TypeError(
-                f"Can only send broadcast telegrams, not {type(telegram.tpci)}."
+        await self.xknx.cemi_handler.send_telegram(
+            Telegram(
+                GroupAddress("0/0/0"),
+                tpci=TDataBroadcast(),
+                payload=payload,
             )
+        )
 
     @asynccontextmanager
     async def broadcast(self) -> AsyncIterator[BroadcastContext]:

--- a/xknx/management/procedures.py
+++ b/xknx/management/procedures.py
@@ -11,7 +11,6 @@ from xknx.exceptions import (
 )
 from xknx.telegram import Telegram, apci, tpci
 from xknx.telegram.address import (
-    GroupAddress,
     IndividualAddress,
     IndividualAddressableType,
 )
@@ -93,10 +92,7 @@ async def nm_individual_address_read(
     addresses = []
     # initialize queue or event handler gathering broadcasts
     async with xknx.management.broadcast() as bc_context:
-        broadcast_telegram = Telegram(
-            GroupAddress("0/0/0"), payload=apci.IndividualAddressRead()
-        )
-        await xknx.management.send_broadcast(broadcast_telegram)
+        await xknx.management.send_broadcast(apci.IndividualAddressRead())
         async for result in bc_context.receive(timeout=timeout):
             if isinstance(result.payload, apci.IndividualAddressResponse):
                 addresses.append(result.source_address)
@@ -149,10 +145,7 @@ async def nm_invididual_address_write(
         logger.debug("Device already has requested address, no write operation needed.")
     else:
         await xknx.management.send_broadcast(
-            Telegram(
-                GroupAddress("0/0/0"),
-                payload=apci.IndividualAddressWrite(address=individual_address),
-            )
+            payload=apci.IndividualAddressWrite(address=individual_address),
         )
         logger.debug("Wrote new address %s to device.", individual_address)
 
@@ -193,12 +186,9 @@ async def nm_individual_address_serial_number_read(
 
     # initialize queue or event handler gathering broadcasts
     async with xknx.management.broadcast() as bc_context:
-        broadcast_telegram = Telegram(
-            destination_address=GroupAddress("0/0/0"),
-            source_address=xknx.current_address,
-            payload=apci.IndividualAddressSerialRead(serial=serial),
+        await xknx.management.send_broadcast(
+            payload=apci.IndividualAddressSerialRead(serial=serial)
         )
-        await xknx.management.send_broadcast(broadcast_telegram)
         async for result in bc_context.receive(timeout=timeout):
             if (
                 isinstance(result.payload, apci.IndividualAddressSerialResponse)
@@ -215,11 +205,9 @@ async def nm_individual_address_serial_number_write(
     """Write individual address to device with specified serial number."""
     individual_address = IndividualAddress(individual_address)
     await xknx.management.send_broadcast(
-        Telegram(
-            destination_address=GroupAddress("0/0/0"),
-            payload=apci.IndividualAddressSerialWrite(
-                address=individual_address, serial=serial
-            ),
+        payload=apci.IndividualAddressSerialWrite(
+            address=individual_address,
+            serial=serial,
         )
     )
     logger.debug(


### PR DESCRIPTION
It should only ever send broadcasts, so no need to check for `tpci.TDataBroadcast` internally and repeat `GroupAddress(0)` for every use since these is mandatory.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)