### PR TITLE
Add `DPTBase.get_dpt` DPT definition helper classmethod

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ nav_order: 2
 ### DPT
 
 - Add `DPTBase.dpt_number_str` and `DPTBase.dpt_name` classmethods for human readable DPT number (eg. "9.001") and class name (eg. "DPTTemperature (9.001)").
+- Add `DPTBase.get_dpt` classmethod to get a DPT class by its number, name or DPTBase type.
 
 # 3.5.0 Swing it 2025-01-28
 

--- a/xknx/core/group_address_dpt.py
+++ b/xknx/core/group_address_dpt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 import logging
 
-from xknx.dpt.dpt import DPTBase, _DPTMainSubDict
+from xknx.dpt.dpt import DPTBase
 from xknx.exceptions import ConversionError, CouldNotParseAddress, CouldNotParseTelegram
 from xknx.telegram import Telegram, TelegramDecodedData
 from xknx.telegram.address import (
@@ -16,6 +16,7 @@ from xknx.telegram.address import (
     parse_device_group_address,
 )
 from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
+from xknx.typing import DPTParsable
 
 _GA_DPT_LOGGER = logging.getLogger("xknx.ga_dpt")
 
@@ -32,7 +33,7 @@ class GroupAddressDPT:
 
     def set(
         self,
-        ga_dpt: Mapping[DeviceAddressableType, int | str | _DPTMainSubDict],
+        ga_dpt: Mapping[DeviceAddressableType, DPTParsable],
     ) -> None:
         """Assign decoders to group addresses."""
         unknown_dpts = set()

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -18,12 +18,14 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from xknx.core import Task
+from xknx.dpt import DPTBase
 from xknx.remote_value import (
     GroupAddressesType,
     RemoteValue,
     RemoteValueSensor,
     RemoteValueSwitch,
 )
+from xknx.typing import DPTParsable
 
 from .device import Device, DeviceCallbackType
 
@@ -41,7 +43,7 @@ class ExposeSensor(Device):
         name: str,
         group_address: GroupAddressesType = None,
         respond_to_read: bool = True,
-        value_type: int | str | None = None,
+        value_type: DPTParsable | type[DPTBase] | None = None,
         cooldown: float = 0,
         device_updated_cb: DeviceCallbackType[ExposeSensor] | None = None,
     ) -> None:

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from xknx.dpt import DPTBase
+from xknx.dpt import DPTString
 from xknx.remote_value import GroupAddressesType, RemoteValueString
 from xknx.typing import DPTParsable
 
@@ -27,7 +27,7 @@ class Notification(Device):
         group_address_state: GroupAddressesType = None,
         respond_to_read: bool = False,
         sync_state: bool | int | float | str = True,
-        value_type: DPTParsable | type[DPTBase] | None = None,
+        value_type: DPTParsable | type[DPTString] | None = None,
         device_updated_cb: DeviceCallbackType[Notification] | None = None,
     ) -> None:
         """Initialize notification class."""

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
+from xknx.dpt import DPTBase
 from xknx.remote_value import GroupAddressesType, RemoteValueString
+from xknx.typing import DPTParsable
 
 from .device import Device, DeviceCallbackType
 
@@ -25,7 +27,7 @@ class Notification(Device):
         group_address_state: GroupAddressesType = None,
         respond_to_read: bool = False,
         sync_state: bool | int | float | str = True,
-        value_type: int | str | None = None,
+        value_type: DPTParsable | type[DPTBase] | None = None,
         device_updated_cb: DeviceCallbackType[Notification] | None = None,
     ) -> None:
         """Initialize notification class."""

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
-from xknx.dpt import DPTBase
+from xknx.dpt import DPTNumeric
 from xknx.remote_value import GroupAddressesType, RemoteValueNumeric
 from xknx.typing import DPTParsable
 
@@ -35,7 +35,7 @@ class NumericValue(Device):
         group_address_state: GroupAddressesType = None,
         respond_to_read: bool = False,
         sync_state: bool | int | float | str = True,
-        value_type: DPTParsable | type[DPTBase] | None = None,
+        value_type: DPTParsable | type[DPTNumeric] | None = None,
         always_callback: bool = False,
         device_updated_cb: DeviceCallbackType[NumericValue] | None = None,
     ) -> None:

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
+from xknx.dpt import DPTBase
 from xknx.remote_value import GroupAddressesType, RemoteValueNumeric
+from xknx.typing import DPTParsable
 
 from .device import Device, DeviceCallbackType
 
@@ -33,7 +35,7 @@ class NumericValue(Device):
         group_address_state: GroupAddressesType = None,
         respond_to_read: bool = False,
         sync_state: bool | int | float | str = True,
