### PR TITLE
Refactor ClimateMode and add DPTHVACStatus

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -29,6 +29,7 @@ nav_order: 2
 
 - A Device doesn't auto-add to `xknx.devices` anymore. It can be done via `xknx.devices.async_add()` now. `xknx.devices.async_remove` stops a device from processing telegrams, removes from StateUpdater and cancels its internal tasks. Removed devices can be added again.
 - `Device.shutdown` method is removed
+- Refactor `ClimateMode` device
 
 ### DPT
 
@@ -38,7 +39,10 @@ nav_order: 2
   - 235.001 - DPTTariffActiveEnergy - TariffActiveEnergy
   - 242.600 - DPTColorXYY - XYYColor
   - 251.600 - DPTColorRGBW - RGBWColor
+  - 20.60102 - DPTHVACStatusMode - HVACStatus (removed DPTControllerStatus in favour of this)
 - DPTEnum: Common interface for DPT transcoders with enumueration values. Transcoders accept Enum or string values for encoding.
+  - 20.102 - DPTHVACMode - HVACOperationMode
+  - 20.105 - DPTHVACContrMode - HVACControllerMode
 - Support dict values with "main" and "sub" keys for `DPTBase.parse_transcoder()`
 
 ### Address
@@ -51,6 +55,7 @@ nav_order: 2
 - Convert Telegram and APCI to dataclasses. `Telegram` is not hashable anymore.
 - RemoteValue instances use pre-decoded data from Telegrams if available and `dpt_class` for is set - otherwise they decode the data themselves in `from_knx` like before.
 - Remove unused RemoteValue1Count class
+- Add value argument to RemoteValue `after_update_cb` callback
 
 # 2.12.2 Fix thread leak 2024-03-05
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -39,7 +39,7 @@ nav_order: 2
   - 235.001 - DPTTariffActiveEnergy - TariffActiveEnergy
   - 242.600 - DPTColorXYY - XYYColor
   - 251.600 - DPTColorRGBW - RGBWColor
-  - 20.60102 - DPTHVACStatusMode - HVACStatus (removed DPTControllerStatus in favour of this)
+  - 20.60102 - DPTHVACStatus - HVACStatus (removed DPTControllerStatus in favour of this)
 - DPTEnum: Common interface for DPT transcoders with enumueration values. Transcoders accept Enum or string values for encoding.
   - 20.102 - DPTHVACMode - HVACOperationMode
   - 20.105 - DPTHVACContrMode - HVACControllerMode

--- a/test/dpt_tests/dpt_hvac_mode_test.py
+++ b/test/dpt_tests/dpt_hvac_mode_test.py
@@ -104,7 +104,7 @@ class TestHVACStatus:
         "data",
         [
             {
-                "mode": "happy",  # invalid
+                "mode": 1,  # invalid
                 "dew_point": False,
                 "heat_cool": "heat",
                 "inactive": False,
@@ -113,7 +113,14 @@ class TestHVACStatus:
             {
                 "mode": "comfort",
                 "dew_point": False,
-                "heat_cool": "free",  # invalid
+                "heat_cool": "invalid",  # invalid
+                "inactive": False,
+                "frost_alarm": False,
+            },
+            {
+                "mode": "comfort",
+                "dew_point": False,
+                "heat_cool": "nodem",  # invalid for HVACStatus
                 "inactive": False,
                 "frost_alarm": False,
             },
@@ -161,12 +168,12 @@ class TestDPTHVACStatus:
             (
                 HVACStatus(
                     mode=HVACOperationMode.NIGHT,
-                    dew_point=False,
+                    dew_point=True,
                     heat_cool=HVACControllerMode.COOL,
-                    inactive=True,
-                    frost_alarm=False,
+                    inactive=False,
+                    frost_alarm=True,
                 ),
-                (0b00100010,),
+                (0b00101001,),
             ),
         ],
     )

--- a/test/remote_value_tests/remote_value_climate_mode_test.py
+++ b/test/remote_value_tests/remote_value_climate_mode_test.py
@@ -22,9 +22,7 @@ class TestRemoteValueOperationMode:
     def test_to_knx_operation_mode(self):
         """Test to_knx function with normal operation."""
         xknx = XKNX()
