### PR TITLE
Non-awaitable callbacks in Devices and RemoteValues

### DIFF
--- a/docs/binary_sensor.md
+++ b/docs/binary_sensor.md
@@ -23,7 +23,7 @@ The logic within switches can further handle if a button is pressed once or twic
 - `ignore_internal_state` allows callback call regardless of the current binary sensor state. Defaults to `False`
 - `context_timeout` time in seconds telegrams should be counted towards the current context to increment the counter. If set `ignore_internal_state` is set `True`. Defaults to `None`
 - `reset_after` may be used to reset the internal state to `OFF` again after given time in sec. Defaults to `None`
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ nav_order: 2
 ### General
 
 - Drop support for Python 3.9
+- Change callback signatures from awaitable to callable in `XKNX.device_updated_cb`, Device, Devices and RemoteValue.
 - Added eager telegram data decoding for GroupValueWrite / GroupValueResponse Telegrams. DPTs for group addresses can be set using `xknx.group_address_dpt.set()`. `Telegram` has a new attribute `decoded_data` which is set when a decoder was found.
 
 ### Devices
@@ -38,7 +39,7 @@ nav_order: 2
 - Convert Telegram and APCI to dataclasses. `Telegram` is not hashable anymore.
 - Use `asyncio.gather` where applicable (mostly device telegram process pipeline)
 - RemoteValue instances use pre-decoded data from Telegrams if available and `dpt_class` for is set - otherwise they decode the data themselves in `from_knx` like before.
-- Remove `async` from `RemoteValue.set` and `.respond` (nothing has to be awaited there)
+- Change `RemoteValue.after_update_cb` from awaitable to callable. Remove `async` from `RemoteValue.set`, `.respond`, `.process` and `.update_value` (nothing has to be awaited there).
 
 # 2.12.2 Fix thread leak 2024-03-05
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -38,6 +38,7 @@ nav_order: 2
 - Convert Telegram and APCI to dataclasses. `Telegram` is not hashable anymore.
 - Use `asyncio.gather` where applicable (mostly device telegram process pipeline)
 - RemoteValue instances use pre-decoded data from Telegrams if available and `dpt_class` for is set - otherwise they decode the data themselves in `from_knx` like before.
+- Remove `async` from `RemoteValue.set` and `.respond` (nothing has to be awaited there)
 
 # 2.12.2 Fix thread leak 2024-03-05
 

--- a/docs/climate.md
+++ b/docs/climate.md
@@ -47,7 +47,7 @@ Climate are representations of KNX HVAC/Climate controls.
 - `group_address_heat_cool_state` KNX address for reading heating / cooling mode. *DPT 1*
 - `operation_modes` Overrides the supported operation modes.
 - `controller_modes` Overrides the supported controller modes.
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 **Note:** `group_address_operation_mode_protection` / `group_address_operation_mode_night` / `group_address_operation_mode_comfort` / `group_address_operation_mode_standby` are not necessary if `group_address_operation_mode` was specified. When one of these is set `True`, the others will be set `False`. When one of these is set `Standby`, `Comfort`, `Frost_Protection` and `Night` will be set as supported. If `group_address_operation_mode_standby` is omitted, `Standby` is set when the other 3 are set to `False`.
 If only a subset of operation modes shall be used a list of supported modes may be passed to `operation_modes`.

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -29,7 +29,7 @@ Shutters are simple representations of blind/roller cover actuators. With XKNX y
 - `invert_updown` invert up/down binary payload. Default: False
 - `invert_position` invert position percentage from / to KNX bus. Default: False
 - `invert_angle` invert angle from / to KNX bus. Default: False
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -16,7 +16,7 @@ An instantiated device can be added to `xknx.devices` to receive telegrams and s
 
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
-* `device_updated_cb` List of awaitable callbacks for each update.
+* `device_updated_cb` List of callbacks for each update.
 * `group_address*` Group address for a specific function. If a list is passed the first element is used for sending / reading,  the rest are passively updating state (listening group address).
 
 * `has_group_address(group_address)` Test if device has given group address.

--- a/docs/fan.md
+++ b/docs/fan.md
@@ -22,7 +22,7 @@ Fans are simple representations of KNX controlled fans. They support switching o
 - `group_address_switch` is the KNX group address of the fan on/off state. If not used, on/off will implicitly be controlled via `group_address_speed` instead. Used for sending. *DPT 1.001*
 - `group_address_switch_state` is the KNX group address of the fan on/off state. Used for updating and reading state. *DPT 1.001*
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 - `max_step` Maximum step amount for fans which are controlled with steps and not percentage. If this attribute is set, the fan is controlled by sending the step value in the range `0` and `max_step`. In that case, the group address DPT changes from *DPT 5.001* to *DPT 5.010*. Default: None
 
 ## [](#header-2)Example

--- a/docs/light.md
+++ b/docs/light.md
@@ -54,7 +54,7 @@ The Light object is either a representation of a binary or dimm actor, LED-contr
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `min_kelvin` lowest possible color temperature in Kelvin. Default: 2700
 - `max_kelvin` highest possible color temperature in Kelvin. Default: 6000
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/numeric_value.md
+++ b/docs/numeric_value.md
@@ -21,7 +21,7 @@ NumericValue devices send values to the KNX bus. Received values update the devi
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `value_type` controls how the value should be encoded / decoded. The attribute may have may have parseable value types representing numeric values.
 - `always_callback` defines if a callback shall be triggered for consecutive GroupValueWrite telegrams with same payload. Defaults to `False`
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/raw_value.md
+++ b/docs/raw_value.md
@@ -21,7 +21,7 @@ RawValue devices send uint values to the KNX bus. Received values update the dev
 - `respond_to_read` if `True` GroupValueRead requests to the `group_address` are answered. Defaults to `False`
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `always_callback` defines if a callback shall be triggered for consecutive GroupValueWrite telegrams with same payload. Defaults to `False`
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/sensor.md
+++ b/docs/sensor.md
@@ -19,7 +19,7 @@ Sensors are monitoring temperature, air humidity, pressure etc. from KNX bus.
 - `sync_state` defines if the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `always_callback` defines if a callback shall be triggered for consecutive GroupValueWrite telegrams with same payload. Defaults to `False`
 - `value_type` controls how the value should be rendered in a human readable representation. The attribute may have may have the values `percent`, `temperature`, `illuminance`, `speed_ms` or `current`.
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Example
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -21,7 +21,7 @@ Switches are simple representations of binary actors. They mainly support switch
 - `sync_state` defines if and how often the value should be actively read from the bus. If `False` no GroupValueRead telegrams will be sent to its group address. Defaults to `True`
 - `invert` inverts the payload so state "on" is represented by 0 on bus and "off" by 1. Defaults to `False`
 - `reset_after` may be used to reset the switch to `OFF` again after given time in sec. Defaults to `None`
-- `device_updated_cb` awaitable callback for each update.
+- `device_updated_cb` Callback for each update.
 
 
 ## [](#header-2)Example

--- a/docs/time.md
+++ b/docs/time.md
@@ -31,7 +31,7 @@ await xknx.devices['TimeTest'].sync()
 * `group_address` is the KNX group address of the sensor device.
 * `broadcast_type` defines the value type that will be sent to the KNX bus. Valid attributes are: 'time', 'date' and 'datetime'. Default: `time`
 * `localtime` If set `True` sync() and GroupValueRead requests always return the current local time. On `False` the set value will be sent. Default: `True`
-* `device_updated_cb` awaitable callback for each update.
+* `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Daemon mode
 

--- a/docs/weather.md
+++ b/docs/weather.md
@@ -52,7 +52,7 @@ The weather device is basically a set of sensors that you can obtain from your w
 - **group_address_air_pressure** KNX address reading current air pressure. **DPT 9.006**
 - **group_address_humidity** KNX address for reading current humidity. **DPT 9.007**
 - **sync_state** Periodically sync the state.
-- **device_updated_cb** awaitable callback for each update.
+- **device_updated_cb** Callback for each update.
 
 ```python
 

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -42,7 +42,7 @@ The constructor of the XKNX object takes several parameters:
   - LONG: representation like '1/2/34' with middle groups
 - `connection_state_changed_cb` is a callback which is called every time the connection state to the gateway changes. See [callbacks](#callbacks) documentation for details.
 - `telegram_received_cb` is a callback which is called after every received KNX telegram. See [callbacks](#callbacks) documentation for details.
-- `device_updated_cb` is an async callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
+- `device_updated_cb` is a callback after a [XKNX device](#devices) was updated. See [callbacks](#callbacks) documentation for details.
 - `rate_limit` in telegrams per second - can be used to limit the outgoing traffic to the KNX/IP interface by the telegram queue. `0` disables rate limiter. Disabled by default.
 - `multicast_group` is the multicast group used for discovery - can be used to override the default multicast address (`224.0.23.12`)
 - `multicast_port` is the multicast port used for discovery - can be used to override the default multicast port (`3671`)
@@ -161,7 +161,7 @@ from xknx import XKNX
 from xknx.devices import Device, Switch
 
 
-async def device_updated_cb(device: Device):
+def device_updated_cb(device: Device):
     print("Callback received from {0}".format(device.name))
 
 

--- a/examples/example_callback.py
+++ b/examples/example_callback.py
@@ -7,7 +7,7 @@ from xknx.devices import Light
 from xknx.io import ConnectionConfig, ConnectionType
 
 
-async def light_callback(light: Light) -> None:
+def light_callback(light: Light) -> None:
     """Run callback when the light changed any of its state."""
     print(f"{light.name} - {light.state}")
 

--- a/examples/example_daemon.py
+++ b/examples/example_daemon.py
@@ -6,7 +6,7 @@ from xknx import XKNX
 from xknx.devices import Device, Switch
 
 
-async def device_updated_cb(device: Device) -> None:
+def device_updated_cb(device: Device) -> None:
     """Do something with the updated device."""
     print(f"Callback received from {device.name}")
 

--- a/examples/example_light_rgbw.py
+++ b/examples/example_light_rgbw.py
@@ -19,29 +19,29 @@ async def main() -> None:
         device_name="RGBWLight",
     )
 
-    await rgbw.set(RGBWColor(255, 255, 255, 0))  # cold-white
+    rgbw.set(RGBWColor(255, 255, 255, 0))  # cold-white
     await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 0, 0, 255))  # warm-white
+    rgbw.set(RGBWColor(0, 0, 0, 255))  # warm-white
     await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 0, 0, 0))  # off
-    await asyncio.sleep(1)
-
-    await rgbw.set(RGBWColor(255, 0, 0, 0))  # red
-    await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 255, 0, 0))  # green
-    await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 0, 255, 0))  # blue
-    await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 0, 0, 0))  # off
+    rgbw.set(RGBWColor(0, 0, 0, 0))  # off
     await asyncio.sleep(1)
 
-    await rgbw.set(RGBWColor(255, 255, 0, 0))
+    rgbw.set(RGBWColor(255, 0, 0, 0))  # red
     await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 255, 255, 0))
+    rgbw.set(RGBWColor(0, 255, 0, 0))  # green
     await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(255, 0, 255, 0))
+    rgbw.set(RGBWColor(0, 0, 255, 0))  # blue
     await asyncio.sleep(1)
