### PR TITLE
Parse DPT transcoders by dictionaries with "main" and "sub" keys

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ nav_order: 2
   - 235.001 - DPTTariffActiveEnergy - TariffActiveEnergy
   - 242.600 - DPTColorXYY - XYYColor
   - 251.600 - DPTColorRGBW - RGBWColor
+- Support dict values with "main" and "sub" keys for `DPTBase.parse_transcoder()`
 
 # 2.12.2 Fix thread leak 2024-03-05
 

--- a/test/dpt_tests/dpt_test.py
+++ b/test/dpt_tests/dpt_test.py
@@ -67,10 +67,10 @@ class TestDPTBase:
     @pytest.mark.parametrize(
         "equal_dpts",
         [
-            # strings in sequences would fail type checking, but should work nevertheless
-            ["2byte_unsigned", 7, "DPT-7", [7], ["7", None], (7,), (7, None)],
-            ["temperature", "9.001", [9, 1], (9, 1), ("9", "1")],
-            ["active_energy", "13.010", [13, 10], (13, 10), ["13", "10"]],
+            # strings in dictionaries would fail type checking, but should work nevertheless
+            ["2byte_unsigned", 7, "DPT-7", {"main": 7}, {"main": "7", "sub": None}],
+            ["temperature", "9.001", {"main": 9, "sub": 1}, {"main": "9", "sub": "1"}],
+            ["active_energy", "13.010", {"main": 13, "sub": 10}],
         ],
     )
     def test_dpt_alternative_notations(self, equal_dpts: list[Any]):
@@ -92,6 +92,26 @@ class TestDPTBase:
         assert DPTBase.parse_transcoder("temperature") == DPTTemperature
         assert DPTNumeric.parse_transcoder("temperature") == DPTTemperature
         assert DPT2ByteFloat.parse_transcoder("temperature") == DPTTemperature
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            0,
+            999999999,
+            9.001,  # float is not valid
+            "invalid_string",
+            {"sub": 1},
+            {"main": None, "sub": None},
+            {"main": "invalid"},
+            {"main": 9, "sub": "invalid"},
+            [9, 1],
+            (9,),
+        ],
+    )
+    def test_parse_transcoder_invalid_data(self, value: Any):
+        """Test parsing invalid data."""
+        assert DPTBase.parse_transcoder(value) is None
 
 
 class TestDPTBaseSubclass:

--- a/test/dpt_tests/dpt_test.py
+++ b/test/dpt_tests/dpt_test.py
@@ -1,5 +1,7 @@
 """Unit test for KNX binary/integer objects."""
 
+from typing import Any
+
 import pytest
 
 from xknx.dpt import (
@@ -62,19 +64,20 @@ class TestDPTBase:
         ]
         assert len(dpt_tuples) == len(set(dpt_tuples))
 
-    def test_dpt_alternative_notations(self):
-        """Test the parser for accepting alternateive notations for the same DPT class."""
-        dpt1 = DPTBase.parse_transcoder("2byte_unsigned")
-        dpt2 = DPTBase.parse_transcoder(7)
-        dpt3 = DPTBase.parse_transcoder("DPT-7")
-        assert dpt1 == dpt2
-        assert dpt2 == dpt3
-        dpt4 = DPTBase.parse_transcoder("temperature")
-        dpt5 = DPTBase.parse_transcoder("9.001")
-        assert dpt4 == dpt5
-        dpt7 = DPTBase.parse_transcoder("active_energy")
-        dpt8 = DPTBase.parse_transcoder("13.010")
-        assert dpt7 == dpt8
+    @pytest.mark.parametrize(
+        "equal_dpts",
+        [
+            # strings in sequences would fail type checking, but should work nevertheless
+            ["2byte_unsigned", 7, "DPT-7", [7], ["7", None], (7,), (7, None)],
+            ["temperature", "9.001", [9, 1], (9, 1), ("9", "1")],
+            ["active_energy", "13.010", [13, 10], (13, 10), ["13", "10"]],
+        ],
+    )
+    def test_dpt_alternative_notations(self, equal_dpts: list[Any]):
+        """Test the parser for accepting alternative notations for the same DPT class."""
+        parsed = [DPTBase.parse_transcoder(dpt) for dpt in equal_dpts]
+        assert issubclass(parsed[0], DPTBase)
+        assert all(parsed[0] == dpt for dpt in parsed)
 
     def test_parse_transcoder_from_subclass(self):
         """Test parsing only subclasses of a DPT class."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Dict data in `DPTBase.parse_transcoder()`s `value_type` parameter is supported in the following format:
```json
{"main": 9, "sub": 1}
```
xknxproject data can be used like this
```py
data: KNXProject
ga_types: dict[str, type[DPTBase] | None]
ga_types = {
    ga["address"]: DPTBase.parse_transcoder(ga["dpt"])
    for ga in data["group_addresses"].values()
}
```

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)