-        remote_value = RemoteValueOperationMode(
-            xknx, climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE
-        )
+        remote_value = RemoteValueOperationMode(xknx)
         assert remote_value.to_knx(HVACOperationMode.COMFORT) == DPTArray((0x01,))
 
     def test_to_knx_controller_mode(self):
@@ -72,9 +70,7 @@ class TestRemoteValueOperationMode:
     def test_from_knx_operation_mode(self):
         """Test from_knx function with normal operation."""
         xknx = XKNX()
-        remote_value = RemoteValueOperationMode(
-            xknx, climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE
-        )
+        remote_value = RemoteValueOperationMode(xknx)
         assert remote_value.from_knx(DPTArray((0x02,))) == HVACOperationMode.STANDBY
 
     def test_from_knx_controller_mode(self):
@@ -94,12 +90,6 @@ class TestRemoteValueOperationMode:
         )
         with pytest.raises(CouldNotParseTelegram):
             remote_value.from_knx(DPTArray((0x9, 0xF)))
-
-    def test_from_knx_operation_mode_error(self):
-        """Test from_knx function with invalid payload."""
-        xknx = XKNX()
-        with pytest.raises(ConversionError):
-            RemoteValueOperationMode(xknx, climate_mode_type=None)
 
     def test_from_knx_binary(self):
         """Test from_knx function with normal operation."""
@@ -134,9 +124,7 @@ class TestRemoteValueOperationMode:
     def test_to_knx_error_operation_mode(self):
         """Test to_knx function with wrong parameter."""
         xknx = XKNX()
-        remote_value = RemoteValueOperationMode(
-            xknx, climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE
-        )
+        remote_value = RemoteValueOperationMode(xknx)
         with pytest.raises(ConversionError):
             remote_value.to_knx(256)
         with pytest.raises(ConversionError):
@@ -172,9 +160,7 @@ class TestRemoteValueOperationMode:
         """Test setting value."""
         xknx = XKNX()
         remote_value = RemoteValueOperationMode(
-            xknx,
-            group_address=GroupAddress("1/2/3"),
-            climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
+            xknx, group_address=GroupAddress("1/2/3")
         )
         remote_value.set(HVACOperationMode.NIGHT)
         assert xknx.telegrams.qsize() == 1