-    await rgbw.set(RGBWColor(0, 0, 0, 0))  # off
+    rgbw.set(RGBWColor(0, 0, 0, 0))  # off
+    await asyncio.sleep(1)
+
+    rgbw.set(RGBWColor(255, 255, 0, 0))
+    await asyncio.sleep(1)
+    rgbw.set(RGBWColor(0, 255, 255, 0))
+    await asyncio.sleep(1)
+    rgbw.set(RGBWColor(255, 0, 255, 0))
+    await asyncio.sleep(1)
+    rgbw.set(RGBWColor(0, 0, 0, 0))  # off
     await asyncio.sleep(1)
 
     await xknx.stop()

--- a/examples/example_powermeter_mqtt.py
+++ b/examples/example_powermeter_mqtt.py
@@ -62,7 +62,7 @@ RE_CURRENT = re.compile("Current_")
 RE_FREQUENCY = re.compile("Frequency_")
 
 
-async def device_updated_cb(device):
+def device_updated_cb(device):
     """Do something with the updated device."""
     # print(device.name + ' ' + str(device.resolve_state()) + ' ' + device.unit_of_measurement())
     value = None

--- a/test/devices_tests/binary_sensor_test.py
+++ b/test/devices_tests/binary_sensor_test.py
@@ -1,6 +1,6 @@
 """Unit test for BinarySensor objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import BinarySensor
@@ -73,13 +73,13 @@ class TestBinarySensor:
         """Test process / reading telegrams from telegram queue."""
         xknx = XKNX()
         reset_after_sec = 1
-        async_after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         binaryinput = BinarySensor(
             xknx,
             "TestInput",
             "1/2/3",
             reset_after=reset_after_sec,
-            device_updated_cb=async_after_update_callback,
+            device_updated_cb=after_update_callback,
         )
         telegram_on = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -92,22 +92,22 @@ class TestBinarySensor:
         await time_travel(reset_after_sec)
         assert not binaryinput.state
         # once for 'on' and once for 'off'
-        assert async_after_update_callback.call_count == 2
+        assert after_update_callback.call_count == 2
 
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         # multiple telegrams during reset_after time period shall reset timer
         await binaryinput.process(telegram_on)
-        async_after_update_callback.assert_called_once()
+        after_update_callback.assert_called_once()
         await binaryinput.process(telegram_on)
         await binaryinput.process(telegram_on)
         # second and third telegram resets timer but doesn't run callback
-        async_after_update_callback.assert_called_once()
+        after_update_callback.assert_called_once()
         assert binaryinput.state
 
         await time_travel(reset_after_sec)
         assert not binaryinput.state
         # once for 'on' and once for 'off'
-        assert async_after_update_callback.call_count == 2
+        assert after_update_callback.call_count == 2
 
     async def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
@@ -125,13 +125,13 @@ class TestBinarySensor:
     #
     # TEST SWITCHED ON
     #
-    async def test_is_on(self):
+    def test_is_on(self):
         """Test is_on() and is_off() of a BinarySensor with state 'on'."""
         xknx = XKNX()
         binaryinput = BinarySensor(xknx, "TestInput", "1/2/3")
         assert not binaryinput.is_on()
         assert binaryinput.is_off()
-        await binaryinput._set_internal_state(True)
+        binaryinput._set_internal_state(True)
 
         assert binaryinput.is_on()
         assert not binaryinput.is_off()
@@ -139,11 +139,11 @@ class TestBinarySensor:
     #
     # TEST SWITCHED OFF
     #
-    async def test_is_off(self):
+    def test_is_off(self):
         """Test is_on() and is_off() of a BinarySensor with state 'off'."""
         xknx = XKNX()
         binaryinput = BinarySensor(xknx, "TestInput", "1/2/3")
-        await binaryinput._set_internal_state(False)
+        binaryinput._set_internal_state(False)
 
         assert not binaryinput.is_on()
         assert binaryinput.is_off()
@@ -157,9 +157,9 @@ class TestBinarySensor:
         switch = BinarySensor(
             xknx, "TestInput", group_address_state="1/2/3", ignore_internal_state=False
         )
-        async_after_update_callback = AsyncMock()
+        after_update_callback = Mock()
 
-        switch.register_device_updated_cb(async_after_update_callback)
+        switch.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -168,12 +168,12 @@ class TestBinarySensor:
         await switch.process(telegram)
         # no _context_task started because ignore_internal_state is False
         assert switch._context_task is None
-        async_after_update_callback.assert_called_once_with(switch)
+        after_update_callback.assert_called_once_with(switch)
 
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         # send same telegram again
         await switch.process(telegram)
-        async_after_update_callback.assert_not_called()
+        after_update_callback.assert_not_called()
 
     async def test_process_callback_ignore_internal_state(self):
         """Test after_update_callback after state of switch was changed."""
@@ -185,9 +185,9 @@ class TestBinarySensor:
             ignore_internal_state=True,
             context_timeout=0.001,
         )
-        async_after_update_callback = AsyncMock()
+        after_update_callback = Mock()
 
-        switch.register_device_updated_cb(async_after_update_callback)
+        switch.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -196,25 +196,25 @@ class TestBinarySensor:
         assert switch.counter == 0
 
         await switch.process(telegram)
-        async_after_update_callback.assert_not_called()
+        after_update_callback.assert_not_called()
         assert switch.counter == 1
         await switch._context_task
-        async_after_update_callback.assert_called_with(switch)
+        after_update_callback.assert_called_with(switch)
         # once with counter 1 and once with counter 0
-        assert async_after_update_callback.call_count == 2
+        assert after_update_callback.call_count == 2
 
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         # send same telegram again
         await switch.process(telegram)
         assert switch.counter == 1
         await switch.process(telegram)
         assert switch.counter == 2
-        async_after_update_callback.assert_not_called()
+        after_update_callback.assert_not_called()
 
         await switch._context_task
-        async_after_update_callback.assert_called_with(switch)
+        after_update_callback.assert_called_with(switch)
         # once with counter 2 and once with counter 0
-        assert async_after_update_callback.call_count == 2
+        assert after_update_callback.call_count == 2
         assert switch.counter == 0
 
     async def test_process_callback_ignore_internal_state_no_counter(self):
@@ -227,9 +227,9 @@ class TestBinarySensor:
             ignore_internal_state=True,
             context_timeout=0,
         )
-        async_after_update_callback = AsyncMock()
+        after_update_callback = Mock()
 
-        switch.register_device_updated_cb(async_after_update_callback)
+        switch.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -238,12 +238,12 @@ class TestBinarySensor:
         await switch.process(telegram)
         # no _context_task started because context_timeout is False
         assert switch._context_task is None
-        async_after_update_callback.assert_called_once_with(switch)
+        after_update_callback.assert_called_once_with(switch)
 
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         # send same telegram again
         await switch.process(telegram)
-        async_after_update_callback.assert_called_once_with(switch)
+        after_update_callback.assert_called_once_with(switch)
 
     async def test_process_group_value_response(self):
         """Test process of GroupValueResponse telegrams."""
@@ -254,9 +254,9 @@ class TestBinarySensor:
             group_address_state="1/2/3",
             ignore_internal_state=True,
         )
-        async_after_update_callback = AsyncMock()
+        after_update_callback = Mock()
 
-        switch.register_device_updated_cb(async_after_update_callback)
+        switch.register_device_updated_cb(after_update_callback)
 
         write_telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -272,16 +272,16 @@ class TestBinarySensor:
         # initial GroupValueResponse changes state and runs callback
         await switch.process(response_telegram)
         assert switch.state
-        async_after_update_callback.assert_called_once_with(switch)
+        after_update_callback.assert_called_once_with(switch)
         # GroupValueWrite with same payload runs callback because of `ignore_internal_state`
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         await switch.process(write_telegram)
         assert switch.state
-        async_after_update_callback.assert_called_once_with(switch)
+        after_update_callback.assert_called_once_with(switch)
         # GroupValueResponse should not run callback when state has not changed
-        async_after_update_callback.reset_mock()
+        after_update_callback.reset_mock()
         await switch.process(response_telegram)
-        async_after_update_callback.assert_not_called()
+        after_update_callback.assert_not_called()
 
     #
     # TEST COUNTER

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1,6 +1,6 @@
 """Unit test for Climate objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -147,7 +147,7 @@ class TestClimate:
             group_address_setpoint_shift_state="1/2/4",
             setpoint_shift_mode=SetpointShiftMode.DPT6010,
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         climate.register_device_updated_cb(after_update_callback)
         xknx.devices.async_add(climate)
 
