### PR TITLE
Fix mypy checks on Windows systems

### DIFF
--- a/xknx/io/transport/tcp_transport.py
+++ b/xknx/io/transport/tcp_transport.py
@@ -40,7 +40,7 @@ class TCPTransport(KNXIPTransport):
             # cryptography (eg. X25519PublicKey.from_public_bytes() in IP Secure handshake)
             # https://github.com/python/cpython/issues/99941
             try:
-                if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):  # type: ignore[attr-defined]
+                if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):  # type: ignore[attr-defined, unused-ignore] # unused-ignore for Windows
                     self.data_received_callback = lambda data: data_received_callback(
                         bytes(data)
                     )

--- a/xknx/io/transport/udp_transport.py
+++ b/xknx/io/transport/udp_transport.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import socket
-from sys import platform
+import sys
 from typing import Callable
 
 from xknx.exceptions import CommunicationError, CouldNotParseKNXIP
@@ -114,10 +114,10 @@ class UDPTransport(KNXIPTransport):
         )
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
 
-        if platform == "win32":
+        if sys.platform == "win32":
             # '' represents INADDR_ANY
             sock.bind(("", remote_addr[1]))
-        elif platform == "darwin":
+        elif sys.platform == "darwin":
             # allows multiple sockets to the same port by multiple processes
             # behaves like SO_REUSEADDR for bind for INADDR_ANY
             # (GatewayScanner opens multiple sockets)


### PR DESCRIPTION
Mypy on Win32 gave some errors. With the added Code mypy shows no Errors. (Thanks to Farmio)

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Fixes Errors on mypy win32 System:

xknx\io\transport\udp_transport.py:124: error: Module has no attribute "SO_REUSEPORT"  [attr-defined]
                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)

and

xknx\io\transport\tcp_transport.py:43: error: Unused "type: ignore" comment  [unused-ignore]
                    if isinstance(asyncio.get_event_loop(), asyncio.ProactorEventLoop):  # type: ignore[attr-defined]



## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)