### PR TITLE
ClimateMode: filter modes for possible values and account for read-only modes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,7 +14,9 @@ nav_order: 2
 
 ### Devices
 
-- Restore `Climate.suppports_operation_mode` and `Climate.supports_controller_mode` to be `True` when read-only (like pre 3.0.0).
+- ClimateMode: Restore `Climate.suppports_operation_mode` and `Climate.supports_controller_mode` to be `True` when read-only (like pre 3.0.0)
+- ClimateMode: Filter custom operation modes for available settable modes
+- ClimateMode: For binary operation modes, only list configured modes and `Standby` in `operation_modes`
 
 ### Bugfixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - Add DPT 1 definitions (as of KNX Specification 03_07_02 version 02.02.01)
 
+### Devices
+
+- Restore `Climate.suppports_operation_mode` and `Climate.supports_controller_mode` to be `True` when read-only (like pre 3.0.0).
+
 ### Bugfixes
 
 - Fix log message for DPT decoding errors in `GroupAddressDPT` parsing

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1328,7 +1328,7 @@ class TestClimate:
         }
 
     def test_supported_operation_modes_heat_cool(self):
-        """Test get_supported_operation_modes with heat_cool group address."""
+        """Test supported controller_modes with heat_cool address."""
         xknx = XKNX()
         climate_mode = ClimateMode(
             xknx,
@@ -1336,7 +1336,23 @@ class TestClimate:
             group_address_heat_cool="1/2/14",
             group_address_heat_cool_state="1/2/15",
         )
+        assert climate_mode.supports_controller_mode
         assert set(climate_mode.controller_modes) == {
+            HVACControllerMode.HEAT,
+            HVACControllerMode.COOL,
+        }
+
+    def test_supported_operation_modes_heat_cool_read_only(self):
+        """Test supported controller_modes with heat_cool_state address."""
+        xknx = XKNX()
+        climate_mode = ClimateMode(
+            xknx,
+            "TestClimate",
+            group_address_heat_cool_state="1/2/15",
+        )
+        assert climate_mode.supports_controller_mode
+        assert climate_mode.controller_modes == []  # only writable modes
+        assert set(climate_mode.gather_controller_modes(only_writable=False)) == {
             HVACControllerMode.HEAT,
             HVACControllerMode.COOL,
         }
@@ -1386,10 +1402,7 @@ class TestClimate:
     def test_custom_supported_controller_modes_when_controller_mode_unsupported(self):
         """Test get_supported_operation_modes with custom mode as str list."""
         str_modes = ["Heat", "Cool"]
-        modes = [
-            HVACControllerMode.HEAT,
-            HVACControllerMode.COOL,
-        ]
+        modes = []
         xknx = XKNX()
         climate_mode = ClimateMode(
             xknx,

--- a/test/devices_tests/climate_test.py
+++ b/test/devices_tests/climate_test.py
@@ -1308,9 +1308,9 @@ class TestClimate:
 
         assert set(climate_mode.operation_modes) == {
             HVACOperationMode.COMFORT,
-            HVACOperationMode.STANDBY,
             HVACOperationMode.ECONOMY,
             HVACOperationMode.BUILDING_PROTECTION,
+            HVACOperationMode.STANDBY,
         }
 
     def test_supported_operation_modes_only_economy(self):
@@ -1319,12 +1319,11 @@ class TestClimate:
         climate_mode = ClimateMode(
             xknx, "TestClimate", group_address_operation_mode_economy="1/2/7"
         )
-        # If one binary climate object is set, all 4 operation modes are supported.
+        # If one binary climate object is set, this mode and Standby are supported.
+        # All binary modes off -> Standby according to MDT heating actuator
         assert set(climate_mode.operation_modes) == {
-            HVACOperationMode.STANDBY,
             HVACOperationMode.ECONOMY,
-            HVACOperationMode.COMFORT,
-            HVACOperationMode.BUILDING_PROTECTION,
+            HVACOperationMode.STANDBY,
         }
 
     def test_supported_operation_modes_heat_cool(self):
@@ -1378,6 +1377,24 @@ class TestClimate:
             xknx,
             "TestClimate",
             group_address_operation_mode="1/2/7",
+            operation_modes=str_modes,
+        )
+        assert climate_mode.operation_modes == modes
+
+    def test_custom_supported_operation_modes_only_valid(self):
+        """Test get_supported_operation_modes with custom mode as str list."""
+        str_modes = [
+            "Standby",
+            "Building Protection",
+            "Comfort",  # Comfort can't be set - no address set
+        ]
+        modes = [HVACOperationMode.STANDBY, HVACOperationMode.BUILDING_PROTECTION]
+        xknx = XKNX()
+        climate_mode = ClimateMode(
+            xknx,
+            "TestClimate",
+            group_address_operation_mode_standby="1/2/7",
+            group_address_operation_mode_protection="1/2/8",
             operation_modes=str_modes,
         )
         assert climate_mode.operation_modes == modes

