### PR TITLE
Add support for making connections over unix domain sockets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,10 @@ nav_order: 2
 - Fix typo in management procedure (`nm_invididual_address_write` was renamed to `nm_individual_address_write`)
 - Fix TunnellingFeatureResponse missing `return_code`
 
+### Connection
+
+- Add support for making connections over unix domain sockets.
+
 # 3.3.0 Climate humidity 2024-10-20
 
 ### Devices

--- a/examples/example_telegram_monitor_unix.py
+++ b/examples/example_telegram_monitor_unix.py
@@ -1,0 +1,86 @@
+"""Example for the telegram monitor callback over unix domain socket."""
+
+import asyncio
+import getopt
+import socket
+import subprocess
+import sys
+
+from xknx import XKNX
+from xknx.io import ConnectionConfig, ConnectionType
+from xknx.telegram import AddressFilter, Telegram
+
+
+def telegram_received_cb(telegram: Telegram) -> None:
+    """Do something with the received telegram."""
+    print(f"Telegram received: {telegram}")
+
+
+def show_help() -> None:
+    """Print Help."""
+    print("Telegram filter.")
+    print("")
+    print("Usage:")
+    print("")
+    print(__file__, "                            Listen to all telegrams")
+    print(
+        __file__, "-f --filter 1/2/*,1/4/[5-6]    Filter for specific group addresses"
+    )
+    print(
+        __file__, "-host hostname                 Connect to a specific host over ssh"
+    )
+    print(__file__, "-h --help                      Print help")
+    print("")
+
+
+async def monitor(host, address_filters: list[AddressFilter] | None) -> None:
+    """Set telegram_received_cb within XKNX and connect to KNX/IP device in daemon mode."""
+    if host is None:
+        connection_config = ConnectionConfig(
+            connection_type=ConnectionType.TUNNELING_TCP,
+            gateway_path="/run/knxnet",
+        )
+    else:
+        async def connect_ssh(loop, protocol_factory):
+            s1, s2 = socket.socketpair()
+
+            cmd = ['ssh', '--', host, 'socat STDIO UNIX-CONNECT:/run/knxnet']
+
+            subprocess.Popen(cmd, stdin=s2, stdout=s2)
+
+            return await loop.create_unix_connection(protocol_factory, sock=s1)
+
+        connection_config = ConnectionConfig(
+            connection_type=ConnectionType.TUNNELING_TCP,
+            connect_cb=connect_ssh,
+        )
+    xknx = XKNX(connection_config=connection_config, daemon_mode=True)
+    xknx.telegram_queue.register_telegram_received_cb(
+        telegram_received_cb, address_filters
+    )
+    await xknx.start()
+    await xknx.stop()
+
+
+async def main(argv: list[str]) -> None:
+    """Parse command line arguments and start monitor."""
+    try:
+        opts, _ = getopt.getopt(argv, "hf:", ["help", "filter=", "host="])
+    except getopt.GetoptError:
+        show_help()
+        sys.exit(2)
+    host = None
+    address_filters = None
+    for opt, arg in opts:
+        if opt in ["-h", "--help"]:
+            show_help()
+            sys.exit()
+        if opt in ["--host"]:
+            host = arg
+        if opt in ["-f", "--filter"]:
+            address_filters = list(map(AddressFilter, arg.split(",")))
+    await monitor(host, address_filters)
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv[1:]))

--- a/xknx/io/connection.py
+++ b/xknx/io/connection.py
@@ -41,6 +41,8 @@ class ConnectionConfig:
     * local_ip: Local ip or interface name though which xknx should connect.
     * gateway_ip: IP or hostname of KNX/IP tunneling device.
     * gateway_port: Port of KNX/IP tunneling device.
+    * gateway_path: Filename of unix domain socket of KNX/IP tunneling device.
+    * connect_cb: A callback which will be called every time a connection is created.
     * route_back: For UDP TUNNELING connection.
         The KNXnet/IP Server shall use the IP address and port in the received IP package
         as the target IP address or port number for the response to the KNXnet/IP Client.
@@ -62,6 +64,8 @@ class ConnectionConfig:
         local_port: int = 0,
         gateway_ip: str | None = None,
         gateway_port: int = DEFAULT_MCAST_PORT,
+        gateway_path: str | None = None,
+        connect_cb: Callable[[asyncio.AbstractEventLoop, Callable[[], asyncio.Protocol]], Awaitable[Tuple[asyncio.Transport, asyncio.Protocol]]] | None = None,
         route_back: bool = False,
         multicast_group: str = DEFAULT_MCAST_GRP,
         multicast_port: int = DEFAULT_MCAST_PORT,
@@ -80,6 +84,8 @@ class ConnectionConfig:
         self.local_port = local_port
         self.gateway_ip = gateway_ip
         self.gateway_port = gateway_port
+        self.gateway_path = gateway_path
+        self.connect_cb = connect_cb
         self.route_back = route_back
         self.multicast_group = multicast_group
         self.multicast_port = multicast_port


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Add support for making connections over unix domain sockets.

The protocol used for the unix domain sockets is the same as the TCP protocol. The primary advantage of using unix domain sockets is that permissions can be applied if the server is running on the same host as the xknx application. This can be used to run knxd (e. g. to connect to a USB interface) and expose the socket only for certain users/groups. knxd supports TCP and unix domain sockets starting with version 0.14.68 (or PR  <https://github.com/knxd/knxd/pull/573>).

This also adds support for connecting to arbitrary streams, which can be used to connect to a knxd on another host using ssh, see `examples/example_telegram_monitor_unix.py` for an example.


## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)