@@ -239,9 +225,7 @@ class TestRemoteValueOperationMode:
         """Test process telegram."""
         xknx = XKNX()
         remote_value = RemoteValueOperationMode(
-            xknx,
-            group_address=GroupAddress("1/2/3"),
-            climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
+            xknx, group_address=GroupAddress("1/2/3")
         )
         telegram = Telegram(
             destination_address=GroupAddress("1/2/3"),
@@ -282,9 +266,7 @@ class TestRemoteValueOperationMode:
         """Test process erroneous telegram."""
         xknx = XKNX()
         remote_value = RemoteValueOperationMode(
-            xknx,
-            group_address=GroupAddress("1/2/3"),
-            climate_mode_type=RemoteValueOperationMode.ClimateModeType.HVAC_MODE,
+            xknx, group_address=GroupAddress("1/2/3")
         )
 
         telegram = Telegram(

--- a/xknx/devices/binary_sensor.py
+++ b/xknx/devices/binary_sensor.py
@@ -82,10 +82,9 @@ class BinarySensor(Device):
         """Return the last telegram received from the RemoteValue."""
         return self.remote_value.telegram
 
-    def _state_from_remote_value(self) -> None:
+    def _state_from_remote_value(self, state: bool) -> None:
         """Update the internal state from RemoteValue (Callback)."""
-        if self.remote_value.value is not None:
-            self._set_internal_state(self.remote_value.value)
+        self._set_internal_state(state)
 
     def _set_internal_state(self, state: bool) -> None:
         """Set the internal state of the device. If state was changed after_update hooks and connected Actions are executed."""

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -18,7 +18,7 @@ from xknx.remote_value.remote_value_climate_mode import (
     RemoteValueBinaryOperationMode,
     RemoteValueClimateModeBase,
     RemoteValueControllerMode,
-    RemoteValueControllerStatus,
+    RemoteValueHVACStatus,
     RemoteValueOperationMode,
 )
 
@@ -74,7 +74,7 @@ class ClimateMode(Device):
             feature_name="Controller mode",
             after_update_cb=self._set_internal_controller_mode,
         )
-        self.remote_value_controller_status = RemoteValueControllerStatus(
+        self.remote_value_controller_status = RemoteValueHVACStatus(
             xknx,
             group_address=group_address_controller_status,
             group_address_state=group_address_controller_status_state,

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -300,17 +300,13 @@ class Cover(Device):
             self._auto_stop_task = None
         self.after_update()
 
-    def _target_position_from_rv(self) -> None:
+    def _target_position_from_rv(self, new_target_postion: int) -> None:
         """Update the target position from RemoteValue (Callback)."""
-        if self.position_target.value is not None:
-            self._start_position_update(target_position=self.position_target.value)
+        self._start_position_update(target_position=new_target_postion)
 
-    def _current_position_from_rv(self) -> None:
+    def _current_position_from_rv(self, new_position: int) -> None:
         """Update the current position from RemoteValue (Callback)."""
         position_before_update = self.travelcalculator.current_position()
-        new_position = self.position_current.value
-        if new_position is None:
-            return
         if self.is_traveling():
             self.travelcalculator.update_position(new_position)
         else:

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -77,7 +77,10 @@ class Device(ABC):
         if device_updated_cb in self.device_updated_cbs:
             self.device_updated_cbs.remove(device_updated_cb)
 
-    def after_update(self: DeviceT) -> None:
+    def after_update(
+        self: DeviceT,
+        *args: Any,  # a single argument may be passed if used as a RemoteValue callback
+    ) -> None:
         """Execute callbacks after internal state has been changed."""
         for device_callback in self.device_updated_cbs:
             try:

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -56,7 +56,7 @@ class ExposeSensor(Device):
                 group_address=group_address,
                 sync_state=False,
                 device_name=self.name,
-                after_update_cb=self.after_update,
+                after_update_cb=self.expose_after_update,
             )
         else:
             self.sensor_value = RemoteValueSensor(
@@ -64,16 +64,16 @@ class ExposeSensor(Device):
                 group_address=group_address,
                 sync_state=False,
                 device_name=self.name,
-                after_update_cb=self.after_update,
+                after_update_cb=self.expose_after_update,
                 value_type=value_type,
             )
         self._cooldown_latest_value: Any | None = None
         self._cooldown_task: Task | None = None
         self._cooldown_task_name = f"expose_sensor.cooldown_{id(self)}"
 
-    def after_update(self) -> None:
+    def expose_after_update(self, value: int | float | str | bool) -> None:
         """Call after state was updated."""
-        self._cooldown_latest_value = self.sensor_value.value
+        self._cooldown_latest_value = value
         super().after_update()
 
     def _iter_remote_values(self) -> Iterator[RemoteValue[Any]]:

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -31,7 +31,7 @@ from xknx.remote_value import (
     RemoteValueScaling,
     RemoteValueSwitch,
 )
-from xknx.typing import CallbackType
+from xknx.remote_value.remote_value import RVCallbackType
 
 from .device import Device, DeviceCallbackType
 
@@ -60,7 +60,7 @@ class _SwitchAndBrightness:
         group_address_brightness: GroupAddressesType = None,
         group_address_brightness_state: GroupAddressesType = None,
         sync_state: bool | int | float | str = True,
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[bool | int] | None = None,
     ):
         self.switch = RemoteValueSwitch(
             xknx,
@@ -361,7 +361,7 @@ class Light(Device):
             )
         )
 
-    def _individual_color_callback_debounce(self) -> None:
+    def _individual_color_callback_debounce(self, *args: Any) -> None:
         """Run callback after all individual colors were updated or timeout passed."""
 
         async def debouncer() -> None:
@@ -563,13 +563,12 @@ class Light(Device):
             self.hue.set(hue)
             self.saturation.set(saturation)
 
-    def _xyy_color_from_rv(self) -> None:
+    def _xyy_color_from_rv(self, xyy_color: XYYColor) -> None:
         """Update the current xyY-color from RemoteValue (Callback)."""
