### PR TITLE
Split multicast socket for UDPTransport

### DIFF
--- a/test/integration_tests/__init__.py
+++ b/test/integration_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests."""

--- a/test/integration_tests/routing_multicast_test.py
+++ b/test/integration_tests/routing_multicast_test.py
@@ -1,0 +1,51 @@
+"""Tests for KNX/IP routing indications using multicast."""
+
+import asyncio
+from unittest.mock import Mock
+
+from xknx import XKNX
+from xknx.dpt.payload import DPTBinary
+from xknx.io.connection import ConnectionConfig, ConnectionType
+from xknx.telegram import GroupAddress, IndividualAddress, Telegram
+from xknx.telegram.apci import GroupValueWrite
+from xknx.telegram.telegram import TelegramDirection
+from xknx.telegram.tpci import TDataGroup
+from xknx.util import asyncio_timeout
+
+
+async def test_routing_indication_multicast() -> None:
+    """Test exchanging routing indication using multicast."""
+    routing1_mock = Mock()
+    data_received = asyncio.Event()
+    received_data: Telegram | None = None
+
+    def routing2_callback(telegram: Telegram) -> None:
+        """Set test data from receiving xknx instance."""
+        nonlocal received_data
+        received_data = telegram
+        data_received.set()
+
+    msg = Telegram(
+        destination_address=GroupAddress("1/2/2"),
+        source_address=IndividualAddress("1.1.1"),
+        payload=GroupValueWrite(DPTBinary(1)),
+        tpci=TDataGroup(),
+    )
+
+    async with (
+        XKNX(
+            connection_config=ConnectionConfig(connection_type=ConnectionType.ROUTING),
+            telegram_received_cb=routing1_mock,
+        ) as xknx1,
+        XKNX(
+            connection_config=ConnectionConfig(connection_type=ConnectionType.ROUTING),
+            telegram_received_cb=routing2_callback,
+        ),
+    ):
+        await xknx1.telegrams.put(msg)
+        async with asyncio_timeout(1):
+            await data_received.wait()
+
+        msg.direction = TelegramDirection.INCOMING
+        routing1_mock.assert_not_called()
+        assert received_data == msg

--- a/test/integration_tests/routing_multicast_test.py
+++ b/test/integration_tests/routing_multicast_test.py
@@ -1,6 +1,7 @@
 """Tests for KNX/IP routing indications using multicast."""
 
 import asyncio
+from typing import Final
 from unittest.mock import Mock
 
 from xknx import XKNX
@@ -11,6 +12,8 @@ from xknx.telegram.apci import GroupValueWrite
 from xknx.telegram.telegram import TelegramDirection
 from xknx.telegram.tpci import TDataGroup
 from xknx.util import asyncio_timeout
+
+EXPERIMENTAL_MCAST_GRP: Final = "224.0.0.254"
 
 
 async def test_routing_indication_multicast() -> None:
@@ -36,14 +39,14 @@ async def test_routing_indication_multicast() -> None:
         XKNX(
             connection_config=ConnectionConfig(
                 connection_type=ConnectionType.ROUTING,
-                local_ip="127.0.0.1",
+                multicast_group=EXPERIMENTAL_MCAST_GRP,
             ),
             telegram_received_cb=routing1_mock,
         ) as xknx1,
         XKNX(
             connection_config=ConnectionConfig(
                 connection_type=ConnectionType.ROUTING,
-                local_ip="127.0.0.1",
+                multicast_group=EXPERIMENTAL_MCAST_GRP,
             ),
             telegram_received_cb=routing2_callback,
         ),

--- a/test/integration_tests/routing_multicast_test.py
+++ b/test/integration_tests/routing_multicast_test.py
@@ -34,11 +34,17 @@ async def test_routing_indication_multicast() -> None:
 
     async with (
         XKNX(
-            connection_config=ConnectionConfig(connection_type=ConnectionType.ROUTING),
+            connection_config=ConnectionConfig(
+                connection_type=ConnectionType.ROUTING,
+                local_ip="127.0.0.1",
+            ),
             telegram_received_cb=routing1_mock,
         ) as xknx1,
         XKNX(
-            connection_config=ConnectionConfig(connection_type=ConnectionType.ROUTING),
+            connection_config=ConnectionConfig(
+                connection_type=ConnectionType.ROUTING,
+                local_ip="127.0.0.1",
+            ),
             telegram_received_cb=routing2_callback,
         ),
     ):

--- a/test/integration_tests/routing_multicast_test.py
+++ b/test/integration_tests/routing_multicast_test.py
@@ -13,6 +13,8 @@ from xknx.telegram.telegram import TelegramDirection
 from xknx.telegram.tpci import TDataGroup
 from xknx.util import asyncio_timeout
 
+# RFC 4727 multicast group for testing purposes
+# to not mess with live installations when running tests
 EXPERIMENTAL_MCAST_GRP: Final = "224.0.0.254"
 
 


### PR DESCRIPTION
Create a separate socket when creating an UDPTransport with a remote multicast address to receive and send messages.
This allows us to distinguish messages we sent ourselves.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)