### PR TITLE
Support explicitly passing a keyring in the secure config

### DIFF
--- a/xknx/io/connection.py
+++ b/xknx/io/connection.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 import os
 from typing import Any
 
+from xknx.secure import Keyring
 from xknx.telegram.address import IndividualAddress, IndividualAddressableType
 
 from .const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT
@@ -106,6 +107,7 @@ class SecureConfig:
     * user_password: the user password for knx secure.
     * knxkeys_file_path: Full path to the knxkeys file including the file name.
     * knxkeys_password: Password to decrypt the knxkeys file.
+    * keyring: Already-loaded keyring if it shouldn't be read from the knxkeys file.
     """
 
     def __init__(
@@ -118,7 +120,7 @@ class SecureConfig:
         user_password: str | None = None,
         knxkeys_file_path: str | os.PathLike[Any] | None = None,
         knxkeys_password: str | None = None,
-        keyring = None,
+        keyring: Keyring | None = None,
     ) -> None:
         """Initialize SecureConfig class."""
         self.backbone_key = bytes.fromhex(backbone_key) if backbone_key else None

--- a/xknx/io/connection.py
+++ b/xknx/io/connection.py
@@ -118,6 +118,7 @@ class SecureConfig:
         user_password: str | None = None,
         knxkeys_file_path: str | os.PathLike[Any] | None = None,
         knxkeys_password: str | None = None,
+        keyring = None,
     ) -> None:
         """Initialize SecureConfig class."""
         self.backbone_key = bytes.fromhex(backbone_key) if backbone_key else None
@@ -127,6 +128,7 @@ class SecureConfig:
         self.user_password = user_password
         self.knxkeys_file_path = knxkeys_file_path
         self.knxkeys_password = knxkeys_password
+        self.keyring = keyring
 
     def __eq__(self, other: object) -> bool:
         """Equality for SecureConfig class (used in unit tests)."""

--- a/xknx/io/knxip_interface.py
+++ b/xknx/io/knxip_interface.py
@@ -80,7 +80,9 @@ class KNXIPInterface:
             local_ip = await util.validate_ip(local_ip, address_name="Local IP")
         keyring: Keyring | None = None
         if secure_config := self.connection_config.secure_config:
-            if (
+            if secure_config.keyring is not None:
+                keyring = secure_config.keyring
+            elif (
                 secure_config.knxkeys_file_path is not None
                 and secure_config.knxkeys_password is not None
             ):


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Allow a keyring to be passed explicitly through a secure config rather than always being read from a file.

The motivation is that for our usage we have the desired contents of the keyring in memory and it would be great if it wasn't necessary to write it to a file only to have `xknx` read it back into memory immediately after.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests

(This isn't really any of the above)

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)

(I'm not sure any of these are relevant but please let me know if they are.)