@@ -165,7 +165,7 @@ class TestClimate:
         """Test if after_update_callback is called after update of Climate object was changed."""
 
         xknx = XKNX()
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
@@ -196,7 +196,7 @@ class TestClimate:
             group_address_target_temperature="1/2/2",
             group_address_setpoint_shift="1/2/3",
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         climate.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
@@ -230,7 +230,7 @@ class TestClimate:
         climate_mode = ClimateMode(
             xknx, "TestClimateMode", group_address_operation_mode="1/2/4"
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
 
         climate = Climate(xknx, "TestClimate", mode=climate_mode)
         climate_mode.register_device_updated_cb(after_update_callback)
@@ -811,7 +811,7 @@ class TestClimate:
         xknx.devices.async_add(climate)
 
         # base temperature is 20 °C
-        await climate.target_temperature.process(
+        climate.target_temperature.process(
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
                 payload=GroupValueWrite(DPT2ByteFloat().to_knx(20.00)),
@@ -837,7 +837,7 @@ class TestClimate:
             payload=GroupValueWrite(DPTArray((0x87, 0xC4))),
         )  # -0.6
         # simulate incoming new target temperature for next calculation
-        await climate.target_temperature.process(
+        climate.target_temperature.process(
             Telegram(
                 destination_address=GroupAddress("1/2/2"),
                 payload=GroupValueWrite(DPT2ByteFloat().to_knx(19.40)),
@@ -1053,7 +1053,7 @@ class TestClimate:
     async def test_process_controller_status_wrong_payload(self):
         """Test process wrong telegram for controller status (wrong payload type)."""
         xknx = XKNX()
-        updated_cb = AsyncMock()
+        updated_cb = Mock()
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
@@ -1073,7 +1073,7 @@ class TestClimate:
     async def test_process_controller_status_payload_invalid_length(self):
         """Test process wrong telegram for controller status (wrong payload length)."""
         xknx = XKNX()
-        updated_cb = AsyncMock()
+        updated_cb = Mock()
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
@@ -1093,7 +1093,7 @@ class TestClimate:
     async def test_process_operation_mode_wrong_payload(self):
         """Test process wrong telegram for operation mode (wrong payload type)."""
         xknx = XKNX()
-        updated_cb = AsyncMock()
+        updated_cb = Mock()
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
@@ -1113,7 +1113,7 @@ class TestClimate:
     async def test_process_operation_mode_payload_invalid_length(self):
         """Test process wrong telegram for operation mode (wrong payload length)."""
         xknx = XKNX()
-        updated_cb = AsyncMock()
+        updated_cb = Mock()
         climate_mode = ClimateMode(
             xknx,
             "TestClimate",
@@ -1135,7 +1135,7 @@ class TestClimate:
 
         xknx = XKNX()
         climate = Climate(xknx, "TestClimate", group_address_temperature="1/2/3")
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         climate.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -151,7 +151,7 @@ class TestClimate:
         climate.register_device_updated_cb(after_update_callback)
         xknx.devices.async_add(climate)
 
-        await climate.target_temperature.set(23.00)
+        climate.target_temperature.set(23.00)
         await xknx.devices.process(xknx.telegrams.get_nowait())
         after_update_callback.assert_called_with(climate)
         after_update_callback.reset_mock()
@@ -409,7 +409,7 @@ class TestClimate:
         await xknx.devices.process(xknx.telegrams.get_nowait())
         assert not climate3.initialized_for_setpoint_shift_calculations
 
-        await climate3.target_temperature.set(23.00)
+        climate3.target_temperature.set(23.00)
         await xknx.devices.process(xknx.telegrams.get_nowait())
         assert climate3.initialized_for_setpoint_shift_calculations
 
@@ -514,7 +514,7 @@ class TestClimate:
         await xknx.devices.process(xknx.telegrams.get_nowait())
         assert not climate.initialized_for_setpoint_shift_calculations
 
-        await climate.target_temperature.set(23.00)
+        climate.target_temperature.set(23.00)
         await xknx.devices.process(xknx.telegrams.get_nowait())
         assert climate.initialized_for_setpoint_shift_calculations
         assert climate.target_temperature_min == "3"
@@ -546,7 +546,7 @@ class TestClimate:
         )
         await xknx.devices.process(_telegram)
 
-        await climate.target_temperature.set(23.00)
+        climate.target_temperature.set(23.00)
         assert xknx.telegrams.qsize() == 1
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
@@ -625,7 +625,7 @@ class TestClimate:
         )
         await xknx.devices.process(_telegram)
 
-        await climate.target_temperature.set(23.00)
+        climate.target_temperature.set(23.00)
         assert xknx.telegrams.qsize() == 1
         _telegram = xknx.telegrams.get_nowait()
         assert _telegram == Telegram(
@@ -707,7 +707,7 @@ class TestClimate:
             payload=GroupValueWrite(DPTArray(6)),
         )
 
-        await climate.target_temperature.set(23.00)
+        climate.target_temperature.set(23.00)
         assert xknx.telegrams.qsize() == 1
         _telegram = xknx.telegrams.get_nowait()
         await xknx.devices.process(_telegram)

--- a/test/devices_tests/device_test.py
+++ b/test/devices_tests/device_test.py
@@ -1,6 +1,6 @@
 """Unit test for Switch objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from xknx import XKNX
 from xknx.devices import Device, Sensor
@@ -13,33 +13,33 @@ from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWri
 class TestDevice:
     """Test class for Switch object."""
 
-    async def test_device_updated_cb(self):
+    def test_device_updated_cb(self):
         """Test device updated cb is added to the device."""
         xknx = XKNX()
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         device = Device(xknx, "TestDevice", device_updated_cb=after_update_callback)
 
-        await device.after_update()
+        device.after_update()
         after_update_callback.assert_called_with(device)
 
-    async def test_process_callback(self):
+    def test_process_callback(self):
         """Test process / reading telegrams from telegram queue. Test if callback was called."""
         xknx = XKNX()
         device = Device(xknx, "TestDevice")
-        after_update_callback1 = AsyncMock()
-        after_update_callback2 = AsyncMock()
+        after_update_callback1 = Mock()
+        after_update_callback2 = Mock()
         device.register_device_updated_cb(after_update_callback1)
         device.register_device_updated_cb(after_update_callback2)
 
         # Triggering first time. Both have to be called
-        await device.after_update()
+        device.after_update()
         after_update_callback1.assert_called_with(device)
         after_update_callback2.assert_called_with(device)
         after_update_callback1.reset_mock()
         after_update_callback2.reset_mock()
 
         # Triggering 2nd time. Both have to be called
-        await device.after_update()
+        device.after_update()
         after_update_callback1.assert_called_with(device)
         after_update_callback2.assert_called_with(device)
         after_update_callback1.reset_mock()
@@ -47,7 +47,7 @@ class TestDevice:
 
         # Unregistering first callback
         device.unregister_device_updated_cb(after_update_callback1)
-        await device.after_update()
+        device.after_update()
         after_update_callback1.assert_not_called()
         after_update_callback2.assert_called_with(device)
         after_update_callback1.reset_mock()
@@ -55,24 +55,24 @@ class TestDevice:
 
         # Unregistering second callback
         device.unregister_device_updated_cb(after_update_callback2)
-        await device.after_update()
+        device.after_update()
         after_update_callback1.assert_not_called()
         after_update_callback2.assert_not_called()
 
     @patch("logging.Logger.exception")
-    async def test_bad_callback(self, logging_exception_mock):
+    def test_bad_callback(self, logging_exception_mock):
         """Test handling callback raising an exception."""
         xknx = XKNX()
         device = Device(xknx, "TestDevice")
-        good_callback_1 = AsyncMock()
-        bad_callback = AsyncMock(side_effect=Exception("Boom"))
-        good_callback_2 = AsyncMock()
+        good_callback_1 = Mock()
+        bad_callback = Mock(side_effect=Exception("Boom"))
+        good_callback_2 = Mock()
 
         device.register_device_updated_cb(good_callback_1)
         device.register_device_updated_cb(bad_callback)
         device.register_device_updated_cb(good_callback_2)
 
-        await device.after_update()
+        device.after_update()
         good_callback_1.assert_called_with(device)
         bad_callback.assert_called_with(device)
         good_callback_2.assert_called_with(device)

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -1,6 +1,6 @@
 """Unit test for devices container within XKNX."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -169,7 +169,7 @@ class TestDevices:
     # TEST CALLBACK
     #
     @patch.multiple(Device, __abstractmethods__=set())
-    async def test_device_updated_callback(self):
+    def test_device_updated_callback(self):
         """Test if device updated callback is called correctly if device was updated."""
         xknx = XKNX()
         device1 = Device(xknx, "TestDevice1")
@@ -177,43 +177,43 @@ class TestDevices:
         xknx.devices.async_add(device1)
         xknx.devices.async_add(device2)
 
-        async_after_update_callback1 = AsyncMock()
-        async_after_update_callback2 = AsyncMock()
+        after_update_callback1 = Mock()
+        after_update_callback2 = Mock()
 
         # Registering both callbacks
-        xknx.devices.register_device_updated_cb(async_after_update_callback1)
-        xknx.devices.register_device_updated_cb(async_after_update_callback2)
+        xknx.devices.register_device_updated_cb(after_update_callback1)
+        xknx.devices.register_device_updated_cb(after_update_callback2)
 
         # Triggering first device. Both callbacks to be called
-        await device1.after_update()
-        async_after_update_callback1.assert_called_with(device1)
-        async_after_update_callback2.assert_called_with(device1)
-        async_after_update_callback1.reset_mock()
-        async_after_update_callback2.reset_mock()
+        device1.after_update()
+        after_update_callback1.assert_called_with(device1)
+        after_update_callback2.assert_called_with(device1)
+        after_update_callback1.reset_mock()
+        after_update_callback2.reset_mock()
 
         # Triggering 2nd device. Both callbacks have to be called
-        await device2.after_update()
-        async_after_update_callback1.assert_called_with(device2)
-        async_after_update_callback2.assert_called_with(device2)
-        async_after_update_callback1.reset_mock()
-        async_after_update_callback2.reset_mock()
+        device2.after_update()
+        after_update_callback1.assert_called_with(device2)
+        after_update_callback2.assert_called_with(device2)
+        after_update_callback1.reset_mock()
+        after_update_callback2.reset_mock()
 
         # Unregistering first callback
-        xknx.devices.unregister_device_updated_cb(async_after_update_callback1)
+        xknx.devices.unregister_device_updated_cb(after_update_callback1)
 
         # Triggering first device. Only second callback has to be called
-        await device1.after_update()
-        async_after_update_callback1.assert_not_called()
-        async_after_update_callback2.assert_called_with(device1)
-        async_after_update_callback1.reset_mock()
-        async_after_update_callback2.reset_mock()
+        device1.after_update()
+        after_update_callback1.assert_not_called()
+        after_update_callback2.assert_called_with(device1)
+        after_update_callback1.reset_mock()
+        after_update_callback2.reset_mock()
 
         # Unregistering second callback
-        xknx.devices.unregister_device_updated_cb(async_after_update_callback2)
+        xknx.devices.unregister_device_updated_cb(after_update_callback2)
 
         # Triggering second device. No callback should be called
-        await device2.after_update()
-        async_after_update_callback1.assert_not_called()
-        async_after_update_callback2.assert_not_called()
-        async_after_update_callback1.reset_mock()
-        async_after_update_callback2.reset_mock()
+        device2.after_update()
+        after_update_callback1.assert_not_called()
+        after_update_callback2.assert_not_called()
+        after_update_callback1.reset_mock()
+        after_update_callback2.reset_mock()

--- a/test/devices_tests/expose_sensor_test.py
+++ b/test/devices_tests/expose_sensor_test.py
@@ -1,6 +1,6 @@
 """Unit test for Sensor objects."""
 
-from unittest.mock import AsyncMock, call
+from unittest.mock import AsyncMock, Mock, call
 
 from xknx import XKNX
 from xknx.devices import ExposeSensor
@@ -206,7 +206,7 @@ class TestExposeSensor:
         """Test setting value. Test if callback is called."""
 
         xknx = XKNX()
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         expose_sensor = ExposeSensor(
             xknx, "TestSensor", group_address="1/2/3", value_type="temperature"
         )

--- a/test/devices_tests/fan_test.py
+++ b/test/devices_tests/fan_test.py
@@ -1,6 +1,6 @@
 """Unit test for Fan objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import Fan
@@ -272,7 +272,7 @@ class TestFan:
     async def test_process_speed_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         fan = Fan(
             xknx, name="TestFan", group_address_speed="1/2/3", device_updated_cb=cb_mock
         )
@@ -372,7 +372,7 @@ class TestFan:
     async def test_process_fan_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         fan = Fan(
             xknx, name="TestFan", group_address_speed="1/2/3", device_updated_cb=cb_mock
         )

--- a/test/devices_tests/light_test.py
+++ b/test/devices_tests/light_test.py
@@ -1,6 +1,6 @@
 """Unit test for Light objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import Light
@@ -1310,7 +1310,7 @@ class TestLight:
         )
         xknx.devices.async_add(light)
 
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         light.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
@@ -1343,7 +1343,7 @@ class TestLight:
     async def test_process_dimm_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",
@@ -1365,7 +1365,7 @@ class TestLight:
     async def test_process_dimm_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",
@@ -1501,8 +1501,8 @@ class TestLight:
     async def test_process_individual_color_debouncer(self, time_travel):
         """Test the debouncer for individual color lights."""
         xknx = XKNX()
-        rgb_callback = AsyncMock()
-        rgbw_callback = AsyncMock()
+        rgb_callback = Mock()
+        rgbw_callback = Mock()
 
         rgb_light = Light(
             xknx,
@@ -1694,7 +1694,7 @@ class TestLight:
     async def test_process_tunable_white_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",
@@ -1714,7 +1714,7 @@ class TestLight:
     async def test_process_tunable_white_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",
@@ -1759,7 +1759,7 @@ class TestLight:
     async def test_process_color_temperature_wrong_payload(self):
         """Test process wrong telegrams. (wrong payload type)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",
@@ -1779,7 +1779,7 @@ class TestLight:
     async def test_process_color_temperature_payload_invalid_length(self):
         """Test process wrong telegrams. (wrong payload length)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        cb_mock = Mock()
         light = Light(
             xknx,
             name="TestLight",

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -1,6 +1,6 @@
 """Unit test for Notification objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import Notification
@@ -54,7 +54,7 @@ class TestNotification:
 
         xknx = XKNX()
         notification = Notification(xknx, "Warning", group_address="1/2/3")
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         notification.register_device_updated_cb(after_update_callback)
 
         telegram_set = Telegram(
@@ -67,9 +67,12 @@ class TestNotification:
     async def test_process_payload_invalid_length(self):
         """Test process wrong telegram (wrong payload length)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        after_update_callback = Mock()
         notification = Notification(
-            xknx, "Warning", group_address="1/2/3", device_updated_cb=cb_mock
+            xknx,
+            "Warning",
+            group_address="1/2/3",
+            device_updated_cb=after_update_callback,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -78,14 +81,17 @@ class TestNotification:
         with patch("logging.Logger.warning") as log_mock:
             await notification.process(telegram)
             log_mock.assert_called_once()
-            cb_mock.assert_not_called()
+            after_update_callback.assert_not_called()
 
     async def test_process_wrong_payload(self):
         """Test process wrong telegram (wrong payload type)."""
         xknx = XKNX()
-        cb_mock = AsyncMock()
+        after_update_callback = Mock()
         notification = Notification(
-            xknx, "Warning", group_address="1/2/3", device_updated_cb=cb_mock
+            xknx,
+            "Warning",
+            group_address="1/2/3",
+            device_updated_cb=after_update_callback,
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -94,7 +100,7 @@ class TestNotification:
         with patch("logging.Logger.warning") as log_mock:
             await notification.process(telegram)
             log_mock.assert_called_once()
-            cb_mock.assert_not_called()
+            after_update_callback.assert_not_called()
 
     #
     # TEST RESPOND

--- a/test/devices_tests/numeric_value_test.py
+++ b/test/devices_tests/numeric_value_test.py
@@ -1,6 +1,6 @@
 """Unit test for NumericValue objects."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 import pytest
 
@@ -247,7 +247,7 @@ class TestNumericValue:
         sensor = NumericValue(
             xknx, "TestSensor", group_address="1/2/3", value_type="temperature"
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
@@ -273,7 +273,7 @@ class TestNumericValue:
             value_type="temperature",
             always_callback=True,
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
@@ -292,7 +292,7 @@ class TestNumericValue:
         """Test setting value. Test if callback is called."""
 
         xknx = XKNX()
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         num_value = NumericValue(
             xknx, "TestSensor", group_address="1/2/3", value_type="temperature"
         )

--- a/test/devices_tests/raw_value_test.py
+++ b/test/devices_tests/raw_value_test.py
@@ -1,6 +1,6 @@
 """Unit test for RawValue objects."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 import pytest
 
@@ -154,7 +154,7 @@ class TestRawValue:
             2,
             group_address="1/2/3",
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
@@ -180,7 +180,7 @@ class TestRawValue:
             group_address="1/2/3",
             always_callback=True,
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -1,6 +1,6 @@
 """Unit test for Sensor objects."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import Mock
 
 import pytest
 
@@ -703,7 +703,7 @@ class TestSensor:
             always_callback=False,
             value_type="volume_liquid_litre",
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
         payload = DPTArray((0x00, 0x00, 0x01, 0x00))
         #  set initial payload of sensor
@@ -786,7 +786,7 @@ class TestSensor:
         sensor = Sensor(
             xknx, "TestSensor", group_address_state="1/2/3", value_type="temperature"
         )
-        after_update_callback = AsyncMock()
+        after_update_callback = Mock()
         sensor.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(

--- a/test/devices_tests/switch_test.py
+++ b/test/devices_tests/switch_test.py
@@ -1,6 +1,6 @@
 """Unit test for Switch objects."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import Mock
 
 from xknx import XKNX
 from xknx.devices import Switch
@@ -47,7 +47,7 @@ class TestSwitch:
     async def test_process(self):
         """Test process / reading telegrams from telegram queue. Test if device was updated."""
         xknx = XKNX()
-        callback_mock = AsyncMock()
+        callback_mock = Mock()
 
         switch1 = Switch(
             xknx, "TestOutlet", group_address="1/2/3", device_updated_cb=callback_mock
@@ -89,7 +89,7 @@ class TestSwitch:
     async def test_process_state(self):
         """Test process / reading telegrams from telegram queue. Test if device was updated."""
         xknx = XKNX()
-        callback_mock = AsyncMock()
+        callback_mock = Mock()
 
         switch1 = Switch(
             xknx,
@@ -222,12 +222,7 @@ class TestSwitch:
         switch = Switch(xknx, "TestOutlet", group_address="1/2/3")
 
         after_update_callback = Mock()
-
-        async def async_after_update_callback(device):
-            """Async callback."""
-            after_update_callback(device)
-
-        switch.register_device_updated_cb(async_after_update_callback)
+        switch.register_device_updated_cb(after_update_callback)
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -380,7 +375,7 @@ class TestSwitch:
     async def test_process_passive(self):
         """Test process / reading telegrams from telegram queue. Test if device was updated."""
         xknx = XKNX()
-        callback_mock = AsyncMock()
+        callback_mock = Mock()
 
         switch1 = Switch(
             xknx,

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -41,7 +41,7 @@ class TestRemoteValue1Count:
             payload=GroupValueWrite(DPTArray((0x65,))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
@@ -49,10 +49,10 @@ class TestRemoteValue1Count:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64,))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == 100
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
@@ -61,12 +61,12 @@ class TestRemoteValue1Count:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_1count_test.py
+++ b/test/remote_value_tests/remote_value_1count_test.py
@@ -26,14 +26,14 @@ class TestRemoteValue1Count:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValue1Count(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(100)
+        remote_value.set(100)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64,))),
         )
-        await remote_value.set(101)
+        remote_value.set(101)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -235,7 +235,7 @@ class TestRemoteValueOperationMode:
             payload=GroupValueWrite(DPTBinary(False)),
         )
 
-    async def test_process_operation_mode(self):
+    def test_process_operation_mode(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueOperationMode(
@@ -247,10 +247,10 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x00,))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == HVACOperationMode.AUTO
 
-    async def test_process_controller_mode(self):
+    def test_process_controller_mode(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueControllerMode(
@@ -260,10 +260,10 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x00,))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == HVACControllerMode.AUTO
 
-    async def test_process_binary(self):
+    def test_process_binary(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueBinaryOperationMode(
@@ -275,10 +275,10 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(True)),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == HVACOperationMode.FROST_PROTECTION
 
-    async def test_to_process_error_operation_mode(self):
+    def test_to_process_error_operation_mode(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueOperationMode(
@@ -291,17 +291,17 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None
 
-    async def test_to_process_error_binary_operation_mode(self):
+    def test_to_process_error_binary_operation_mode(self):
         """Test processing invalid payload."""
         xknx = XKNX()
         remote_value = RemoteValueBinaryOperationMode(
@@ -315,9 +315,9 @@ class TestRemoteValueOperationMode:
                 DPTArray((1,)),
             ),
         )
-        assert await remote_value.process(telegram=invalid_telegram) is False
+        assert remote_value.process(telegram=invalid_telegram) is False
 
-    async def test_to_process_error_controller_mode(self):
+    def test_to_process_error_controller_mode(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueControllerMode(
@@ -328,17 +328,17 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None
 
-    async def test_to_process_error_heat_cool(self):
+    def test_to_process_error_heat_cool(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueBinaryHeatCool(
@@ -351,12 +351,12 @@ class TestRemoteValueOperationMode:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x01,))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -176,14 +176,14 @@ class TestRemoteValueOperationMode:
             group_address=GroupAddress("1/2/3"),
             climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
         )
-        await remote_value.set(HVACOperationMode.NIGHT)
+        remote_value.set(HVACOperationMode.NIGHT)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x03,))),
         )
-        await remote_value.set(HVACOperationMode.FROST_PROTECTION)
+        remote_value.set(HVACOperationMode.FROST_PROTECTION)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -197,14 +197,14 @@ class TestRemoteValueOperationMode:
         remote_value = RemoteValueControllerMode(
             xknx, group_address=GroupAddress("1/2/3")
         )
-        await remote_value.set(HVACControllerMode.COOL)
+        remote_value.set(HVACControllerMode.COOL)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x03,))),
         )