-        new_xyy = self.xyy_color.value
-        if self._xyy_color_valid is not None and new_xyy is not None:
-            self._xyy_color_valid = self._xyy_color_valid | new_xyy
+        if self._xyy_color_valid is not None:
+            self._xyy_color_valid = self._xyy_color_valid | xyy_color
         else:
-            self._xyy_color_valid = new_xyy
+            self._xyy_color_valid = xyy_color
         self.after_update()
 
     @property

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -191,7 +191,7 @@ from .dpt_14 import (
 from .dpt_16 import DPTLatin1, DPTString
 from .dpt_17 import DPTSceneNumber
 from .dpt_19 import DPTDateTime
-from .dpt_20 import DPTControllerStatus, DPTHVACContrMode, DPTHVACMode
+from .dpt_20 import DPTHVACContrMode, DPTHVACMode, DPTHVACStatus
 from .dpt_232 import DPTColorRGB, RGBColor
 from .dpt_235 import DPTTariffActiveEnergy, TariffActiveEnergy
 from .dpt_242 import DPTColorXYY, XYYColor

--- a/xknx/dpt/dpt_20.py
+++ b/xknx/dpt/dpt_20.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Literal
 
-from xknx.exceptions import ConversionError
-
-from .dpt import DPTEnum
+from .dpt import DPTComplex, DPTComplexData, DPTEnum
 from .payload import DPTArray, DPTBinary
 
 
@@ -20,6 +20,26 @@ class HVACOperationMode(Enum):
     STANDBY = "Standby"
     NIGHT = "Night"
     FROST_PROTECTION = "Frost Protection"
+
+
+class DPTHVACMode(DPTEnum[HVACOperationMode]):
+    """
+    Abstraction for KNX HVAC mode.
+
+    DPT 20.102
+    """
+
+    dpt_main_number = 20
+    dpt_sub_number = 102
+    value_type = "hvac_mode"
+    data_type = HVACOperationMode
+    VALUE_MAP = {
+        0: HVACOperationMode.AUTO,
+        1: HVACOperationMode.COMFORT,
+        2: HVACOperationMode.STANDBY,
+        3: HVACOperationMode.NIGHT,
+        4: HVACOperationMode.FROST_PROTECTION,
+    }
 
 
 class HVACControllerMode(Enum):
@@ -74,63 +94,124 @@ class DPTHVACContrMode(DPTEnum[HVACControllerMode]):
         }
 
 