-        value_type: int | str | None = None,
+        value_type: DPTParsable | type[DPTBase] | None = None,
         always_callback: bool = False,
         device_updated_cb: DeviceCallbackType[NumericValue] | None = None,
     ) -> None:

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -12,11 +12,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
+from xknx.dpt import DPTBase
 from xknx.remote_value import (
     GroupAddressesType,
     RemoteValue,
     RemoteValueSensor,
 )
+from xknx.typing import DPTParsable
 
 from .device import Device, DeviceCallbackType
 
@@ -35,7 +37,7 @@ class Sensor(Device):
         group_address_state: GroupAddressesType = None,
         sync_state: bool | int | float | str = True,
         always_callback: bool = False,
-        value_type: int | str | None = None,
+        value_type: DPTParsable | type[DPTBase] | None = None,
         device_updated_cb: DeviceCallbackType[Sensor] | None = None,
     ) -> None:
         """Initialize Sensor class."""

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -214,6 +214,23 @@ class DPTBase(ABC):
                 return None
             return cls.transcoder_by_dpt(dpt_main=main, dpt_sub=_sub)
 
+    @classmethod
+    def get_dpt(cls: type[Self], value_type: DPTParsable | type[DPTBase]) -> type[Self]:
+        """
+        Return DPT class from value.
+
+        Raises ValueError if value_type can't be parsed to DPT class.
+        """
+        if isinstance(value_type, type):
+            if issubclass(value_type, cls) and not isabstract(value_type):
+                return value_type
+        else:
+            if transcoder := cls.parse_transcoder(value_type):
+                return transcoder
+        raise ValueError(
+            f"Invalid value type for base class {cls.__name__}: {value_type}"
+        )
+
 
 class DPTNumeric(DPTBase):
     """Base class for KNX data point types decoding numeric values."""

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -8,19 +8,12 @@ from dataclasses import dataclass
 from enum import Enum
 from inspect import isabstract
 import struct
-from typing import Any, Generic, TypedDict, TypeVar, cast, final
+from typing import Any, Generic, TypeVar, cast, final
 
 from xknx.exceptions import ConversionError, CouldNotParseTelegram
-from xknx.typing import Self
+from xknx.typing import DPTParsable, Self
 
 from .payload import DPTArray, DPTBinary
-
-
-class _DPTMainSubDict(TypedDict):
-    """DPT type dictionary in accordance to xknxproject DPTType data."""
-
-    main: int
-    sub: int | None
 
 
 class DPTBase(ABC):
@@ -183,9 +176,7 @@ class DPTBase(ABC):
         return None
 
     @classmethod
-    def parse_transcoder(
-        cls: type[Self], value_type: int | str | _DPTMainSubDict
-    ) -> type[Self] | None:
+    def parse_transcoder(cls: type[Self], value_type: DPTParsable) -> type[Self] | None:
         """
         Return Class reference of DPTBase subclass from value_type or DPT number.
 

--- a/xknx/tools/group_communication.py
+++ b/xknx/tools/group_communication.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from inspect import isabstract
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -94,13 +93,7 @@ async def read_group_value(
 def _parse_dpt(value_type: DPTParsable | type[DPTBase] | None) -> type[DPTBase] | None:
     if value_type is None:
         return None
-    if isinstance(value_type, type):
-        if issubclass(value_type, DPTBase) and not isabstract(value_type):
-            return value_type
-    else:
-        if transcoder := DPTBase.parse_transcoder(value_type):
-            return transcoder
-    raise ValueError(f"Invalid value_type: {value_type}")
+    return DPTBase.get_dpt(value_type)
 
 
 def _parse_payload(

--- a/xknx/typing/__init__.py
+++ b/xknx/typing/__init__.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypedDict, TypeVar
 
 if sys.version_info >= (3, 11):
     from typing import Self as Self
@@ -22,3 +22,13 @@ DeviceT = TypeVar("DeviceT", bound="Device")
 DeviceCallbackType = Callable[[DeviceT], None]
 
 TelegramCallbackType = Callable[["Telegram"], None]
+
+
+class DPTMainSubDict(TypedDict):
+    """DPT type dictionary in accordance to xknxproject DPTType data."""
+
+    main: int
+    sub: int | None
+
+
+DPTParsable = str | int | DPTMainSubDict


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
This accepts int, string, dict (`{"main": int, "sub": int | None}`) or DPT classes. It raises ValueError if no usable subclass is found.

Examples:

```py
x = DPTBase.get_dpt(16)
reveal_type(x)  # -> type[DPTBase]

y = DPTNumeric.get_dpt(16)  # raises ValueError since DPT 16 is not Numeric
reveal_type(y)  # -> type[DPTNumeric]

DPTBase.get_dpt(DPTNumeric)  # raises ValueError since DPTNumeric is abstract (not a DPT definition, but a category of definitions)

DPTBase.get_dpt(DPTString)  # -> DPTString

DPTEnum.get_dpt({"main": 1, "sub": 8})  # -> DPTUpDown
```

cc @philippwaller 
Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)