### PR TITLE
Don't process `RemoteValue.read_state` responses twice

### DIFF
--- a/test/devices_tests/sensor_expose_loop_test.py
+++ b/test/devices_tests/sensor_expose_loop_test.py
@@ -277,7 +277,12 @@ class TestBinarySensorExposeLoop:
         xknx.cemi_handler.send_telegram.assert_called_with(outgoing_telegram)
         assert expose.resolve_state() == test_value
 
-        bin_sensor = BinarySensor(xknx, "TestSensor", group_address_state="1/1/1")
+        bin_sensor = BinarySensor(
+            xknx,
+            "TestSensor",
+            group_address_state="1/1/1",
+        )
+        xknx.devices.async_add(bin_sensor)
         assert bin_sensor.state is None
 
         # read sensor state (from expose as it has the same GA)

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -145,9 +145,8 @@ class TestRemoteValue:
             patch_read.return_value = telegram
 
             await remote_value.read_state(wait_for_result=True)
-
-            assert remote_value.telegram == telegram
-            assert remote_value.value
+            patch_read.assert_called_once()
+            # RemoteValue.value is updated by RemoteValue.process called from Device / TelegramQueue
 
     async def test_read_state_none(self):
         """Test read state while waiting for the result but got None."""
@@ -161,6 +160,7 @@ class TestRemoteValue:
             patch_read.return_value = None
 
             await remote_value.read_state(wait_for_result=True)
+            patch_read.assert_called_once()
             mock_warning.assert_called_once_with(
                 "Could not sync group address '%s' (%s - %s)",
                 GroupAddress("1/2/3"),

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -250,10 +250,7 @@ class RemoteValue(ABC, Generic[ValueT]):
 
             value_reader = ValueReader(self.xknx, self.group_address_state)
             if wait_for_result:
-                telegram = await value_reader.read()
-                if telegram is not None:
-                    await self.process(telegram)
-                else:
+                if await value_reader.read() is None:
                     logger.warning(
                         "Could not sync group address '%s' (%s - %s)",
                         self.group_address_state,


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
The response is piped to `process` from the Device / TelegramQueue anyway. No need to directly await `process` from the read method.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)