### PR TITLE
Add `return_code` for TunnellingFeatureResponse

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,8 +6,11 @@ nav_order: 2
 
 # Changelog
 
-- Added rate limit (in packets per second) option to P2PConnection.
+### Management
+
+- Add rate limit (in packets per second) option to P2PConnection.
 - Fix typo in management procedure (`nm_invididual_address_write` was renamed to `nm_individual_address_write`)
+- Fix TunnellingFeatureResponse missing `return_code`
 
 # 3.3.0 Climate humidity 2024-10-20
 

--- a/test/knxip_tests/tunnelling_feature_test.py
+++ b/test/knxip_tests/tunnelling_feature_test.py
@@ -12,6 +12,7 @@ from xknx.knxip import (
     TunnellingFeatureSet,
     TunnellingFeatureType,
 )
+from xknx.management.application_layer_enum import ReturnCode
 
 
 class TestKNXIPTunnellingFeature:
@@ -74,13 +75,14 @@ class TestKNXIPTunnellingFeature:
         assert (
             knxipframe.body.feature_type == TunnellingFeatureType.BUS_CONNECTION_STATUS
         )
+        assert knxipframe.body.return_code == ReturnCode.E_SUCCESS
         assert knxipframe.body.data == b"\x01\x00"
 
         tunnelling_request = TunnellingFeatureResponse(
             communication_channel_id=1,
             sequence_counter=23,
-            status_code=ErrorCode.E_NO_ERROR,
             feature_type=TunnellingFeatureType.BUS_CONNECTION_STATUS,
+            return_code=ReturnCode.E_SUCCESS,
             data=b"\x01\x00",
         )
         knxipframe2 = KNXIPFrame.init_from_body(tunnelling_request)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -695,7 +695,7 @@ class TestStringRepresentations:
         assert (
             str(tunnelling_feature)
             == '<TunnellingFeatureResponse communication_channel_id="23" sequence_counter="42" status_code="ErrorCode.E_NO_ERROR" '
-            'feature_type="TunnellingFeatureType.BUS_CONNECTION_STATUS" data="0100" />'
+            'feature_type="TunnellingFeatureType.BUS_CONNECTION_STATUS" return_code="ReturnCode.E_SUCCESS" data="0100" />'
         )
 
     def test_tunnelling_feature_set(self):

--- a/xknx/management/application_layer_enum.py
+++ b/xknx/management/application_layer_enum.py
@@ -1,0 +1,46 @@
+"""Enums for KNX Application Layer."""
+
+from enum import Enum
+
+
+class ReturnCode(Enum):
+    """Enum class for Generic device management Return Codes."""
+
+    ## Basic positive Return Code
+    # The service, function or command is executed successfully, without additional information.
+    E_SUCCESS = 0x00
+    ## Generic negative Return Codes
+    # Memory cannot be accessed or only with fault(s).
+    E_MEMORY_ERROR = 0xF1
+    # Requested data will not fit into a Frame supported by this server.
+    # This shall be used for Device limitations of the maximum supported Frame length
+    # by accessing resources (Properties, Function Properties, memory…) of the device.
+    E_LENGTH_EXCEEDS_MAX_APDU_LENGTH = 0xF4
+    # Writing data beyond what is reserved for the addressed Resource.
+    E_DATA_OVERFLOW = 0xF5
+    # Write value too low. Preferable to give this instead of “Value not supported”.
+    E_DATA_MIN = 0xF6
+    # Write value too high. Preferable to give this instead of “Value not supported”.
+    E_DATA_MAX = 0xF7
+    # The service or function is supported, but request data is not valid for this receiver.
+    E_DATA_VOID = 0xF8
+    # Data could generally be written, but not possible at this time.
+    E_TEMPORARILY_NOT_AVAILABLE = 0xF9
+    # Read access attempted to a “write only” service or Resource.
+    E_ACCESS_WRITE_ONLY = 0xFA
+    # Write access attempted to a “read only” service or Resource.
+    E_ACCESS_READ_ONLY = 0xFB
+    # Access denied due to authorization reasons. A_Authorize as well as KNX Security
+    E_ACCESS_DENIED = 0xFC
+    # Interface Object or Property is not present, or index is out of range.
+    E_ADDRESS_VOID = 0xFD
+    # Write access with a wrong datatype (Datapoint length).
+    E_DATA_TYPE_CONFLICT = 0xFE
+    # The service, function or command has failed without a closer indication of the problem.
+    E_ERROR = 0xFF
+    ## Generic positive Return Codes
+    # (01h-1Fh - None proposed)
+    ## Specific positive Return Codes
+    # (20h-5Fh - None proposed)
+    ## Specific negative Return Codes
+    # (A0h-DFh - None proposed)


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
TunnellingFeatureResponse was missing `return_code`. 
When an error occured - eg. `ReturnCode.E_ACCESS_READ_ONLY` -  some tunnelling server implementations omit `data` (Gira, Weinzierl) while others return the received data (Enertex).

cc @pdgendt 
Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)