-class DPTHVACMode(DPTEnum[HVACOperationMode]):
-    """
-    Abstraction for KNX HVAC mode.
+@dataclass(slots=True)
+class HVACStatus(DPTComplexData):
+    """Class for HVACStatus."""
 
-    DPT 20.102
+    mode: HVACOperationMode
+    dew_point: bool
+    heat_cool: Literal[HVACControllerMode.HEAT, HVACControllerMode.COOL]
+    inactive: bool
+    frost_alarm: bool
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> HVACStatus:
+        """Init from a dictionary."""
+        try:
+            _mode = data["mode"]
+            _heat_cool = data["heat_cool"]
+            try:
+                mode = HVACOperationMode[_mode.upper()]
+                heat_cool = HVACControllerMode[_heat_cool.upper()]
+            except AttributeError as err:
+                raise ValueError(
+                    f"Invalid type for HVAC mode or heat_cool: {err}"
+                ) from err
+            if heat_cool not in (HVACControllerMode.HEAT, HVACControllerMode.COOL):
+                raise ValueError(f"Invalid value for HVAC heat_cool: {heat_cool=}")
+            dew_point = data["dew_point"]
+            inactive = data["inactive"]
+            frost_alarm = data["frost_alarm"]
+        except KeyError as err:
+            raise ValueError(f"Missing required key: {err}") from err
+
+        if (
+            not isinstance(dew_point, bool)
+            or not isinstance(inactive, bool)
+            or not isinstance(frost_alarm, bool)
+        ):
+            raise ValueError(
+                f"Invalid value for HVACStatus boolean fields: {dew_point=}, {inactive=}, {frost_alarm=}"
+            )
+
+        return cls(
+            mode=mode,
+            dew_point=dew_point,
+            heat_cool=heat_cool,  # type: ignore[arg-type]  # checked by `not in (HVACControllerMode.HEAT, HVACControllerMode.COOL)` above
+            inactive=inactive,
+            frost_alarm=frost_alarm,
+        )
+
+    def as_dict(self) -> dict[str, str | bool]:
+        """Create a JSON serializable dictionary."""
+        return {
+            "mode": self.mode.name.lower(),
+            "dew_point": self.dew_point,
+            "heat_cool": self.heat_cool.name.lower(),
+            "inactive": self.inactive,
+            "frost_alarm": self.frost_alarm,
+        }
+
+
+class DPTHVACStatus(DPTComplex[HVACStatus]):
+    """
+    Abstraction for KNX HVACStatus.
+
+    Non-standardised DP type (in accordance with KNX AN097 “Eberle Status Byte”).
     """
 
+    data_type = HVACStatus
+    payload_type = DPTArray
+    payload_length = 1
     dpt_main_number = 20
-    dpt_sub_number = 102
-    value_type = "hvac_mode"
-    data_type = HVACOperationMode
+    dpt_sub_number = 60102
+    value_type = "hvac_status"
 
     @classmethod
-    def get_value_map(cls) -> Mapping[int, HVACOperationMode]:
-        """Return mapping of raw KNX values to Enum members."""
-        return {
-            0: HVACOperationMode.AUTO,
-            1: HVACOperationMode.COMFORT,
-            2: HVACOperationMode.STANDBY,
-            3: HVACOperationMode.NIGHT,
-            4: HVACOperationMode.FROST_PROTECTION,
-        }
-
-
-class DPTControllerStatus(DPTEnum[HVACOperationMode]):
-    """
-    Abstraction for KNX HVAC Controller status.
-
-    Non-standardised DP type (in accordance with KNX AN 097/07 rev 3).
-
-    Help needed:
-    The values of this type were retrieved by reverse engineering. Any
-    notes on the correct implementation of this type are highly appreciated.
-    """
-
-    data_type = HVACOperationMode
-
-    @classmethod
-    def get_value_map(cls) -> Mapping[int, HVACOperationMode]:
-        """Return mapping of raw KNX values to Enum members."""
-        return {
-            0x21: HVACOperationMode.COMFORT,
-            0x22: HVACOperationMode.STANDBY,
-            0x24: HVACOperationMode.NIGHT,
-            0x28: HVACOperationMode.FROST_PROTECTION,
-        }
-
-    @classmethod
-    def from_knx(cls, payload: DPTArray | DPTBinary) -> HVACOperationMode:
+    def from_knx(cls, payload: DPTArray | DPTBinary) -> HVACStatus:
         """Parse/deserialize from KNX/IP raw data."""
-        raw = cls.validate_payload(payload)
-        if raw[0] & 8 > 0:
-            return HVACOperationMode.FROST_PROTECTION
-        if raw[0] & 4 > 0:
-            return HVACOperationMode.NIGHT
-        if raw[0] & 2 > 0:
-            return HVACOperationMode.STANDBY
-        if raw[0] & 1 > 0:
-            return HVACOperationMode.COMFORT
-        raise ConversionError(f"Payload not supported for {cls.__name__}", raw=raw)
+        raw = cls.validate_payload(payload)[0]
+
+        mode: HVACOperationMode
+        if raw & 0b10000000:
+            mode = HVACOperationMode.COMFORT
+        elif raw & 0b01000000:
+            mode = HVACOperationMode.STANDBY
+        elif raw & 0b00100000:
+            mode = HVACOperationMode.NIGHT
+        elif raw & 0b00010000:
+            mode = HVACOperationMode.FROST_PROTECTION
+        else:
+            mode = HVACOperationMode.AUTO
+
+        return HVACStatus(
+            mode=mode,
+            dew_point=bool(raw & 0b00001000),
+            heat_cool=HVACControllerMode.HEAT
+            if raw & 0b00000100
+            else HVACControllerMode.COOL,
+            inactive=bool(raw & 0b00000010),
+            frost_alarm=bool(raw & 0b00000001),
+        )
+
+    @classmethod
+    def _to_knx(cls, value: HVACStatus) -> DPTArray:
+        """Serialize to KNX/IP raw data."""
+        raw = 0
+        if value.mode is HVACOperationMode.COMFORT:
+            raw |= 0b10000000
+        elif value.mode is HVACOperationMode.STANDBY:
+            raw |= 0b01000000
+        elif value.mode is HVACOperationMode.NIGHT:
+            raw |= 0b00100000
+        elif value.mode is HVACOperationMode.FROST_PROTECTION:
+            raw |= 0b00010000
+        if value.dew_point:
+            raw |= 0b00001000
+        if value.heat_cool is HVACControllerMode.HEAT:
+            raw |= 0b00000100
+        if value.inactive:
+            raw |= 0b00000010
+        if value.frost_alarm:
+            raw |= 0b00000001
+        return DPTArray(raw)

--- a/xknx/dpt/dpt_20.py
+++ b/xknx/dpt/dpt_20.py
@@ -186,7 +186,7 @@ class DPTHVACStatus(DPTComplex[HVACStatus]):
         elif raw & 0b00010000:
             mode = HVACOperationMode.FROST_PROTECTION
         else:
-            mode = HVACOperationMode.AUTO
+            mode = HVACOperationMode.AUTO  # not sure if this is possible / valid
 
         return HVACStatus(
             mode=mode,

--- a/xknx/dpt/dpt_20.py
+++ b/xknx/dpt/dpt_20.py
@@ -33,13 +33,17 @@ class DPTHVACMode(DPTEnum[HVACOperationMode]):
     dpt_sub_number = 102
     value_type = "hvac_mode"
     data_type = HVACOperationMode
-    VALUE_MAP = {
-        0: HVACOperationMode.AUTO,
-        1: HVACOperationMode.COMFORT,
-        2: HVACOperationMode.STANDBY,
-        3: HVACOperationMode.NIGHT,
-        4: HVACOperationMode.FROST_PROTECTION,
-    }
+
+    @classmethod
+    def get_value_map(cls) -> Mapping[int, HVACOperationMode]:
+        """Return mapping of raw KNX values to Enum members."""
+        return {
+            0: HVACOperationMode.AUTO,
+            1: HVACOperationMode.COMFORT,
+            2: HVACOperationMode.STANDBY,
+            3: HVACOperationMode.NIGHT,
+            4: HVACOperationMode.FROST_PROTECTION,
+        }
 
 
 class HVACControllerMode(Enum):

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -58,82 +58,6 @@ class RemoteValueClimateModeBase(RemoteValue[HVACModeT]):
         """Set controller mode. Return if not supported."""
 
 
-class RemoteValueControllerStatus(RemoteValueClimateModeBase[HVACStatus]):
-    """Abstraction for remote value of KNX climate controller status."""
-
-    dpt_class = DPTHVACStatus
-
-    def __init__(
-        self,
-        xknx: XKNX,
-        group_address: GroupAddressesType = None,
-        group_address_state: GroupAddressesType = None,
-        sync_state: bool | int | float | str = True,
-        device_name: str | None = None,
-        feature_name: str = "Controller status",
-        after_update_cb: RVCallbackType[HVACStatus] | None = None,
-    ):
-        """Initialize remote value of KNX climate controller status."""
-        super().__init__(
-            xknx,
-            group_address=group_address,
-            group_address_state=group_address_state,
-            sync_state=sync_state,
-            device_name=device_name,
-            feature_name=feature_name,
-            after_update_cb=after_update_cb,
-        )
-
-    def supported_operation_modes(self) -> list[HVACOperationMode]:
-        """Return a list of all supported operation modes."""
-        return [
-            HVACOperationMode.COMFORT,
-            HVACOperationMode.STANDBY,
-            HVACOperationMode.NIGHT,
-            HVACOperationMode.FROST_PROTECTION,
-        ]
-
-    def set_operation_mode(self, mode: HVACOperationMode) -> None:
-        """Set operation mode. Return if not supported."""
-        if mode not in self.supported_operation_modes():
-            return
-        if self._value is None:
-            raise ConversionError(
-                "HVACStatus value not initialized. Can not write new mode.",
-                device_name=self.device_name,
-            )
-        new_status = HVACStatus(
-            mode=mode,
-            dew_point=self._value.dew_point,
-            heat_cool=self._value.heat_cool,
-            inactive=self._value.inactive,
-            frost_alarm=self._value.frost_alarm,
-        )
-        return super().set(new_status)
-
-    def supported_controller_modes(self) -> list[HVACControllerMode]:
-        """Return a list of all supported controller modes."""
-        return [HVACControllerMode.HEAT, HVACControllerMode.COOL]
-
-    def set_controller_mode(self, mode: HVACControllerMode) -> None:
-        """Set controller mode. Return if not supported."""
-        if mode not in self.supported_controller_modes():
-            return
-        if self._value is None:
-            raise ConversionError(
-                "HVACStatus value not initialized. Can not write new mode.",
-                device_name=self.device_name,
-            )
-        new_status = HVACStatus(
-            mode=self._value.mode,
-            dew_point=self._value.dew_point,
-            heat_cool=mode,  # type: ignore[arg-type]
-            inactive=self._value.inactive,
-            frost_alarm=self._value.frost_alarm,
-        )
-        super().set(new_status)
-
-
 class RemoteValueOperationMode(RemoteValueClimateModeBase[HVACOperationMode]):
     """Abstraction for remote value of KNX climate operation modes."""
 
@@ -222,6 +146,82 @@ class RemoteValueControllerMode(RemoteValueClimateModeBase[HVACControllerMode]):
         if mode not in self.supported_controller_modes():
             return
         super().set(mode)
+
+
+class RemoteValueHVACStatus(RemoteValueClimateModeBase[HVACStatus]):
+    """Abstraction for remote value of KNX climate HVAC status (Eberle status)."""
+
+    dpt_class = DPTHVACStatus
+
+    def __init__(
+        self,
+        xknx: XKNX,
+        group_address: GroupAddressesType = None,
+        group_address_state: GroupAddressesType = None,
+        sync_state: bool | int | float | str = True,
+        device_name: str | None = None,
+        feature_name: str = "Controller status",
+        after_update_cb: RVCallbackType[HVACStatus] | None = None,
+    ):
+        """Initialize remote value of KNX climate controller status."""
+        super().__init__(
+            xknx,
+            group_address=group_address,
+            group_address_state=group_address_state,
+            sync_state=sync_state,
+            device_name=device_name,
+            feature_name=feature_name,
+            after_update_cb=after_update_cb,
+        )
+
+    def supported_operation_modes(self) -> list[HVACOperationMode]:
+        """Return a list of all supported operation modes."""
+        return [
+            HVACOperationMode.COMFORT,
+            HVACOperationMode.STANDBY,
+            HVACOperationMode.NIGHT,
+            HVACOperationMode.FROST_PROTECTION,
+        ]
+
+    def set_operation_mode(self, mode: HVACOperationMode) -> None:
+        """Set operation mode. Return if not supported."""
+        if mode not in self.supported_operation_modes():
+            return
+        if self._value is None:
+            raise ConversionError(
+                "HVACStatus value not initialized. Can not write new mode.",
+                device_name=self.device_name,
+            )
+        new_status = HVACStatus(
+            mode=mode,
+            dew_point=self._value.dew_point,
+            heat_cool=self._value.heat_cool,
+            inactive=self._value.inactive,
+            frost_alarm=self._value.frost_alarm,
+        )
+        return super().set(new_status)
+
+    def supported_controller_modes(self) -> list[HVACControllerMode]:
+        """Return a list of all supported controller modes."""
+        return [HVACControllerMode.HEAT, HVACControllerMode.COOL]
+
+    def set_controller_mode(self, mode: HVACControllerMode) -> None:
+        """Set controller mode. Return if not supported."""
+        if mode not in self.supported_controller_modes():
+            return
+        if self._value is None:
+            raise ConversionError(
+                "HVACStatus value not initialized. Can not write new mode.",
+                device_name=self.device_name,
+            )
+        new_status = HVACStatus(
+            mode=self._value.mode,
+            dew_point=self._value.dew_point,
+            heat_cool=mode,  # type: ignore[arg-type]
+            inactive=self._value.inactive,
+            frost_alarm=self._value.frost_alarm,
+        )
+        super().set(new_status)
 
 
 class RemoteValueBinaryOperationMode(

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -9,9 +9,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary, DPTColorRGBW, RGBWColor
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -28,7 +27,7 @@ class RemoteValueColorRGBW(RemoteValue[RGBWColor]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Color RGBW",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[RGBWColor] | None = None,
     ):
         """Initialize remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
         super().__init__(

--- a/xknx/remote_value/remote_value_control.py
+++ b/xknx/remote_value/remote_value_control.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING, Any
 
 from xknx.dpt import DPTControlStepCode
 from xknx.exceptions import ConversionError
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -31,7 +30,7 @@ class RemoteValueControl(RemoteValue[Any]):
         value_type: str | None = None,
         device_name: str | None = None,
         feature_name: str = "Control",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[Any] | None = None,
     ):
         """Initialize control remote value."""
         if value_type is None:

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -12,9 +12,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTDate, DPTDateTime, DPTTime
 from xknx.exceptions import ConversionError
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -40,7 +39,7 @@ class RemoteValueDateTime(RemoteValue[time.struct_time]):
         value_type: str = "time",
         device_name: str | None = None,
         feature_name: str = "DateTime",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[time.struct_time] | None = None,
     ):
         """Initialize RemoteValueDateTime class."""
         try:

--- a/xknx/remote_value/remote_value_raw.py
+++ b/xknx/remote_value/remote_value_raw.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -31,7 +30,7 @@ class RemoteValueRaw(RemoteValue[int]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Raw",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[int] | None = None,
     ):
         """Initialize RemoteValueRaw class."""
         self.payload_length = payload_length

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -29,7 +28,7 @@ class RemoteValueScaling(RemoteValue[int]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "Value",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[int] | None = None,
         range_from: int = 0,
         range_to: int = 100,
     ):

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING, TypeVar
 
 from xknx.dpt import DPTBase, DPTNumeric, DPTString
 from xknx.exceptions import ConversionError
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -37,7 +36,7 @@ class _RemoteValueGeneric(RemoteValue[ValueT]):
         value_type: int | str | None = None,
         device_name: str | None = None,
         feature_name: str = "Value",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[ValueT] | None = None,
     ):
         """Initialize RemoteValueSensor class."""
         _dpt_class = (

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary, DPTTemperature, DPTValue1Count
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -36,7 +35,7 @@ class RemoteValueSetpointShift(RemoteValue[float]):
         group_address_state: GroupAddressesType = None,
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[float] | None = None,
         setpoint_shift_mode: SetpointShiftMode | None = None,
         setpoint_shift_step: float = 0.1,
     ):

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -35,7 +34,7 @@ class RemoteValueStep(RemoteValue["RemoteValueStep.Direction"]):
         group_address_state: GroupAddressesType = None,
         device_name: str | None = None,
         feature_name: str = "Step",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[Direction] | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.007."""

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -10,9 +10,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -29,7 +28,7 @@ class RemoteValueSwitch(RemoteValue[bool]):
         sync_state: bool | int | float | str = True,
         device_name: str | None = None,
         feature_name: str = "State",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[bool] | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.001."""

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import CallbackType
 
-from .remote_value import GroupAddressesType, RemoteValue
+from .remote_value import GroupAddressesType, RemoteValue, RVCallbackType
 
 if TYPE_CHECKING:
     from xknx.xknx import XKNX
@@ -35,7 +34,7 @@ class RemoteValueUpDown(RemoteValue["RemoteValueUpDown.Direction"]):
         group_address_state: GroupAddressesType = None,
         device_name: str | None = None,
         feature_name: str = "Up/Down",
-        after_update_cb: CallbackType | None = None,
+        after_update_cb: RVCallbackType[Direction] | None = None,
         invert: bool = False,
     ):
         """Initialize remote value of KNX DPT 1.008."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
- Refactor `ClimateMode` device
- Add value argument to RemoteValue `after_update_cb` callback
- Add DPTHVACStatus (Eberle status) and support parsing operation mode and heat/cool from it in ClimateMode
- removed DPTControllerStatus in favour of DPTHVACStatus

Fixes #1348

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)