-        await remote_value.set(HVACControllerMode.NIGHT_PURGE)
+        remote_value.set(HVACControllerMode.NIGHT_PURGE)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -220,14 +220,14 @@ class TestRemoteValueOperationMode:
             group_address=GroupAddress("1/2/3"),
             operation_mode=HVACOperationMode.STANDBY,
         )
-        await remote_value.set(HVACOperationMode.STANDBY)
+        remote_value.set(HVACOperationMode.STANDBY)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(True)),
         )
-        await remote_value.set(HVACOperationMode.FROST_PROTECTION)
+        remote_value.set(HVACOperationMode.FROST_PROTECTION)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -48,14 +48,14 @@ class TestRemoteValueColorRGB:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(RGBColor(100, 101, 102))
+        remote_value.set(RGBColor(100, 101, 102))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
         )
-        await remote_value.set(RGBColor(100, 101, 104))
+        remote_value.set(RGBColor(100, 101, 104))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_color_rgb_test.py
+++ b/test/remote_value_tests/remote_value_color_rgb_test.py
@@ -63,7 +63,7 @@ class TestRemoteValueColorRGB:
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x68))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
@@ -71,10 +71,10 @@ class TestRemoteValueColorRGB:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == RGBColor(100, 101, 102)
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGB(xknx, group_address=GroupAddress("1/2/3"))
@@ -83,12 +83,12 @@ class TestRemoteValueColorRGB:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -68,7 +68,7 @@ class TestRemoteValueColorRGBW:
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x68, 0x69, 0x00, 0x0F))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
@@ -76,10 +76,10 @@ class TestRemoteValueColorRGBW:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == RGBWColor(100, 101, 102, 103)
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
@@ -88,13 +88,13 @@ class TestRemoteValueColorRGBW:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -102,6 +102,6 @@ class TestRemoteValueColorRGBW:
                 DPTArray((0x00, 0x00, 0x0F, 0x64, 0x65, 0x66, 0x67))
             ),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_rgbw_test.py
+++ b/test/remote_value_tests/remote_value_color_rgbw_test.py
@@ -53,14 +53,14 @@ class TestRemoteValueColorRGBW:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueColorRGBW(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(RGBWColor(100, 101, 102, 103))
+        remote_value.set(RGBWColor(100, 101, 102, 103))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67, 0x00, 0x0F))),
         )
-        await remote_value.set(RGBWColor(100, 101, 104, 105))
+        remote_value.set(RGBWColor(100, 101, 104, 105))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_color_xyy_test.py
+++ b/test/remote_value_tests/remote_value_color_xyy_test.py
@@ -69,7 +69,7 @@ class TestRemoteValueColorXYY:
             payload=GroupValueWrite(DPTArray((0xFF, 0xFF, 0xE6, 0x66, 0xFF, 0x03))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx, group_address=GroupAddress("1/2/3"))
@@ -77,10 +77,10 @@ class TestRemoteValueColorXYY:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0xFF, 0xFF, 0x66, 0x66, 0xFA, 0x03))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == XYYColor((1, 0.4), 250)
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx, group_address=GroupAddress("1/2/3"))
@@ -89,12 +89,12 @@ class TestRemoteValueColorXYY:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65, 0x66, 0x67))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_color_xyy_test.py
+++ b/test/remote_value_tests/remote_value_color_xyy_test.py
@@ -54,14 +54,14 @@ class TestRemoteValueColorXYY:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueColorXYY(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(XYYColor((1, 0.9), 102))
+        remote_value.set(XYYColor((1, 0.9), 102))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0xFF, 0xFF, 0xE6, 0x66, 0x66, 0x03))),
         )
