### PR TITLE
Configurable timezone for `Datetime` device using `localtime`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ nav_order: 2
 
 # Changelog
 
+### Devices
+
+- Datetime: Accept `datetime.tzinfo` for `timezone` argument to send time information for specific timezone. Boolean works like before: If `True` use system localtime. If `False` an arbitrary time can be sent.
+
 ### DPT
 
 - Add `DPTBase.dpt_number_str` and `DPTBase.dpt_name` classmethods for human readable DPT number (eg. "9.001") and class name (eg. "DPTTemperature (9.001)").

--- a/docs/time.md
+++ b/docs/time.md
@@ -28,7 +28,7 @@ await xknx.devices['TimeTest'].sync()
 * `xknx` is the XKNX object.
 * `name` is the name of the object.
 * `group_address` is the KNX group address of the sensor device.
-* `localtime` If set `True` sync() and GroupValueRead requests always return the current local time and it is also sent every 60 minutes. On `False` the set value will be sent. Default: `True`
+* `localtime` If set `True` sync() and GroupValueRead requests always return the current systems local time and it is also sent every 60 minutes. Same if set to a `datetime.tzinfo` object, but the time for that timezone information will be used. On `False` the set value will be sent, no automatic sending will be scheduled. Default: `True`
 * `device_updated_cb` Callback for each update.
 
 ## [](#header-2)Local time


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
Datetime device: Accept `bool | datetime.tzinfo` for `timezone` argument. `tzinfo` to send time information for specific timezone. 
Boolean works like before: If `True` use system localtime. If `False` an arbitrary time can be sent.

Closes #1650

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)