### PR TITLE
Remove auto-adding device instances to `xknx.devices`

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -29,6 +29,7 @@ The logic within switches can further handle if a button is pressed once or twic
 
 ```python
 binarysensor = BinarySensor(xknx, 'TestInput', group_address_state='2/3/4')
+xknx.devices.async_add(binarysensor)
 
 # Returns the last received Telegram or None
 binarysensor.last_telegram

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,11 @@ nav_order: 2
 
 - Drop support for Python 3.9
 
+### Devices
+
+- A Device doesn't auto-add to `xknx.devices` anymore. It can be done via `xknx.devices.async_add()` now. `xknx.devices.async_remove` stops a device from processing telegrams, removes from StateUpdater and cancels its internal tasks. Removed devices can be added again.
+- `Device.shutdown` method is removed
+
 ### DPT
 
 - DPTComplex: Common interface for DPT transcoders with multi-value data. Resulting dataclasses can be converted to and from a dict with DPT specific properties to be JSON compatible.

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -53,39 +53,44 @@ Climate are representations of KNX HVAC/Climate controls.
 If only a subset of operation modes shall be used a list of supported modes may be passed to `operation_modes`.
 
 ```python
-climate_mode = ClimateMode(xknx,
-                 'TestClimateMode',
-                 group_address_operation_mode='',
-                 group_address_operation_mode_state='',
-                 group_address_operation_mode_protection=None,
-                 group_address_operation_mode_night=None,
-                 group_address_operation_mode_comfort=None,
-                 group_address_controller_status=None,
-                 group_address_controller_status_state=None,
-                 group_address_controller_mode=None,
-                 group_address_controller_mode_state=None,
-                 operation_modes=None,
-                 controller_modes=None,
-                 device_updated_cb=None)
+climate_mode = ClimateMode(
+    xknx,
+    'TestClimateMode',
+    group_address_operation_mode='',
+    group_address_operation_mode_state='',
+    group_address_operation_mode_protection=None,
+    group_address_operation_mode_night=None,
+    group_address_operation_mode_comfort=None,
+    group_address_controller_status=None,
+    group_address_controller_status_state=None,
+    group_address_controller_mode=None,
+    group_address_controller_mode_state=None,
+    operation_modes=None,
+    controller_modes=None,
+    device_updated_cb=None,
+)
 
 climate = Climate(
-        xknx,
-        'TestClimate',
-        group_address_temperature='',
-        group_address_target_temperature='',
-        group_address_target_temperature_state='',
-        group_address_setpoint_shift='',
-        group_address_setpoint_shift_state='',
-        temperature_step=0.1,
-        setpoint_shift_max=6,
-        setpoint_shift_min=-6,
-        group_address_on_off='',
-        group_address_on_off_state='',
-        on_off_invert=False,
-        min_temp=18,
-        max_temp=26,
-        mode=climate_mode,
-        device_updated_cb=None)
+    xknx,
+    'TestClimate',
+    group_address_temperature='',
+    group_address_target_temperature='',
+    group_address_target_temperature_state='',
+    group_address_setpoint_shift='',
+    group_address_setpoint_shift_state='',
+    temperature_step=0.1,
+    setpoint_shift_max=6,
+    setpoint_shift_min=-6,
+    group_address_on_off='',
+    group_address_on_off_state='',
+    on_off_invert=False,
+    min_temp=18,
+    max_temp=26,
+    mode=climate_mode,
+    device_updated_cb=None,
+)
+xknx.devices.async_add(climate)
+xknx.devices.async_add(climate_mode)
 
 # Set target temperature to 23 degrees. Works with setpoint_shift too.
 await climate.set_target_temperature(23)

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -49,6 +49,7 @@ cover = Cover(
     invert_position=False,
     invert_angle=False,
 )
+xknx.devices.async_add(cover)
 
 # Moving to up position
 await cover.set_up()

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -10,7 +10,7 @@ has_children: true
 XKNX uses devices to separate different functionality in logical groups like lights, climate et al.
 They are also needed in order to provide support for the home assistant plugin.
 
-An instantiated device is automatically added to `xknx.devices`.
+An instantiated device can be added to `xknx.devices` to receive telegrams and start background tasks by calling `xknx.devices.async_add(device)`. It can be removed by calling `xknx.devices.async_remove(device)`.
 
 ## [](#header-2)Common public interface for all Device classes
 
@@ -23,7 +23,6 @@ An instantiated device is automatically added to `xknx.devices`.
 * `sync(wait_for_result)` Read states of device from KNX bus via GroupValueRead requests.
 * `register_device_updated_cb(device_updated_cb)` Register device updated callback.
 * `unregister_device_updated_cb(device_updated_cb)` Unregister device updated callback.
-* `shutdown()` Remove callbacks and device form Devices vector.
 
 ## [](#header-2)Example
 

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -36,6 +36,7 @@ fan = Fan(
     group_address_oscillation='1/2/3',
     group_address_oscillation_state='1/2/4'
 )
+xknx.devices.async_add(fan)
 
 # Set the fan speed
 await fan.set_speed(50)