-        await remote_value.set(XYYColor((1, 0.9), 255))
+        remote_value.set(XYYColor((1, 0.9), 255))
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_control_test.py
+++ b/test/remote_value_tests/remote_value_control_test.py
@@ -25,7 +25,7 @@ class TestRemoteValueControl:
         remote_value = RemoteValueControl(
             xknx, group_address=GroupAddress("1/2/3"), value_type="stepwise"
         )
-        await remote_value.set(25)
+        remote_value.set(25)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_control_test.py
+++ b/test/remote_value_tests/remote_value_control_test.py
@@ -33,7 +33,7 @@ class TestRemoteValueControl:
             payload=GroupValueWrite(DPTBinary(0xB)),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueControl(
@@ -44,10 +44,10 @@ class TestRemoteValueControl:
             payload=GroupValueWrite(DPTBinary(0xB)),
         )
         assert remote_value.value is None
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == 25
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueControl(
@@ -58,12 +58,12 @@ class TestRemoteValueControl:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray(0x01)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(0x10)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -55,7 +55,7 @@ class TestRemoteValueDptValue1Ucount:
             payload=GroupValueWrite(DPTArray((0x0B,))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueDptValue1Ucount(
@@ -65,10 +65,10 @@ class TestRemoteValueDptValue1Ucount:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x0A,))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == 10
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueDptValue1Ucount(
@@ -79,12 +79,12 @@ class TestRemoteValueDptValue1Ucount:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
+++ b/test/remote_value_tests/remote_value_dpt_value_1_ucount_test.py
@@ -40,14 +40,14 @@ class TestRemoteValueDptValue1Ucount:
         remote_value = RemoteValueDptValue1Ucount(
             xknx, group_address=GroupAddress("1/2/3")
         )
-        await remote_value.set(10)
+        remote_value.set(10)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x0A,))),
         )
-        await remote_value.set(11)
+        remote_value.set(11)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_raw_test.py
+++ b/test/remote_value_tests/remote_value_raw_test.py
@@ -47,14 +47,14 @@ class TestRemoteValueRaw:
         rv_1 = RemoteValueRaw(xknx, payload_length=1, group_address="1/2/3")
         rv_2 = RemoteValueRaw(xknx, payload_length=2, group_address="1/2/3")
 
-        await rv_0.set(0)
+        rv_0.set(0)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(False)),
         )
-        await rv_0.set(63)
+        rv_0.set(63)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -62,14 +62,14 @@ class TestRemoteValueRaw:
             payload=GroupValueWrite(DPTBinary(0x3F)),
         )
 
-        await rv_1.set(0)
+        rv_1.set(0)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x00,))),
         )
-        await rv_1.set(63)
+        rv_1.set(63)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -77,14 +77,14 @@ class TestRemoteValueRaw:
             payload=GroupValueWrite(DPTArray((0x3F,))),
         )
 
-        await rv_2.set(0)
+        rv_2.set(0)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x00, 0x00))),
         )
-        await rv_2.set(63)
+        rv_2.set(63)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_raw_test.py
+++ b/test/remote_value_tests/remote_value_raw_test.py
@@ -92,7 +92,7 @@ class TestRemoteValueRaw:
             payload=GroupValueWrite(DPTArray((0x00, 0x3F))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         rv_0 = RemoteValueRaw(xknx, payload_length=0, group_address="1/0/0")
@@ -103,24 +103,24 @@ class TestRemoteValueRaw:
             destination_address=GroupAddress("1/0/0"),
             payload=GroupValueWrite(DPTBinary(0)),
         )
-        await rv_0.process(telegram)
+        rv_0.process(telegram)
         assert rv_0.value == 0
 
         telegram = Telegram(
             destination_address=GroupAddress("1/1/1"),
             payload=GroupValueWrite(DPTArray((0x64,))),
         )
-        await rv_1.process(telegram)
+        rv_1.process(telegram)
         assert rv_1.value == 100
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTArray((0x12, 0x34))),
         )
-        await rv_2.process(telegram)
+        rv_2.process(telegram)
         assert rv_2.value == 4660
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         rv_0 = RemoteValueRaw(xknx, payload_length=0, group_address="1/0/0")
@@ -131,39 +131,39 @@ class TestRemoteValueRaw:
             destination_address=GroupAddress("1/0/0"),
             payload=GroupValueWrite(DPTArray((0x01,))),
         )
-        assert await rv_0.process(telegram) is False
+        assert rv_0.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/0/0"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await rv_0.process(telegram) is False
+        assert rv_0.process(telegram) is False
         assert rv_0.value is None
 
         telegram = Telegram(
             destination_address=GroupAddress("1/1/1"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await rv_1.process(telegram) is False
+        assert rv_1.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/1/1"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await rv_1.process(telegram) is False
+        assert rv_1.process(telegram) is False
         assert rv_1.value is None
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await rv_2.process(telegram) is False
+        assert rv_2.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/2"),
             payload=GroupValueWrite(DPTArray((0x64,))),
         )
-        assert await rv_2.process(telegram) is False
+        assert rv_2.process(telegram) is False
         assert rv_2.value is None
 
     def test_to_knx_error(self):

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -38,14 +38,14 @@ class TestRemoteValueSceneNumber:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set(11)
+        remote_value.set(11)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x0A,))),
         )
-        await remote_value.set(12)
+        remote_value.set(12)
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_scene_number_test.py
+++ b/test/remote_value_tests/remote_value_scene_number_test.py
@@ -53,7 +53,7 @@ class TestRemoteValueSceneNumber:
             payload=GroupValueWrite(DPTArray((0x0B,))),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
@@ -61,10 +61,10 @@ class TestRemoteValueSceneNumber:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x0A,))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == 11
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSceneNumber(xknx, group_address=GroupAddress("1/2/3"))
@@ -73,12 +73,12 @@ class TestRemoteValueSceneNumber:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -67,7 +67,7 @@ class TestRemoteValueStep:
             payload=GroupValueWrite(DPTBinary(1)),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
@@ -76,10 +76,10 @@ class TestRemoteValueStep:
             payload=GroupValueWrite(DPTBinary(0)),
         )
         assert remote_value.value is None
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == RemoteValueStep.Direction.DECREASE
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
@@ -88,12 +88,12 @@ class TestRemoteValueStep:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray(0x01)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(3)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_step_test.py
+++ b/test/remote_value_tests/remote_value_step_test.py
@@ -52,14 +52,14 @@ class TestRemoteValueStep:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueStep(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.decrease()
+        remote_value.decrease()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(0)),
         )
-        await remote_value.increase()
+        remote_value.increase()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -104,7 +104,7 @@ class TestRemoteValueString:
             ),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
@@ -131,10 +131,10 @@ class TestRemoteValueString:
                 )
             ),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == "AAAAABBBBBCCCC"
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
@@ -143,12 +143,12 @@ class TestRemoteValueString:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64, 0x65))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_string_test.py
+++ b/test/remote_value_tests/remote_value_string_test.py
@@ -85,7 +85,7 @@ class TestRemoteValueString:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueString(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.set("asdf")
+        remote_value.set("asdf")
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
@@ -94,7 +94,7 @@ class TestRemoteValueString:
                 DPTArray((97, 115, 100, 102, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
             ),
         )
-        await remote_value.set("ASDF")
+        remote_value.set("ASDF")
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -67,7 +67,7 @@ class TestRemoteValueSwitch:
             payload=GroupValueWrite(DPTBinary(0)),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
@@ -76,11 +76,11 @@ class TestRemoteValueSwitch:
             payload=GroupValueWrite(DPTBinary(1)),
         )
         assert remote_value.value is None
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.telegram is not None
         assert remote_value.value is True
 
-    async def test_process_off(self):
+    def test_process_off(self):
         """Test process OFF telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
@@ -89,11 +89,11 @@ class TestRemoteValueSwitch:
             payload=GroupValueWrite(DPTBinary(0)),
         )
         assert remote_value.value is None
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.telegram is not None
         assert remote_value.value is False
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
@@ -102,12 +102,12 @@ class TestRemoteValueSwitch:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray(0x01)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(3)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_switch_test.py
+++ b/test/remote_value_tests/remote_value_switch_test.py
@@ -52,14 +52,14 @@ class TestRemoteValueSwitch:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueSwitch(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.on()
+        remote_value.on()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        await remote_value.off()
+        remote_value.off()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/test/remote_value_tests/remote_value_temp_test.py
+++ b/test/remote_value_tests/remote_value_temp_test.py
@@ -34,7 +34,7 @@ class TestRemoteValueTemp:
         with pytest.raises(ConversionError):
             remote_value.to_knx("abc")
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueTemp(xknx, group_address=GroupAddress("1/2/3"))
@@ -42,10 +42,10 @@ class TestRemoteValueTemp:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x04, 0x4C))),
         )
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == 11
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueTemp(xknx, group_address=GroupAddress("1/2/3"))
@@ -54,12 +54,12 @@ class TestRemoteValueTemp:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x64,))),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -1,6 +1,6 @@
 """Unit test for RemoveValue objects."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -31,8 +31,8 @@ class TestRemoteValue:
             remote_value.value = "a"
         # new value is used in response Telegram
         test_payload = remote_value.to_knx(2.2)
-        remote_value._send = AsyncMock()
-        await remote_value.respond()
+        remote_value._send = Mock()
+        remote_value.respond()
         remote_value._send.assert_called_with(test_payload, response=True)
         # callback is not called when setting value programmatically
         remote_value.after_update_cb.assert_not_called()
@@ -60,7 +60,7 @@ class TestRemoteValue:
         xknx = XKNX()
         remote_value = RemoteValue(xknx)
         with patch("logging.Logger.info") as mock_info:
-            await remote_value.set(23)
+            remote_value.set(23)
             mock_info.assert_called_with(
                 "Setting value of uninitialized device: %s - %s (value: %s)",
                 "Unknown",
@@ -73,7 +73,7 @@ class TestRemoteValue:
         xknx = XKNX()
         remote_value = RemoteValue(xknx, group_address_state=GroupAddress("1/2/3"))
         with patch("logging.Logger.warning") as mock_warning:
-            await remote_value.set(23)
+            remote_value.set(23)
             mock_warning.assert_called_with(
                 "Attempted to set value for non-writable device: %s - %s (value: %s)",
                 "Unknown",

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -67,7 +67,7 @@ class TestRemoteValueUpDown:
             payload=GroupValueWrite(DPTBinary(0)),
         )
 
-    async def test_process(self):
+    def test_process(self):
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
@@ -76,10 +76,10 @@ class TestRemoteValueUpDown:
             payload=GroupValueWrite(DPTBinary(1)),
         )
         assert remote_value.value is None
-        await remote_value.process(telegram)
+        remote_value.process(telegram)
         assert remote_value.value == RemoteValueUpDown.Direction.DOWN
 
-    async def test_to_process_error(self):
+    def test_to_process_error(self):
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
@@ -88,12 +88,12 @@ class TestRemoteValueUpDown:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray(0x01)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(3)),
         )