--- a/xknx/devices/climate_mode.py
+++ b/xknx/devices/climate_mode.py
@@ -139,29 +139,35 @@ class ClimateMode(Device):
         self.operation_mode = HVACOperationMode.STANDBY
         self.controller_mode = HVACControllerMode.HEAT
 
-        self._operation_modes: list[HVACOperationMode] = []
-        if operation_modes is None:
-            self._operation_modes = self.gather_operation_modes(only_writable=True)
-        else:
+        self._operation_modes = self.gather_operation_modes(only_writable=True)
+        if operation_modes is not None:
+            custom_operation_modes = []
             for op_mode in operation_modes:
                 if isinstance(op_mode, str):
-                    self._operation_modes.append(
+                    custom_operation_modes.append(
                         HVACOperationMode[op_mode.replace(" ", "_").upper()]
                     )
                 elif isinstance(op_mode, HVACOperationMode):
-                    self._operation_modes.append(op_mode)
+                    custom_operation_modes.append(op_mode)
+            self._operation_modes = [
+                mode for mode in custom_operation_modes if mode in self._operation_modes
+            ]
 
-        self._controller_modes: list[HVACControllerMode] = []
-        if controller_modes is None:
-            self._controller_modes = self.gather_controller_modes(only_writable=True)
-        else:
+        self._controller_modes = self.gather_controller_modes(only_writable=True)
+        if controller_modes is not None:
+            custom_controller_modes = []
             for ct_mode in controller_modes:
                 if isinstance(ct_mode, str):
-                    self._controller_modes.append(
+                    custom_controller_modes.append(
                         HVACControllerMode[ct_mode.replace(" ", "_").upper()]
                     )
                 elif isinstance(ct_mode, HVACControllerMode):
-                    self._controller_modes.append(ct_mode)
+                    custom_controller_modes.append(ct_mode)
+            self._controller_modes = [
+                mode
+                for mode in custom_controller_modes
+                if mode in self._controller_modes
+            ]
 
         self.supports_operation_mode = bool(
             self.gather_operation_modes(only_writable=False)
@@ -251,15 +257,11 @@ class ClimateMode(Device):
     @property
     def operation_modes(self) -> list[HVACOperationMode]:
         """Return all configured operation modes."""
-        if not self.supports_operation_mode:
-            return []
         return self._operation_modes
 
     @property
     def controller_modes(self) -> list[HVACControllerMode]:
         """Return all configured controller modes."""
-        if not self.supports_controller_mode:
-            return []
         return self._controller_modes
 
     def gather_operation_modes(

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -251,13 +251,6 @@ class RemoteValueBinaryOperationMode(
                 device_name=str(device_name),
                 feature_name=feature_name,
             )
-        if operation_mode not in self.supported_operation_modes():
-            raise ConversionError(
-                "Operation mode not supported for binary mode object",
-                operation_mode=str(operation_mode),
-                device_name=str(device_name),
-                feature_name=feature_name,
-            )
         self.operation_mode = operation_mode
         super().__init__(
             xknx,
@@ -271,17 +264,15 @@ class RemoteValueBinaryOperationMode(
 
     def supported_operation_modes(self) -> list[HVACOperationMode]:
         """Return a list of all supported operation modes."""
-        return [
-            HVACOperationMode.COMFORT,
-            HVACOperationMode.BUILDING_PROTECTION,
-            HVACOperationMode.ECONOMY,
-            HVACOperationMode.STANDBY,
-        ]
+        # all binary operation modes off -> Standby according to MDT
+        return (
+            [self.operation_mode, HVACOperationMode.STANDBY]
+            if self.operation_mode is not HVACOperationMode.STANDBY
+            else [HVACOperationMode.STANDBY]
+        )
 
     def set_operation_mode(self, mode: HVACOperationMode) -> None:
         """Set operation mode. Return if not supported."""
-        if mode not in self.supported_operation_modes():
-            return
         super().set(mode)
 
     def supported_controller_modes(self) -> list[HVACControllerMode]:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

- Restore `Climate.suppports_operation_mode` and `Climate.supports_controller_mode` to be `True` when read-only (like pre 3.0.0)
- Filter custom operation / controller modes for available settable modes
- For binary operation modes, only list configured modes and `Standby` in `operation_modes`

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)