--- a/docs/light.md
+++ b/docs/light.md
@@ -59,20 +59,23 @@ The Light object is either a representation of a binary or dimm actor, LED-contr
 ## [](#header-2)Example
 
 ```python
-light = Light(xknx,
-              name='TestLight',
-              group_address_switch='1/2/3',
-              group_address_switch_state='1/2/4',
-              group_address_brightness='1/2/5',
-              group_address_brightness_state='1/2/6',
-              group_address_color='1/2/7',
-              group_address_color_state='1/2/8',
-              group_address_rgbw='1/2/13',
-              group_address_rgbw_state='1/2/14',
-              group_address_tunable_white='1/2/9',
-              group_address_tunable_white_state='1/2/10',
-              group_address_color_temperature='1/2/11',
-              group_address_color_temperature_state='1/2/12')
+light = Light(
+    xknx,
+    name='TestLight',
+    group_address_switch='1/2/3',
+    group_address_switch_state='1/2/4',
+    group_address_brightness='1/2/5',
+    group_address_brightness_state='1/2/6',
+    group_address_color='1/2/7',
+    group_address_color_state='1/2/8',
+    group_address_rgbw='1/2/13',
+    group_address_rgbw_state='1/2/14',
+    group_address_tunable_white='1/2/9',
+    group_address_tunable_white_state='1/2/10',
+    group_address_color_temperature='1/2/11',
+    group_address_color_temperature_state='1/2/12'
+)
+xknx.devices.async_add(light)
 
 # Switching light on
 await light.set_on()
@@ -114,24 +117,27 @@ print(light.current_color_temperature)
 ## [](#header-2)Example: RGBW light with individual group addresses for red, green, blue and white
 
 ```python
-light = Light(xknx,
-              name='TestRGBWLight',
-              group_address_switch_red="1/1/1",
-              group_address_switch_red_state="1/1/2",
-              group_address_brightness_red="1/1/3",
-              group_address_brightness_red_state="1/1/4",
-              group_address_switch_green="1/1/5",
-              group_address_switch_green_state="1/1/6",
-              group_address_brightness_green="1/1/7",
-              group_address_brightness_green_state="1/1/8",
-              group_address_switch_blue="1/1/9",
-              group_address_switch_blue_state="1/1/10",
-              group_address_brightness_blue="1/1/11",
-              group_address_brightness_blue_state="1/1/12",
-              group_address_switch_white="1/1/13",
-              group_address_switch_white_state="1/1/14",
-              group_address_brightness_white="1/1/15",
-              group_address_brightness_white_state="1/1/16")
+light = Light(
+    xknx,
+    name='TestRGBWLight',
+    group_address_switch_red="1/1/1",
+    group_address_switch_red_state="1/1/2",
+    group_address_brightness_red="1/1/3",
+    group_address_brightness_red_state="1/1/4",
+    group_address_switch_green="1/1/5",
+    group_address_switch_green_state="1/1/6",
+    group_address_brightness_green="1/1/7",
+    group_address_brightness_green_state="1/1/8",
+    group_address_switch_blue="1/1/9",
+    group_address_switch_blue_state="1/1/10",
+    group_address_brightness_blue="1/1/11",
+    group_address_brightness_blue_state="1/1/12",
+    group_address_switch_white="1/1/13",
+    group_address_switch_white_state="1/1/14",
+    group_address_brightness_white="1/1/15",
+    group_address_brightness_white_state="1/1/16"
+)
+xknx.devices.async_add(light)
 
 # Switching light on
 await light.set_on()
@@ -174,6 +180,7 @@ light = Light(
     group_address_saturation="1/1/4",
     group_address_saturation_state="1/2/4",
 )
+xknx.devices.async_add(light)
 print(light.supports_brightness)
 print(light.supports_hs_color)
 

--- a/docs/numeric_value.md
+++ b/docs/numeric_value.md
@@ -33,6 +33,7 @@ value = NumericValue(
     respond_to_read=True,
     value_type='temperature'
 )
+xknx.devices.async_add(value)
 
 # Set a value without sending to the bus
 value.sensor_value.value = 23.0

--- a/docs/raw_value.md
+++ b/docs/raw_value.md
@@ -33,6 +33,7 @@ value = RawValue(
     group_address='6/2/1',
     respond_to_read=True,
 )
+xknx.devices.async_add(value)
 
 # Set a value without sending to the bus
 value.remote_value.value = 23.0

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -32,6 +32,7 @@ sensor = Sensor(
     sync_state=True,
     value_type='temperature'
 )
+xknx.devices.async_add(sensor)
 
 # Requesting current state via KNX GroupValueRead from the bus
 await sensor.sync(wait_for_result=True)

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -28,6 +28,7 @@ Switches are simple representations of binary actors. They mainly support switch
 
 ```python
 switch = Switch(xknx, 'TestOutlet', group_address='1/2/3')
+xknx.devices.async_add(switch)
 
 # Accessing switch via xknx.devices
 await xknx.devices['TestOutlet'].set_on()

--- a/docs/time.md
+++ b/docs/time.md
@@ -20,6 +20,7 @@ time_device = DateTime(
     broadcast_type='TIME',
     localtime=True
 )
+xknx.devices.async_add(time_device)
 
 # `sync()` doesn't send a GroupValueRead when localtime is True but sends the current time to KNX bus
 await xknx.devices['TimeTest'].sync()
@@ -44,6 +45,7 @@ from xknx.devices import DateTime
 async def main():
     async with XKNX(daemon_mode=True) as xknx:
         time = DateTime(xknx, 'TimeTest', group_address='1/2/3')
+        xknx.devices.async_add(time)
         print("Sending time to KNX bus every hour")
 
 asyncio.run(main())
@@ -51,13 +53,13 @@ asyncio.run(main())
 
 ## [](#header-2)Interface
 
-
 ```python
 from xknx import XKNX
 from xknx.devices import DateTime
 
 xknx = XKNX()
 time_device = DateTime(xknx, 'TimeTest', group_address='1/2/3', broadcast_type='time')