-        assert await remote_value.process(telegram) is False
+        assert remote_value.process(telegram) is False
 
         assert remote_value.value is None

--- a/test/remote_value_tests/remote_value_updown_test.py
+++ b/test/remote_value_tests/remote_value_updown_test.py
@@ -52,14 +52,14 @@ class TestRemoteValueUpDown:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueUpDown(xknx, group_address=GroupAddress("1/2/3"))
-        await remote_value.down()
+        remote_value.down()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTBinary(1)),
         )
-        await remote_value.up()
+        remote_value.up()
         assert xknx.telegrams.qsize() == 1
         telegram = xknx.telegrams.get_nowait()
         assert telegram == Telegram(

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -82,12 +82,12 @@ class BinarySensor(Device):
         """Return the last telegram received from the RemoteValue."""
         return self.remote_value.telegram
 
-    async def _state_from_remote_value(self) -> None:
+    def _state_from_remote_value(self) -> None:
         """Update the internal state from RemoteValue (Callback)."""
         if self.remote_value.value is not None:
-            await self._set_internal_state(self.remote_value.value)
+            self._set_internal_state(self.remote_value.value)
 
-    async def _set_internal_state(self, state: bool) -> None:
+    def _set_internal_state(self, state: bool) -> None:
         """Set the internal state of the device. If state was changed after_update hooks and connected Actions are executed."""
         if state != self.state or self.ignore_internal_state:
             self.state = state
@@ -99,16 +99,16 @@ class BinarySensor(Device):
                     async_func=partial(self._counter_task, self._context_timeout),
                 ).start()
             else:
-                await self.after_update()
+                self.after_update()
 
     async def _counter_task(self, wait_seconds: float) -> None:
         """Trigger after 1 second to prevent double triggers."""
         await asyncio.sleep(wait_seconds)
-        await self.after_update()
+        self.after_update()
 
         self._count_set_on = 0
         self._count_set_off = 0
-        await self.after_update()
+        self.after_update()
 
     @property
     def counter(self) -> int | None:
@@ -147,12 +147,12 @@ class BinarySensor(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        if await self.remote_value.process(telegram, always_callback=True):
+        if self.remote_value.process(telegram, always_callback=True):
             self._process_reset_after()
 
     async def process_group_response(self, telegram: Telegram) -> None:
         """Process incoming GroupValueResponse telegrams."""
-        if await self.remote_value.process(telegram, always_callback=False):
+        if self.remote_value.process(telegram, always_callback=False):
             self._process_reset_after()
 
     def _process_reset_after(self) -> None:
@@ -166,7 +166,7 @@ class BinarySensor(Device):
 
     async def _reset_state(self, wait_seconds: float) -> None:
         await asyncio.sleep(wait_seconds)
-        await self._set_internal_state(False)
+        self._set_internal_state(False)
 
     def is_on(self) -> bool:
         """Return if binary sensor is 'on'."""

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -170,11 +170,11 @@ class Climate(Device):
 
     async def turn_on(self) -> None:
         """Set power status to on."""
-        await self.on.on()
+        self.on.on()
 
     async def turn_off(self) -> None:
         """Set power status to off."""
-        await self.on.off()
+        self.on.off()
 
     @property
     def initialized_for_setpoint_shift_calculations(self) -> bool:
@@ -198,7 +198,7 @@ class Climate(Device):
             validated_temp = self.validate_value(
                 target_temperature, self.min_temp, self.max_temp
             )
-            await self.target_temperature.set(validated_temp)
+            self.target_temperature.set(validated_temp)
 
     @property
     def base_temperature(self) -> float | None:
@@ -240,10 +240,10 @@ class Climate(Device):
             offset, self.setpoint_shift_min, self.setpoint_shift_max
         )
         base_temperature = self.base_temperature
-        await self._setpoint_shift.set(validated_offset)
+        self._setpoint_shift.set(validated_offset)
         # broadcast new target temperature and set internally
         if self.target_temperature.writable and base_temperature is not None:
-            await self.target_temperature.set(base_temperature + validated_offset)
+            self.target_temperature.set(base_temperature + validated_offset)
 
     @property
     def target_temperature_max(self) -> float | None:

--- a/xknx/devices/climate.py
+++ b/xknx/devices/climate.py
@@ -7,7 +7,6 @@ Module for managing the climate within a room.
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterator
 import logging
 from typing import TYPE_CHECKING, Any
@@ -267,12 +266,9 @@ class Climate(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await asyncio.gather(
-            *[
-                remote_value.process(telegram)
-                for remote_value in self._iter_remote_values()
-            ]
-        )
+        for remote_value in self._iter_remote_values():
+            remote_value.process(telegram)
+
         if self.mode is not None:
             await self.mode.process_group_write(telegram)
 

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -217,21 +217,19 @@ class ClimateMode(Device):
         yield self.remote_value_controller_mode
         yield self.remote_value_heat_cool
 
-    async def _set_internal_operation_mode(
-        self, operation_mode: HVACOperationMode
-    ) -> None:
+    def _set_internal_operation_mode(self, operation_mode: HVACOperationMode) -> None:
         """Set internal value of operation mode. Call hooks if operation mode was changed."""
         if operation_mode != self.operation_mode:
             self.operation_mode = operation_mode
-            await self.after_update()
+            self.after_update()
 
-    async def _set_internal_controller_mode(
+    def _set_internal_controller_mode(
         self, controller_mode: HVACControllerMode
     ) -> None:
         """Set internal value of controller mode. Call hooks if controller mode was changed."""
         if controller_mode != self.controller_mode:
             self.controller_mode = controller_mode
-            await self.after_update()
+            self.after_update()
 
     async def set_operation_mode(self, operation_mode: HVACOperationMode) -> None:
         """Set the operation mode of a thermostat. Send new operation_mode to BUS and update internal state."""
@@ -251,7 +249,7 @@ class ClimateMode(Device):
             ):
                 rv_operation.set(operation_mode)
 
-        await self._set_internal_operation_mode(operation_mode)
+        self._set_internal_operation_mode(operation_mode)
 
     async def set_controller_mode(self, controller_mode: HVACControllerMode) -> None:
         """Set the controller mode of a thermostat. Send new controller mode to the bus and update internal state."""
@@ -271,7 +269,7 @@ class ClimateMode(Device):
             ):
                 rv_controller.set(controller_mode)
 
-        await self._set_internal_controller_mode(controller_mode)
+        self._set_internal_controller_mode(controller_mode)
 
     @property
     def operation_modes(self) -> list[HVACOperationMode]:
@@ -309,17 +307,17 @@ class ClimateMode(Device):
         """Process incoming and outgoing GROUP WRITE telegram."""
         if self.supports_operation_mode:
             for rv_mode in self._iter_operation_remote_values():
-                if await rv_mode.process(telegram):
+                if rv_mode.process(telegram):
                     #  ignore inactive RemoteValueBinaryOperationMode
                     if rv_mode.value:
-                        await self._set_internal_operation_mode(rv_mode.value)
+                        self._set_internal_operation_mode(rv_mode.value)
                         return
 
         if self.supports_controller_mode:
             for rv_controller in self._iter_controller_remote_values():
-                if await rv_controller.process(telegram):
+                if rv_controller.process(telegram):
                     if rv_controller.value is not None:
-                        await self._set_internal_controller_mode(rv_controller.value)
+                        self._set_internal_controller_mode(rv_controller.value)
                     return
 
     def __str__(self) -> str:

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -249,7 +249,7 @@ class ClimateMode(Device):
                 rv_operation.writable
                 and operation_mode in rv_operation.supported_operation_modes()
             ):
-                await rv_operation.set(operation_mode)
+                rv_operation.set(operation_mode)
 
         await self._set_internal_operation_mode(operation_mode)
 
@@ -269,7 +269,7 @@ class ClimateMode(Device):
                 rv_controller.writable
                 and controller_mode in rv_controller.supported_operation_modes()
             ):
-                await rv_controller.set(controller_mode)
+                rv_controller.set(controller_mode)
 
         await self._set_internal_controller_mode(controller_mode)
 

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -166,48 +166,48 @@ class Cover(Device):
     async def set_down(self) -> None:
         """Move cover down."""
         if self.updown.writable:
-            await self.updown.down()
+            self.updown.down()
             self._travel_direction_tilt = None
             await self._start_position_update(
                 target_position=self.travelcalculator.position_closed
             )
         elif self.position_target.writable:
-            await self.position_target.set(self.travelcalculator.position_closed)
+            self.position_target.set(self.travelcalculator.position_closed)
 
     async def set_up(self) -> None:
         """Move cover up."""
         if self.updown.writable:
-            await self.updown.up()
+            self.updown.up()
             self._travel_direction_tilt = None
             await self._start_position_update(
                 target_position=self.travelcalculator.position_open
             )
         elif self.position_target.writable:
-            await self.position_target.set(self.travelcalculator.position_open)
+            self.position_target.set(self.travelcalculator.position_open)
 
     async def set_short_down(self) -> None:
         """Move cover short down."""
-        await self.step.increase()
+        self.step.increase()
 
     async def set_short_up(self) -> None:
         """Move cover short up."""
-        await self.step.decrease()
+        self.step.decrease()
 
     async def stop(self) -> None:
         """Stop cover."""
         if self.stop_.writable:
-            await self.stop_.on()
+            self.stop_.on()
         elif self.step.writable:
             if TravelStatus.DIRECTION_UP in (
                 self.travelcalculator.travel_direction,
                 self._travel_direction_tilt,
             ):
-                await self.step.decrease()
+                self.step.decrease()
             elif TravelStatus.DIRECTION_DOWN in (
                 self.travelcalculator.travel_direction,
                 self._travel_direction_tilt,
             ):
-                await self.step.increase()
+                self.step.increase()
         else:
             logger.warning("Stop not supported for device %s", self.get_name())
             return
@@ -217,16 +217,16 @@ class Cover(Device):
     async def set_position(self, position: int) -> None:
         """Move cover to a desginated position."""
         if self.position_target.writable:
-            await self.position_target.set(position)
+            self.position_target.set(position)
             return
         # No direct positioning group address defined
         # fully open or close is always possible even if current position is not known
         current_position = self.travelcalculator.current_position()
         if current_position is None:
             if position == self.travelcalculator.position_open:
-                await self.updown.up()
+                self.updown.up()
             elif position == self.travelcalculator.position_closed:
-                await self.updown.down()
+                self.updown.down()
             else:
                 logger.warning(
                     "Current position unknown. Initialize cover by moving to end position."
@@ -235,9 +235,9 @@ class Cover(Device):
             await self._start_position_update(target_position=position)
             return
         if position < current_position:
-            await self.updown.up()
+            self.updown.up()
         elif position > current_position:
-            await self.updown.down()
+            self.updown.down()
         await self._start_position_update(target_position=position)
         # If device does not support auto_positioning,
         # we have to stop the device when position is reached,
@@ -334,7 +334,7 @@ class Cover(Device):
             else TravelStatus.DIRECTION_UP
         )
 
