### PR TITLE
P2 p rate limit

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@ nav_order: 2
 
 # Changelog
 
+- Added rate limit (in packets per second) option to P2PConnection.
+- Fix typo in management procedure (`nm_invididual_address_write` was renamed to `nm_individual_address_write`)
 
 # 3.3.0 Climate humidity 2024-10-20
 

--- a/examples/example_write_individual_address.py
+++ b/examples/example_write_individual_address.py
@@ -23,7 +23,7 @@ async def main(argv: list[str]) -> int:
 
     async with XKNX() as xknx:
         individual_address = IndividualAddress(address)
-        await procedures.nm_invididual_address_write(xknx, individual_address)
+        await procedures.nm_individual_address_write(xknx, individual_address)
 
     return 0
 

--- a/test/management_tests/procedures_test.py
+++ b/test/management_tests/procedures_test.py
@@ -249,7 +249,7 @@ async def test_nm_individual_address_write(time_travel):
         payload=apci.IndividualAddressWrite(address=individual_address_new),
     )
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address_new
         )
     )
@@ -309,7 +309,7 @@ async def test_nm_individual_address_write_two_devices_in_programming_mode(time_
     )
 
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address_new
         )
     )
@@ -358,7 +358,7 @@ async def test_nm_individual_address_write_no_device_programming_mode(time_trave
     )
 
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address_new
         )
     )
@@ -428,7 +428,7 @@ async def test_nm_individual_address_write_address_found(time_travel):
     )
 
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address
         )
     )
@@ -490,7 +490,7 @@ async def test_nm_individual_address_write_programming_failed(time_travel):
         payload=apci.IndividualAddressWrite(address=individual_address_new),
     )
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address_new
         )
     )
@@ -572,7 +572,7 @@ async def test_nm_individual_address_write_address_found_other_in_programming_mo
     )
 
     task = asyncio.create_task(
-        procedures.nm_invididual_address_write(
+        procedures.nm_individual_address_write(
             xknx=xknx, individual_address=individual_address
         )
     )

--- a/xknx/management/procedures.py
+++ b/xknx/management/procedures.py
@@ -106,7 +106,7 @@ async def nm_individual_address_read(
     return addresses
 
 
-async def nm_invididual_address_write(
+async def nm_individual_address_write(
     xknx: XKNX, individual_address: IndividualAddressableType
 ) -> None:
     """


### PR DESCRIPTION
Added a rate limit option to P2PConnections.

This is not related to the global `rate_limit` parameter passed when creating the xknx object, which only affects data sent by xknx device objects on the bus.

Since different devices might need different limits, I added this parameter on a per-connection level in place of using the global `xknx.rate_limit` value.

Also fixes a typo in one of the management procedures `nm_invididual_address_write` was renamed to `nm_individual_address_write`. This is a breaking change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)