+xknx.devices.async_add(time_device)
 
 await xknx.start()
 # Sending Time to KNX bus

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -28,6 +28,7 @@ The weather device is basically a set of sensors that you can obtain from your w
             group_address_day_night='7/0/7',
             group_address_rain_alarm='7/0/0'
         )
+        xknx.devices.async_add(weather)
 
         await weather.sync(wait_for_result=True)
         print(weather)
@@ -67,6 +68,7 @@ The weather device is basically a set of sensors that you can obtain from your w
             group_address_day_night='7/0/7',
             group_address_rain_alarm='7/0/0'
         )
+        xknx.devices.async_add(weather)
 
         await weather.sync(wait_for_result=True)
 

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -105,7 +105,9 @@ async def main():
     async with XKNX() as xknx:
         switch = Switch(xknx,
                 name='TestSwitch',
-                group_address='1/1/11')
+                group_address='1/1/11'
+        )
+        xknx.devices.async_add(switch)
 
         await switch.set_on()
 
@@ -114,14 +116,18 @@ asyncio.run(main())
 
 # [](#header-2)Devices
 
-XKNX keeps all initialized devices in a local storage named `devices`. All devices may be accessed by their name: `xknx.devices['NameOfDevice']`. When an update via KNX GroupValueWrite or GroupValueResponse was received devices will be updated accordingly.
+To attach a device to XKNX call `xknx.devices.async_add(device)`. Added devices may be accessed by their name: `xknx.devices['NameOfDevice']`. When an update via KNX GroupValueWrite or GroupValueResponse was received devices will be updated accordingly.
+To remove a device from XKNX call `xknx.devices.async_remove(device)`. Removed devices can be re-added at a later point. This cancels background tasks of that device and disconnects it from receiving new telegrams.
 
 Example:
 
 ```python
-switch = Switch(xknx,
-                name='TestSwitch',
-                group_address='1/1/11')
+switch = Switch(
+    xknx,
+    name='TestSwitch',
+    group_address='1/1/11'
+)
+xknx.devices.async_add(switch)
 
 await xknx.devices['TestSwitch'].set_on()
 await xknx.devices['TestSwitch'].set_off()

--- a/examples/example_callback.py
+++ b/examples/example_callback.py
@@ -28,6 +28,7 @@ async def main() -> None:
         group_address_switch_state="1/0/45",
         device_updated_cb=light_callback,
     )
+    xknx.devices.async_add(light)
     # turn on light and listen for 10 seconds for changes
     await light.set_on()
     await asyncio.sleep(10)

--- a/examples/example_climate.py
+++ b/examples/example_climate.py
@@ -6,11 +6,12 @@ from xknx import XKNX
 from xknx.devices import Climate
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP and read the state of a Climate device."""
     xknx = XKNX()
     async with xknx:
         climate = Climate(xknx, "TestClimate", group_address_temperature="6/2/1")
+        xknx.devices.async_add(climate)
         await climate.sync(wait_for_result=True)
         # Will print out state of climate including current temperature:
         print(climate)

--- a/examples/example_daemon.py
+++ b/examples/example_daemon.py
@@ -3,19 +3,18 @@
 import asyncio
 
 from xknx import XKNX
-from xknx.devices import Switch
+from xknx.devices import Device, Switch
 
 
-async def device_updated_cb(device):
+async def device_updated_cb(device: Device) -> None:
     """Do something with the updated device."""
     print(f"Callback received from {device.name}")
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP device and listen if a switch was updated via KNX bus."""
     xknx = XKNX(device_updated_cb=device_updated_cb, daemon_mode=True)
-    Switch(xknx, name="TestOutlet", group_address="1/1/11")
-
+    xknx.devices.async_add(Switch(xknx, name="TestOutlet", group_address="1/1/11"))
     await xknx.start()
     # Wait until Ctrl-C was pressed
     await xknx.stop()

--- a/examples/example_datetime.py
+++ b/examples/example_datetime.py
@@ -6,10 +6,12 @@ from xknx import XKNX
 from xknx.devices import DateTime
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP device and broadcast time."""
     xknx = XKNX(daemon_mode=True)
-    DateTime(xknx, "TimeTest", group_address="1/2/3", broadcast_type="time")
+    xknx.devices.async_add(
+        DateTime(xknx, "TimeTest", group_address="1/2/3", broadcast_type="time")
+    )
     print("Sending time to KNX bus every hour")
     await xknx.start()
     await xknx.stop()

--- a/examples/example_devices.py
+++ b/examples/example_devices.py
@@ -6,11 +6,12 @@ from xknx import XKNX
 from xknx.devices import Switch
 
 
-async def main():
+async def main() -> None:
     """Add test Switch to devices storage and access it by name."""
     xknx = XKNX()
     await xknx.start()
-    Switch(xknx, name="TestOutlet", group_address="1/1/11")
+    switch = Switch(xknx, name="TestOutlet", group_address="1/1/11")
+    xknx.devices.async_add(switch)
 
     await xknx.devices["TestOutlet"].set_on()
     await asyncio.sleep(2)

--- a/examples/example_fan_percent_mode.py
+++ b/examples/example_fan_percent_mode.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Fan
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus, control a fan, and turn it off afterwards."""
     xknx = XKNX()
     await xknx.start()
@@ -18,6 +18,7 @@ async def main():
         group_address_speed="1/0/14",
         max_step=3,
     )
+    xknx.devices.async_add(fan)
 
     # Turn on the fan
     await fan.turn_on()

--- a/examples/example_fan_step_mode.py
+++ b/examples/example_fan_step_mode.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Fan
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus, control a fan, and turn it off afterwards."""
     xknx = XKNX()
     await xknx.start()
@@ -18,6 +18,7 @@ async def main():
         group_address_speed="1/0/14",
         max_step=3,
     )
+    xknx.devices.async_add(fan)
 
     # Turn on the fan
     await fan.turn_on()

--- a/examples/example_light_dimm.py
+++ b/examples/example_light_dimm.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Light
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus, slowly dimm on light, set it off again afterwards."""
     xknx = XKNX()
     await xknx.start()
@@ -17,6 +17,7 @@ async def main():
         group_address_switch="1/0/12",
         group_address_brightness="1/0/14",
     )
+    xknx.devices.async_add(light)
 
     for i in [0, 31, 63, 95, 127, 159, 191, 223, 255]:
         await light.set_brightness(i)

--- a/examples/example_light_state.py
+++ b/examples/example_light_state.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Light
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus and read the state of a Light device."""
     async with XKNX() as xknx:
         light = Light(
@@ -15,6 +15,8 @@ async def main():
             group_address_switch="1/0/12",
             group_address_brightness="1/0/14",
         )
+        xknx.devices.async_add(light)
+
         await light.set_brightness(80)
         # Will do a GroupValueRead for both addresses and block until a result is received
         await light.sync(wait_for_result=True)

--- a/examples/example_light_switch.py
+++ b/examples/example_light_switch.py
@@ -6,11 +6,13 @@ from xknx import XKNX
 from xknx.devices import Light
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus, switch on light, wait 2 seconds and switch of off again."""
     xknx = XKNX()
     await xknx.start()
     light = Light(xknx, name="TestLight", group_address_switch="1/0/9")
+    xknx.devices.async_add(light)
+
     await light.set_on()
     await asyncio.sleep(2)
     await light.set_off()

--- a/examples/example_scene.py
+++ b/examples/example_scene.py
@@ -6,13 +6,13 @@ from xknx import XKNX
 from xknx.devices import Scene
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP bus and run scene."""
-    xknx = XKNX()
-    await xknx.start()
-    scene = Scene(xknx, name="Romantic", group_address="7/0/9", scene_number=23)
-    await scene.run()
-    await xknx.stop()
+    async with XKNX() as xknx:
+        scene = Scene(xknx, name="Romantic", group_address="7/0/9", scene_number=23)
+        xknx.devices.async_add(scene)
+
+        await scene.run()
 
 
 asyncio.run(main())

--- a/examples/example_sensor.py
+++ b/examples/example_sensor.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import BinarySensor, Sensor
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP device and read the value of a temperature and a motion sensor."""
     xknx = XKNX()
     await xknx.start()
@@ -16,6 +16,7 @@ async def main():
         "DiningRoom.Motion.Sensor",
         group_address_state="6/0/2",
     )
+    xknx.devices.async_add(sensor1)
     await sensor1.sync(wait_for_result=True)
     print(sensor1)
 
@@ -25,6 +26,7 @@ async def main():
         group_address_state="6/2/1",
         value_type="temperature",
     )
+    xknx.devices.async_add(sensor2)
 
     await sensor2.sync(wait_for_result=True)
     print(sensor2)

--- a/examples/example_switch.py
+++ b/examples/example_switch.py
@@ -6,11 +6,12 @@ from xknx import XKNX
 from xknx.devices import Switch
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP device, switch on outlet, wait 2 seconds and switch of off again."""
     xknx = XKNX()
     await xknx.start()
     switch = Switch(xknx, name="TestOutlet", group_address="1/1/11")
+    xknx.devices.async_add(switch)
     await switch.set_on()
     await asyncio.sleep(2)
     await switch.set_off()

--- a/examples/example_weather.py
+++ b/examples/example_weather.py
@@ -9,7 +9,7 @@ from xknx.devices import Weather
 logging.basicConfig(level=logging.WARNING)
 
 
-async def main():
+async def main() -> None:
     """Connect to KNX/IP device and create a weather device and read its sensors."""
     xknx = XKNX()
     await xknx.start()
@@ -26,6 +26,7 @@ async def main():
         group_address_day_night="7/0/7",
         group_address_rain_alarm="7/0/0",
     )
+    xknx.devices.async_add(weather)
 
     await weather.sync(wait_for_result=True)
     print(weather.max_brightness)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,11 @@
 """Conftest for XKNX."""
 
 import asyncio
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
+from xknx import XKNX
 
 
 class EventLoopClockAdvancer:
@@ -49,3 +52,19 @@ class EventLoopClockAdvancer:
 def time_travel(event_loop: asyncio.AbstractEventLoop) -> EventLoopClockAdvancer:
     """Advance loop time and run callbacks."""
     return EventLoopClockAdvancer(event_loop)
+
+
+@pytest.fixture
+def xknx_no_interface():
+    """Return XKNX instance without KNX/IP interface."""
+
+    def knx_ip_interface_mock():
+        """Create a xknx knx ip interface mock."""
+        mock = Mock()
+        mock.start = AsyncMock()
+        mock.stop = AsyncMock()
+        mock.send_cemi = AsyncMock()
+        return mock
+
+    with patch("xknx.xknx.knx_interface_factory", return_value=knx_ip_interface_mock()):
+        return XKNX()

--- a/test/devices_tests/datetime_test.py
+++ b/test/devices_tests/datetime_test.py
@@ -13,11 +13,6 @@ from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWri
 class TestDateTime:
     """Test class for DateTime object."""
 
-    # pylint: disable=attribute-defined-outside-init
-    def teardown_method(self):
-        """Cancel broadcast_task."""
-        self.datetime.__del__()
-
     #
     # SET Time
     #

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.devices import BinarySensor, Device, Devices, Light, Switch
+from xknx.devices import BinarySensor, Device, Light, Switch
 from xknx.telegram import GroupAddress
 
 
@@ -19,9 +19,13 @@ class TestDevices:
         """Test get item by name or by index."""
         xknx = XKNX()
         light1 = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        xknx.devices.async_add(light1)
         switch1 = Switch(xknx, "TestOutlet_1", group_address="1/2/3")
+        xknx.devices.async_add(switch1)
         light2 = Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
+        xknx.devices.async_add(light2)
         switch2 = Switch(xknx, "TestOutlet_2", group_address="1/2/4")
+        xknx.devices.async_add(switch2)
 
         assert xknx.devices["Living-Room.Light_1"] == light1
         assert xknx.devices["TestOutlet_1"] == switch1
@@ -42,24 +46,23 @@ class TestDevices:
     def test_device_by_group_address(self):
         """Test get devices by group address."""
         xknx = XKNX()
-        devices = Devices()
 
         light1 = Light(xknx, "Livingroom", group_address_switch="1/6/7")
         sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
         sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
         light2 = Light(xknx, "Livingroom", group_address_switch="1/6/8")
-        devices.add(light1)
-        devices.add(sensor1)
-        devices.add(sensor2)
-        devices.add(light2)
+        xknx.devices.async_add(light1)
+        xknx.devices.async_add(sensor1)
+        xknx.devices.async_add(sensor2)
+        xknx.devices.async_add(light2)
 
-        assert tuple(devices.devices_by_group_address(GroupAddress("1/6/7"))) == (
+        assert tuple(xknx.devices.devices_by_group_address(GroupAddress("1/6/7"))) == (
             light1,
         )
-        assert tuple(devices.devices_by_group_address(GroupAddress("1/6/8"))) == (
+        assert tuple(xknx.devices.devices_by_group_address(GroupAddress("1/6/8"))) == (
             light2,
         )
-        assert tuple(devices.devices_by_group_address(GroupAddress("3/0/1"))) == (
+        assert tuple(xknx.devices.devices_by_group_address(GroupAddress("3/0/1"))) == (
             sensor1,
             sensor2,
         )
@@ -67,41 +70,48 @@ class TestDevices:
     def test_iter(self):
         """Test __iter__() function."""
         xknx = XKNX()
-        devices = Devices()
 
         light1 = Light(xknx, "Livingroom", group_address_switch="1/6/7")
         sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
         sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
         light2 = Light(xknx, "Livingroom", group_address_switch="1/6/8")
-        devices.add(light1)
-        devices.add(sensor1)
-        devices.add(sensor2)
-        devices.add(light2)
+        xknx.devices.async_add(light1)
+        xknx.devices.async_add(sensor1)
+        xknx.devices.async_add(sensor2)
+        xknx.devices.async_add(light2)
 
-        assert tuple(devices.__iter__()) == (light1, sensor1, sensor2, light2)
+        assert tuple(xknx.devices.__iter__()) == (light1, sensor1, sensor2, light2)
 
     def test_len(self):
         """Test len() function."""
         xknx = XKNX()
         assert len(xknx.devices) == 0
 
-        Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        light = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        xknx.devices.async_add(light)
         assert len(xknx.devices) == 1
 
-        BinarySensor(xknx, "DiningRoom.Motion.Sensor", group_address_state="3/0/1")
+        binary_sensor = BinarySensor(
+            xknx, "DiningRoom.Motion.Sensor", group_address_state="3/0/1"
+        )
+        xknx.devices.async_add(binary_sensor)
         assert len(xknx.devices) == 2
 
-        BinarySensor(xknx, "DiningRoom.Motion.Sensor", group_address_state="3/0/1")
-        assert len(xknx.devices) == 3
+        xknx.devices.async_remove(light)
+        assert len(xknx.devices) == 1
 
-        Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
-        assert len(xknx.devices) == 4
+        xknx.devices.async_add(light)
+        assert len(xknx.devices) == 2
 
     def test_contains(self):
         """Test __contains__() function."""
         xknx = XKNX()
-        Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
-        Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
+        xknx.devices.async_add(
+            Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        )
+        xknx.devices.async_add(
+            Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
+        )
 
         assert "Living-Room.Light_1" in xknx.devices
         assert "Living-Room.Light_2" in xknx.devices
@@ -113,17 +123,20 @@ class TestDevices:
         xknx = XKNX()
         device1 = Device(xknx, "TestDevice1")
         device2 = Device(xknx, "TestDevice2")
+        xknx.devices.async_add(device1)
+        xknx.devices.async_add(device2)
         assert len(xknx.devices) == 2
-        device1.shutdown()
+        xknx.devices.async_remove(device1)
         assert len(xknx.devices) == 1
         assert "TestDevice1" not in xknx.devices
-        device2.shutdown()
+        xknx.devices.async_remove(device2)
         assert len(xknx.devices) == 0
 
     async def test_modification_of_device(self):
         """Test if devices object does store references and not copies of objects."""
         xknx = XKNX()
         light1 = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        xknx.devices.async_add(light1)
         for device in xknx.devices:
             await device.set_on()
             await xknx.devices.process(xknx.telegrams.get_nowait())
@@ -139,12 +152,6 @@ class TestDevices:
             await xknx.devices.process(xknx.telegrams.get_nowait())
         assert light1.state
 
-    def test_add_wrong_type(self):
-        """Test if exception is raised when wrong type of devices is added."""
-        xknx = XKNX()
-        with pytest.raises(TypeError):
-            xknx.devices.add("fnord")
-
     #
     # TEST SYNC
     #
@@ -152,8 +159,8 @@ class TestDevices:
     async def test_sync(self):
         """Test sync function."""
         xknx = XKNX()
-        Device(xknx, "TestDevice1")
-        Device(xknx, "TestDevice2")
+        xknx.devices.async_add(Device(xknx, "TestDevice1"))
+        xknx.devices.async_add(Device(xknx, "TestDevice2"))
         with patch("xknx.devices.Device.sync", new_callable=AsyncMock) as mock_sync:
             await xknx.devices.sync()
             assert mock_sync.call_count == 2
@@ -167,6 +174,8 @@ class TestDevices:
         xknx = XKNX()
         device1 = Device(xknx, "TestDevice1")
         device2 = Device(xknx, "TestDevice2")
+        xknx.devices.async_add(device1)
+        xknx.devices.async_add(device2)
 
         async_after_update_callback1 = AsyncMock()
         async_after_update_callback2 = AsyncMock()

--- a/test/devices_tests/expose_sensor_test.py
+++ b/test/devices_tests/expose_sensor_test.py
@@ -211,6 +211,7 @@ class TestExposeSensor:
             xknx, "TestSensor", group_address="1/2/3", value_type="temperature"
         )
         expose_sensor.register_device_updated_cb(after_update_callback)
+        xknx.devices.async_add(expose_sensor)
 
         await expose_sensor.set(21.0)
         await xknx.devices.process(xknx.telegrams.get_nowait())
@@ -232,12 +233,14 @@ class TestExposeSensor:
             value_type="temperature",
             cooldown=10,
         )
+        xknx.devices.async_add(expose_sensor_cd)
         expose_sensor_no_cd = ExposeSensor(
             xknx,
             "TestSensor",
             group_address="1/2/4",
             value_type="temperature",
         )
+        xknx.devices.async_add(expose_sensor_no_cd)
 
         await expose_sensor_cd.set(21.0)
         await expose_sensor_no_cd.set(21.0)

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -674,6 +674,8 @@ class TestLight:
         """Test setting the brightness of a non dimmable Light."""
         xknx = XKNX()
         light = Light(xknx, name="TestLight", group_address_switch="1/2/3")
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_brightness(23)
             assert xknx.telegrams.qsize() == 0
@@ -739,6 +741,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         await light.set_color((23, 24, 25))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -753,6 +757,8 @@ class TestLight:
         """Test setting the color of a non light without color."""
         xknx = XKNX()
         light = Light(xknx, name="TestLight", group_address_switch="1/2/3")
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_color((23, 24, 25))
             assert xknx.telegrams.qsize() == 0
@@ -779,6 +785,8 @@ class TestLight:
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
         )
+        xknx.devices.async_add(light)
+
         await light.set_color([23, 24, 25])
         assert xknx.telegrams.qsize() == 3
         telegrams = [xknx.telegrams.get_nowait() for _ in range(3)]
@@ -828,6 +836,8 @@ class TestLight:
             "TestLight",
             group_address_switch_red="1/1/1",
         )
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_color((23, 24, 25))
             assert xknx.telegrams.qsize() == 0
@@ -848,6 +858,8 @@ class TestLight:
             group_address_color="1/2/4",
             group_address_rgbw="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         await light.set_color((23, 24, 25), 26)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -867,6 +879,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color="1/2/4",
         )
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_color((23, 24, 25), 26)
 
@@ -898,6 +912,8 @@ class TestLight:
             group_address_brightness_white="1/1/15",
             group_address_brightness_white_state="1/1/16",
         )
+        xknx.devices.async_add(light)
+
         await light.set_color([23, 24, 25], white=26)
         assert xknx.telegrams.qsize() == 4
         telegrams = [xknx.telegrams.get_nowait() for _ in range(4)]
@@ -968,6 +984,8 @@ class TestLight:
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
         )
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_color((23, 24, 25), 26)
 
@@ -989,6 +1007,8 @@ class TestLight:
             group_address_hue="1/2/4",
             group_address_saturation="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         await light.set_hs_color((359, 99))
         assert xknx.telegrams.qsize() == 2
 
@@ -1054,6 +1074,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color="1/2/4",
         )
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_hs_color((22, 25))
 
@@ -1074,6 +1096,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_xyy_color="1/2/4",
         )
+        xknx.devices.async_add(light)
+
         await light.set_xyy_color(XYYColor((0.52, 0.31), 25))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -1093,6 +1117,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color="1/2/4",
         )
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_xyy_color(XYYColor((0.5, 0.3), 25))
 
@@ -1113,6 +1139,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_tunable_white="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         await light.set_tunable_white(23)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -1125,6 +1153,8 @@ class TestLight:
         """Test setting the tunable white value of a non tw Light."""
         xknx = XKNX()
         light = Light(xknx, name="TestLight", group_address_switch="1/2/3")
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_tunable_white(23)
             assert xknx.telegrams.qsize() == 0
@@ -1144,6 +1174,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color_temperature="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         await light.set_color_temperature(4000)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -1169,6 +1201,8 @@ class TestLight:
             group_address_color_temperature="1/2/5",
             color_temperature_type=ColorTemperatureType.FLOAT_2_BYTE,
         )
+        xknx.devices.async_add(light)
+
         await light.set_color_temperature(4000)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
@@ -1188,6 +1222,8 @@ class TestLight:
         """Test setting the color temperature value of an unsupported Light."""
         xknx = XKNX()
         light = Light(xknx, name="TestLight", group_address_switch="1/2/3")
+        xknx.devices.async_add(light)
+
         with patch("logging.Logger.warning") as mock_warn:
             await light.set_color_temperature(4000)
             assert xknx.telegrams.qsize() == 0
@@ -1207,6 +1243,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_brightness="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         assert light.state is None
 
         telegram = Telegram(
@@ -1242,6 +1280,8 @@ class TestLight:
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
         )
+        xknx.devices.async_add(light)
+
         assert light.state is None
 
         telegram = Telegram(
@@ -1268,6 +1308,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_brightness="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         after_update_callback = AsyncMock()
         light.register_device_updated_cb(after_update_callback)
 
@@ -1287,6 +1329,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_brightness="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         assert light.current_brightness is None
 
         telegram = Telegram(
@@ -1307,6 +1351,8 @@ class TestLight:
             group_address_brightness="1/2/5",
             device_updated_cb=cb_mock,
         )
+        xknx.devices.async_add(light)
+
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTBinary(1)),
@@ -1327,6 +1373,8 @@ class TestLight:
             group_address_brightness="1/2/5",
             device_updated_cb=cb_mock,
         )
+        xknx.devices.async_add(light)
+
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
             payload=GroupValueWrite(DPTArray((23, 24))),
@@ -1345,6 +1393,8 @@ class TestLight:
             group_address_switch="1/2/3",
             group_address_color="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         assert light.current_color == (None, None)
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
@@ -1372,6 +1422,8 @@ class TestLight:
             group_address_brightness_blue="1/1/11",
             group_address_brightness_blue_state="1/1/12",
         )
+        xknx.devices.async_add(light)
+
         assert light.current_color == (None, None)
 
         telegrams = [
@@ -1403,6 +1455,8 @@ class TestLight:
             group_address_color="1/2/4",
             group_address_rgbw="1/2/5",
         )
+        xknx.devices.async_add(light)
+
         assert light.current_color == (None, None)
         telegram = Telegram(
             destination_address=GroupAddress("1/2/5"),
@@ -1434,6 +1488,8 @@ class TestLight:
             group_address_brightness_white="1/1/15",
             group_address_brightness_white_state="1/1/16",
         )
+        xknx.devices.async_add(light)
+
         assert light.current_color == (None, None)
         telegram = Telegram(
             destination_address=GroupAddress("1/1/16"),
@@ -1465,6 +1521,7 @@ class TestLight:
             group_address_brightness_blue_state="1/1/12",
             device_updated_cb=rgb_callback,
         )
+        xknx.devices.async_add(rgb_light)
         rgbw_light = Light(
             xknx,
             "TestRGBWLight",
@@ -1479,6 +1536,7 @@ class TestLight:
             group_address_brightness_white_state="1/1/16",
             device_updated_cb=rgbw_callback,
         )
+        xknx.devices.async_add(rgbw_light)
 
         assert rgb_light.current_color == (None, None)
         assert rgbw_light.current_color == (None, None)

--- a/test/devices_tests/numeric_value_test.py
+++ b/test/devices_tests/numeric_value_test.py
@@ -296,6 +296,7 @@ class TestNumericValue:
         num_value = NumericValue(
             xknx, "TestSensor", group_address="1/2/3", value_type="temperature"
         )
+        xknx.devices.async_add(num_value)
         num_value.register_device_updated_cb(after_update_callback)
 
         await num_value.set(21.0)

--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -192,6 +192,7 @@ class TestSensorExposeLoop:
             group_address="1/1/1",
             value_type=value_type,
         )
+        xknx.devices.async_add(expose)
         assert expose.resolve_state() is None
         # set a value from expose - HA sends strings for new values
         stringified_value = str(test_value)
@@ -213,6 +214,7 @@ class TestSensorExposeLoop:
             group_address_state="1/1/1",
             value_type=value_type,
         )
+        xknx.devices.async_add(sensor)
         assert sensor.resolve_state() is None
 
         # read sensor state (from expose as it has the same GA)
@@ -262,6 +264,7 @@ class TestBinarySensorExposeLoop:
             group_address="1/1/1",
             value_type=value_type,
         )
+        xknx.devices.async_add(expose)
         assert expose.resolve_state() is None
 
         await expose.set(test_value)
@@ -331,6 +334,7 @@ class TestBinarySensorInternalGroupAddressExposeLoop:
             group_address="i-test",
             value_type=value_type,
         )
+        xknx.devices.async_add(expose)
         assert expose.resolve_state() is None
 
         await expose.set(test_value)
@@ -345,7 +349,12 @@ class TestBinarySensorInternalGroupAddressExposeLoop:
         telegram_callback.assert_called_with(outgoing_telegram)
         assert expose.resolve_state() == test_value
 
-        bin_sensor = BinarySensor(xknx, "TestSensor", group_address_state="i-test")
+        bin_sensor = BinarySensor(
+            xknx,
+            "TestSensor",
+            group_address_state="i-test",
+        )
+        xknx.devices.async_add(bin_sensor)
         assert bin_sensor.state is None
 
         # read sensor state (from expose as it has the same GA)

--- a/test/io_tests/secure_session_test.py
+++ b/test/io_tests/secure_session_test.py
@@ -65,8 +65,7 @@ class TestSecureSession:
         )
 
     def teardown_method(self):
-        """Cancel keepalive task."""
-        self.session.stop()
+        """Tear down test class."""
         self.patch_serial_number.stop()
         self.patch_message_tag.stop()
 
@@ -271,6 +270,9 @@ class TestSecureSession:
         )
         await time_travel(0)
         callback_mock.assert_not_called()
+        # async teardown
+        self.session.stop()
+        assert self.session.initialized is False
 
     @patch("xknx.io.transport.tcp_transport.TCPTransport.connect")
     @patch("xknx.io.transport.tcp_transport.TCPTransport.send")
@@ -375,6 +377,9 @@ class TestSecureSession:
         )
         await connect_task
         assert self.session.initialized is True
+        # async teardown
+        self.session.stop()
+        assert self.session.initialized is False
 
     @patch("xknx.io.transport.tcp_transport.TCPTransport.connect")
     @patch("xknx.io.transport.tcp_transport.TCPTransport.send")

--- a/test/tools_tests/tools_test.py
+++ b/test/tools_tests/tools_test.py
@@ -130,6 +130,7 @@ async def test_tools_with_internal_addresses():
         value_type=test_type,
         respond_to_read=True,
     )
+    xknx.devices.async_add(number)
 
     assert number.resolve_state() is None
     await group_value_write(xknx, internal_address, 1, value_type=test_type)

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -175,12 +175,6 @@ class Climate(Device):
         """Set power status to off."""
         await self.on.off()
 
-    def shutdown(self) -> None:
-        """Shutdown this device and the underlying mode."""
-        super().shutdown()
-        if self.mode:
-            self.mode.shutdown()
-
     @property
     def initialized_for_setpoint_shift_calculations(self) -> bool:
         """Test if object is initialized for setpoint shift calculations."""

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -154,10 +154,14 @@ class Cover(Device):
         yield self.angle
         yield self.locked
 
-    def _iter_tasks(self) -> Iterator[Task | None]:
-        """Iterate the device tasks."""
-        yield self._auto_stop_task
-        yield self._periodic_update_task
+    def async_remove_tasks(self) -> None:
+        """Remove async tasks of device."""
+        if self._auto_stop_task is not None:
+            self.xknx.task_registry.unregister(self._auto_stop_task.name)
+            self._auto_stop_task = None
+        if self._periodic_update_task is not None:
+            self.xknx.task_registry.unregister(self._periodic_update_task.name)
+            self._periodic_update_task = None
 
     async def set_down(self) -> None:
         """Move cover down."""

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -80,9 +80,11 @@ class ExposeSensor(Device):
         """Iterate the devices RemoteValue classes."""
         yield self.sensor_value
 
-    def _iter_tasks(self) -> Iterator[Task | None]:
-        """Iterate the device tasks."""
-        yield self._cooldown_task
+    def async_remove_tasks(self) -> None:
+        """Remove async tasks of device."""
+        if self._cooldown_task is not None:
+            self.xknx.task_registry.unregister(self._cooldown_task.name)
+            self._cooldown_task = None
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -66,6 +66,7 @@ class Switch(Device):
         """Remove async tasks of device."""
         if self._reset_task is not None:
             self._reset_task.cancel()
+            self._reset_task = None
 
     @property
     def state(self) -> bool | None:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Don't add `Device` instances to `xknx.devices` from their initializer. This starts asyncio tasks and should not happen in an `__init__` call (it could run in an non-async context).
- Devices can be attached to xknx via `xknx.devices.async_add(device)`
- Devices can be removed from xknx via `xknx.devices.async_remove(device)` 
- Devices can be re-attached. This was not possible before.

Closes #1352

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)