-        await self.angle.set(angle)
+        self.angle.set(angle)
 
     async def sync(self, wait_for_result: bool = False) -> None:
         """Read states of device from KNX bus."""

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -104,7 +104,7 @@ class DateTime(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.remote_value.process(telegram)
+        self.remote_value.process(telegram)
 
     async def process_group_read(self, telegram: Telegram) -> None:
         """Process incoming GROUP READ telegram."""

--- a/xknx/devices/datetime.py
+++ b/xknx/devices/datetime.py
@@ -96,11 +96,11 @@ class DateTime(Device):
 
     async def broadcast_localtime(self, response: bool = False) -> None:
         """Broadcast the local time to KNX bus."""
-        await self.remote_value.set(time.localtime(), response=response)
+        self.remote_value.set(time.localtime(), response=response)
 
     async def set(self, struct_time: time.struct_time) -> None:
         """Set time and send to KNX bus."""
-        await self.remote_value.set(struct_time)
+        self.remote_value.set(struct_time)
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
@@ -114,7 +114,7 @@ class DateTime(Device):
             self.respond_to_read
             and telegram.destination_address == self.remote_value.group_address
         ):
-            await self.remote_value.respond()
+            self.remote_value.respond()
 
     async def sync(self, wait_for_result: bool = False) -> None:
         """Read state of device from KNX bus. Used here to broadcast time to KNX bus."""

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -95,9 +95,9 @@ class ExposeSensor(Device):
         if not self.respond_to_read:
             return
         if self._cooldown_latest_value is not None:
-            await self.sensor_value.set(self._cooldown_latest_value, response=True)
+            self.sensor_value.set(self._cooldown_latest_value, response=True)
             return
-        await self.sensor_value.respond()
+        self.sensor_value.respond()
 
     async def set(self, value: Any) -> None:
         """Set new value."""
@@ -109,7 +109,7 @@ class ExposeSensor(Device):
                 name=self._cooldown_task_name,
                 async_func=self._cooldown_wait,
             ).start()
-        await self.sensor_value.set(value)
+        self.sensor_value.set(value)
 
     async def _cooldown_wait(self) -> None:
         """Send value after cooldown if it differs from last processed value."""
@@ -117,7 +117,7 @@ class ExposeSensor(Device):
             await asyncio.sleep(self.cooldown)
             if self.sensor_value.value == self._cooldown_latest_value:
                 break
-            await self.sensor_value.set(self._cooldown_latest_value)  # type: ignore[arg-type]
+            self.sensor_value.set(self._cooldown_latest_value)  # type: ignore[arg-type]
 
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -71,10 +71,10 @@ class ExposeSensor(Device):
         self._cooldown_task: Task | None = None
         self._cooldown_task_name = f"expose_sensor.cooldown_{id(self)}"
 
-    async def after_update(self) -> None:
+    def after_update(self) -> None:
         """Call after state was updated."""
         self._cooldown_latest_value = self.sensor_value.value
-        await super().after_update()
+        super().after_update()
 
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:
         """Iterate the devices RemoteValue classes."""
@@ -88,7 +88,7 @@ class ExposeSensor(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.sensor_value.process(telegram)
+        self.sensor_value.process(telegram)
 
     async def process_group_read(self, telegram: Telegram) -> None:
         """Process incoming GROUP READ telegram."""

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -9,7 +9,6 @@ It provides functionality for
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Iterator
 from enum import Enum
 import logging
@@ -155,11 +154,9 @@ class Fan(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await asyncio.gather(
-            self.switch.process(telegram),
-            self.speed.process(telegram),
-            self.oscillation.process(telegram),
-        )
+        self.switch.process(telegram)
+        self.speed.process(telegram)
+        self.oscillation.process(telegram)
 
     @property
     def current_speed(self) -> int | None:

--- a/xknx/devices/fan.py
+++ b/xknx/devices/fan.py
@@ -130,7 +130,7 @@ class Fan(Device):
     async def turn_on(self, speed: int | None = None) -> None:
         """Turn on fan."""
         if self.switch.initialized:
-            await self.switch.on()
+            self.switch.on()
             # For a switch GA fan, we only use an explicitly provided speed, but not
             # arbitrarily set a default speed here, compared to the speed GA based fans below.
             if speed is not None:
@@ -141,17 +141,17 @@ class Fan(Device):
     async def turn_off(self) -> None:
         """Turn off fan."""
         if self.switch.initialized:
-            await self.switch.off()
+            self.switch.off()
         else:
             await self.set_speed(0)
 
     async def set_speed(self, speed: int) -> None:
         """Set the fan to a designated speed."""
-        await self.speed.set(speed)
+        self.speed.set(speed)
 
     async def set_oscillation(self, oscillation: bool) -> None:
         """Set the fan oscillation mode on or off."""
-        await self.oscillation.set(oscillation)
+        self.oscillation.set(oscillation)
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -96,18 +96,18 @@ class _SwitchAndBrightness:
     async def set_on(self) -> None:
         """Switch light on."""
         if self.switch.writable:
-            await self.switch.on()
+            self.switch.on()
             return
         if self.brightness.writable:
-            await self.brightness.set(self.brightness.range_to)
+            self.brightness.set(self.brightness.range_to)
 
     async def set_off(self) -> None:
         """Switch light off."""
         if self.switch.writable:
-            await self.switch.off()
+            self.switch.off()
             return
         if self.brightness.writable:
-            await self.brightness.set(0)
+            self.brightness.set(0)
 
     def __eq__(self, other: object) -> bool:
         """Compare for equality."""
@@ -433,7 +433,7 @@ class Light(Device):
     async def set_on(self) -> None:
         """Switch light on."""
         if self.switch.writable:
-            await self.switch.on()
+            self.switch.on()
             return
         await asyncio.gather(
             *[color.set_on() for color in self._iter_individual_colors()]
@@ -442,7 +442,7 @@ class Light(Device):
     async def set_off(self) -> None:
         """Switch light off."""
         if self.switch.writable:
-            await self.switch.off()
+            self.switch.off()
             return
         await asyncio.gather(
             *[color.set_off() for color in self._iter_individual_colors()]
@@ -458,7 +458,7 @@ class Light(Device):
         if not self.supports_brightness:
             logger.warning("Dimming not supported for device %s", self.get_name())
             return
-        await self.brightness.set(brightness)
+        self.brightness.set(brightness)
 
     @property
     def current_color(self) -> tuple[tuple[int, int, int] | None, int | None]:
@@ -510,32 +510,28 @@ class Light(Device):
         if white is not None:
             if self.supports_rgbw:
                 if self.rgbw.initialized:
-                    await self.rgbw.set(RGBWColor(*color, white))
+                    self.rgbw.set(RGBWColor(*color, white))
                     return
                 if all(
                     c.brightness.initialized for c in self._iter_individual_colors()
                 ):
-                    await asyncio.gather(
-                        self.red.brightness.set(color[0]),
-                        self.green.brightness.set(color[1]),
-                        self.blue.brightness.set(color[2]),
-                        self.white.brightness.set(white),
-                    )
+                    self.red.brightness.set(color[0])
+                    self.green.brightness.set(color[1])
+                    self.blue.brightness.set(color[2])
+                    self.white.brightness.set(white)
                     return
             logger.warning("RGBW not supported for device %s", self.get_name())
         else:
             if self.supports_color:
                 if self.color.initialized:
-                    await self.color.set(RGBColor(*color))
+                    self.color.set(RGBColor(*color))
                     return
                 if all(
                     c.brightness.initialized for c in (self.red, self.green, self.blue)
                 ):
-                    await asyncio.gather(
-                        self.red.brightness.set(color[0]),
-                        self.green.brightness.set(color[1]),
-                        self.blue.brightness.set(color[2]),
-                    )
+                    self.red.brightness.set(color[0])
+                    self.green.brightness.set(color[1])
+                    self.blue.brightness.set(color[2])
                     return
             logger.warning("Colors not supported for device %s", self.get_name())
 
@@ -560,17 +556,15 @@ class Light(Device):
             return
         value_sent = False
         if (hue := hs_color[0]) != self.hue.value:
-            await self.hue.set(hue)
+            self.hue.set(hue)
             value_sent = True
         if (saturation := hs_color[1]) != self.saturation.value:
-            await self.saturation.set(saturation)
+            self.saturation.set(saturation)
             value_sent = True
         if not value_sent:
             # at least one value shall be sent to enable turn-on by hs_color
-            await asyncio.gather(
-                self.hue.set(hue),
-                self.saturation.set(saturation),
-            )
+            self.hue.set(hue)
+            self.saturation.set(saturation)
 
     async def _xyy_color_from_rv(self) -> None:
         """Update the current xyY-color from RemoteValue (Callback)."""
@@ -591,7 +585,7 @@ class Light(Device):
         if not self.supports_xyy_color:
             logger.warning("XYY-color not supported for device %s", self.get_name())
             return
-        await self.xyy_color.set(xyy)
+        self.xyy_color.set(xyy)
 
     @property
     def current_tunable_white(self) -> int | None:
@@ -603,7 +597,7 @@ class Light(Device):
         if not self.supports_tunable_white:
             logger.warning("Tunable white not supported for device %s", self.get_name())
             return
-        await self.tunable_white.set(tunable_white)
+        self.tunable_white.set(tunable_white)
 
     @property
     def current_color_temperature(self) -> int | float | None:
@@ -618,7 +612,7 @@ class Light(Device):
                 self.get_name(),
             )
             return
-        await self.color_temperature.set(color_temperature)
+        self.color_temperature.set(color_temperature)
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -55,7 +55,7 @@ class Notification(Device):
     async def set(self, message: str) -> None:
         """Set message."""
         cropped_message = message[:14]
-        await self.remote_value.set(cropped_message)
+        self.remote_value.set(cropped_message)
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
@@ -67,7 +67,7 @@ class Notification(Device):
             self.respond_to_read
             and telegram.destination_address == self.remote_value.group_address
         ):
-            await self.remote_value.respond()
+            self.remote_value.respond()
 
     def __str__(self) -> str:
         """Return object as readable string."""

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -59,7 +59,7 @@ class Notification(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.remote_value.process(telegram)
+        self.remote_value.process(telegram)
 
     async def process_group_read(self, telegram: Telegram) -> None:
         """Process incoming GroupValueResponse telegrams."""

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -62,7 +62,7 @@ class NumericValue(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.sensor_value.process(telegram, always_callback=self.always_callback)
+        self.sensor_value.process(telegram, always_callback=self.always_callback)
 
     async def process_group_read(self, telegram: Telegram) -> None:
         """Process incoming GroupValueResponse telegrams."""

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -70,11 +70,11 @@ class NumericValue(Device):
             self.respond_to_read
             and telegram.destination_address == self.sensor_value.group_address
         ):
-            await self.sensor_value.respond()
+            self.sensor_value.respond()
 
     async def set(self, value: float | int) -> None:
         """Set new value."""
-        await self.sensor_value.set(value)
+        self.sensor_value.set(value)
 
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""

--- a/xknx/devices/raw_value.py
+++ b/xknx/devices/raw_value.py
@@ -62,7 +62,7 @@ class RawValue(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.remote_value.process(telegram, always_callback=self.always_callback)
+        self.remote_value.process(telegram, always_callback=self.always_callback)
 
     async def process_group_read(self, telegram: Telegram) -> None:
         """Process incoming GroupValueResponse telegrams."""

--- a/xknx/devices/raw_value.py
+++ b/xknx/devices/raw_value.py
@@ -70,11 +70,11 @@ class RawValue(Device):
             self.respond_to_read
             and telegram.destination_address == self.remote_value.group_address
         ):
-            await self.remote_value.respond()
+            self.remote_value.respond()
 
     async def set(self, value: int) -> None:
         """Set new value."""
-        await self.remote_value.set(value)
+        self.remote_value.set(value)
 
     def resolve_state(self) -> int | None:
         """Return the current state of the sensor as an unsigned integer."""

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -46,7 +46,7 @@ class Scene(Device):
 
     async def run(self) -> None:
         """Activate scene."""
-        await self.scene_value.set(self.scene_number)
+        self.scene_value.set(self.scene_number)
 
     def __str__(self) -> str:
         """Return object as readable string."""

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -79,11 +79,11 @@ class Sensor(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await self.sensor_value.process(telegram, always_callback=self.always_callback)
+        self.sensor_value.process(telegram, always_callback=self.always_callback)
 
     async def process_group_response(self, telegram: Telegram) -> None:
         """Process incoming GroupValueResponse telegrams."""
-        await self.sensor_value.process(telegram)
+        self.sensor_value.process(telegram)
 
     def unit_of_measurement(self) -> str | None:
         """Return the unit of measurement."""

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -75,11 +75,11 @@ class Switch(Device):
 
     async def set_on(self) -> None:
         """Switch on switch."""
-        await self.switch.on()
+        self.switch.on()
 
     async def set_off(self) -> None:
         """Switch off switch."""
-        await self.switch.off()
+        self.switch.off()
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
@@ -97,7 +97,7 @@ class Switch(Device):
             self.respond_to_read
             and telegram.destination_address == self.switch.group_address
         ):
-            await self.switch.respond()
+            self.switch.respond()
 
     async def _reset_state(self, wait_seconds: float) -> None:
         await asyncio.sleep(wait_seconds)

--- a/xknx/devices/switch.py
+++ b/xknx/devices/switch.py
@@ -83,7 +83,7 @@ class Switch(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        if await self.switch.process(telegram):
+        if self.switch.process(telegram):
             if self.reset_after is not None and self.switch.value:
                 self._reset_task = self.xknx.task_registry.register(
                     name=f"switch.reset_{id(self)}",

--- a/xknx/devices/weather.py
+++ b/xknx/devices/weather.py
@@ -15,7 +15,6 @@ It provides functionality for
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable, Iterator
 from datetime import date, datetime
 from enum import Enum
@@ -250,12 +249,8 @@ class Weather(Device):
 
     async def process_group_write(self, telegram: Telegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
-        await asyncio.gather(
-            *[
-                remote_value.process(telegram)
-                for remote_value in self._iter_remote_values()
-            ]
-        )
+        for remote_value in self._iter_remote_values():
+            remote_value.process(telegram)
 
     @property
     def temperature(self) -> float | None:

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -212,9 +212,7 @@ class RemoteValue(ABC, Generic[ValueT]):
                 await self.after_update_cb()
         return True
 
-    async def _send(
-        self, payload: DPTArray | DPTBinary, response: bool = False
-    ) -> None:
+    def _send(self, payload: DPTArray | DPTBinary, response: bool = False) -> None:
         """Send payload as telegram to KNX bus."""
         if self.group_address is None:
             return
@@ -225,9 +223,9 @@ class RemoteValue(ABC, Generic[ValueT]):
             ),
             source_address=self.xknx.current_address,
         )
-        await self.xknx.telegrams.put(telegram)
+        self.xknx.telegrams.put_nowait(telegram)
 
-    async def set(self, value: ValueT, response: bool = False) -> None:
+    def set(self, value: ValueT, response: bool = False) -> None:
         """Set new value."""
         if not self.initialized:
             logger.info(
@@ -246,15 +244,15 @@ class RemoteValue(ABC, Generic[ValueT]):
             )
             return
         payload = self.to_knx(value)
-        await self._send(payload, response)
+        self._send(payload, response)
         # self._value is set and after_update_cb() called when the outgoing telegram is processed.
 
-    async def respond(self) -> None:
+    def respond(self) -> None:
         """Send current payload as GroupValueResponse telegram to KNX bus."""
         if self._value is None:
             return
         payload = self.to_knx(self._value)
-        await self._send(payload, response=True)
+        self._send(payload, response=True)
 
     async def read_state(self, wait_for_result: bool = False) -> None:
         """Send GroupValueRead telegram for state address to KNX bus."""

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -19,8 +19,9 @@ from xknx.dpt import (
 )
 from xknx.dpt.dpt_hvac_mode import HVACControllerMode, HVACModeT, HVACOperationMode
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -54,7 +55,7 @@ class RemoteValueOperationMode(RemoteValueClimateModeBase[HVACOperationMode]):
         device_name: str | None = None,
         feature_name: str = "Climate mode",
         climate_mode_type: ClimateModeType | None = None,
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize remote value of KNX climate mode."""
         super().__init__(
@@ -101,7 +102,7 @@ class RemoteValueControllerMode(RemoteValueClimateModeBase[HVACControllerMode]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Controller Mode",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize remote value of KNX climate mode."""
         super().__init__(
@@ -138,7 +139,7 @@ class RemoteValueBinaryOperationMode(RemoteValueClimateModeBase[HVACOperationMod
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Climate mode binary",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         operation_mode: HVACOperationMode | None = None,
     ):
         """Initialize remote value of KNX DPT 1 representing a climate operation mode."""
@@ -213,7 +214,7 @@ class RemoteValueBinaryHeatCool(RemoteValueClimateModeBase[HVACControllerMode]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Controller mode Heat/Cool",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         controller_mode: HVACControllerMode | None = None,
     ):
         """Initialize remote value of KNX DPT 1 representing a climate controller mode."""

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.dpt.dpt_color import DPTColorRGBW, RGBWColor
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -28,7 +29,7 @@ class RemoteValueColorRGBW(RemoteValue[RGBWColor]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Color RGBW",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
         super().__init__(

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING, Any
 
 from xknx.dpt import DPTControlStepCode
 from xknx.exceptions import ConversionError
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -30,7 +31,7 @@ class RemoteValueControl(RemoteValue[Any]):
         value_type: str | None = None,
         device_name: str | None = None,
         feature_name: str = "Control",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize control remote value."""
         if value_type is None:

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -12,8 +12,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTDate, DPTDateTime, DPTTime
 from xknx.exceptions import ConversionError
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -39,7 +40,7 @@ class RemoteValueDateTime(RemoteValue[time.struct_time]):
         value_type: str = "time",
         device_name: str | None = None,
         feature_name: str = "DateTime",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize RemoteValueDateTime class."""
         try:

--- a/xknx/remote_value/remote_value_raw.py
+++ b/xknx/remote_value/remote_value_raw.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -30,7 +31,7 @@ class RemoteValueRaw(RemoteValue[int]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Raw",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize RemoteValueRaw class."""
         self.payload_length = payload_length

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -28,7 +29,7 @@ class RemoteValueScaling(RemoteValue[int]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Value",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         range_from: int = 0,
         range_to: int = 100,
     ):

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING, TypeVar
 
 from xknx.dpt import DPTBase, DPTNumeric, DPTString
 from xknx.exceptions import ConversionError
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -36,7 +37,7 @@ class _RemoteValueGeneric(RemoteValue[ValueT]):
         value_type: int | str | None = None,
         device_name: str | None = None,
         feature_name: str = "Value",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
     ):
         """Initialize RemoteValueSensor class."""
         _dpt_class = (

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTValue1Count
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -35,7 +36,7 @@ class RemoteValueSetpointShift(RemoteValue[float]):
         group_address_state: GroupAddressesType = None,
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         setpoint_shift_mode: SetpointShiftMode | None = None,
         setpoint_shift_step: float = 0.1,
     ):

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -34,7 +35,7 @@ class RemoteValueStep(RemoteValue["RemoteValueStep.Direction"]):
         group_address_state: GroupAddressesType = None,
         device_name: str | None = None,
         feature_name: str = "Step",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.007."""

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -78,10 +78,10 @@ class RemoteValueStep(RemoteValue["RemoteValueStep.Direction"]):
             feature_name=self.feature_name,
         )
 
-    async def increase(self) -> None:
+    def increase(self) -> None:
         """Increase value."""
-        await self.set(self.Direction.INCREASE)
+        self.set(self.Direction.INCREASE)
 
-    async def decrease(self) -> None:
+    def decrease(self) -> None:
         """Decrease the value."""
-        await self.set(self.Direction.DECREASE)
+        self.set(self.Direction.DECREASE)

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -67,11 +67,11 @@ class RemoteValueSwitch(RemoteValue[bool]):
             feature_name=self.feature_name,
         )
 
-    async def off(self) -> None:
+    def off(self) -> None:
         """Set value to OFF."""
-        await self.set(False)
+        self.set(False)
 
-    async def on(self) -> None:
+    def on(self) -> None:
         """Set value to ON."""
         # pylint: disable=invalid-name
-        await self.set(True)
+        self.set(True)

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -10,8 +10,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -28,7 +29,7 @@ class RemoteValueSwitch(RemoteValue[bool]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "State",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.001."""

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -11,8 +11,9 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
+from xknx.typing import CallbackType
 
-from .remote_value import AsyncCallbackType, GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -34,7 +35,7 @@ class RemoteValueUpDown(RemoteValue["RemoteValueUpDown.Direction"]):
         group_address_state: GroupAddressesType = None,
         device_name: str | None = None,
         feature_name: str = "Up/Down",
-        after_update_cb: AsyncCallbackType | None = None,
+        after_update_cb: CallbackType | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.008."""

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -74,11 +74,11 @@ class RemoteValueUpDown(RemoteValue["RemoteValueUpDown.Direction"]):
             feature_name=self.feature_name,
         )
 
-    async def down(self) -> None:
+    def down(self) -> None:
         """Set value to down."""
-        await self.set(self.Direction.DOWN)
+        self.set(self.Direction.DOWN)
 
-    async def up(self) -> None:
+    def up(self) -> None:
         """Set value to UP."""
         # pylint: disable=invalid-name
-        await self.set(self.Direction.UP)
+        self.set(self.Direction.UP)

--- a/xknx/typing/__init__.py
+++ b/xknx/typing/__init__.py
@@ -1,0 +1,12 @@
+"""Types used by XKNX."""
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from xknx.devices import Device
+
+CallbackType = Callable[[], None]
+
+DeviceT = TypeVar("DeviceT", bound="Device")
+DeviceCallbackType = Callable[[DeviceT], None]

--- a/xknx/xknx.py
+++ b/xknx/xknx.py
@@ -29,6 +29,7 @@ from xknx.io import (
 )
 from xknx.management import Management
 from xknx.telegram import GroupAddress, GroupAddressType, IndividualAddress, Telegram
+from xknx.typing import DeviceCallbackType
 
 from .__version__ import __version__ as VERSION
 
@@ -42,7 +43,7 @@ class XKNX:
         self,
         address_format: GroupAddressType = GroupAddressType.LONG,
         telegram_received_cb: Callable[[Telegram], Awaitable[None]] | None = None,
-        device_updated_cb: Callable[[Device], Awaitable[None]] | None = None,
+        device_updated_cb: DeviceCallbackType[Device] | None = None,
         connection_state_changed_cb: Callable[[XknxConnectionState], Awaitable[None]]
         | None = None,
         rate_limit: int = 0,


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Change callback signatures from awaitable to callable in `XKNX.device_updated_cb`, Device, Devices and RemoteValue
- Change `RemoteValue.after_update_cb` from awaitable to callable. Remove `async` from `RemoteValue.set`, `.respond`, `.process` and `.update_value` (nothing has to be awaited there).

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)