### PR TITLE
Cover: add invert_stop

### DIFF
--- a/docs/cover.md
+++ b/docs/cover.md
@@ -27,6 +27,7 @@ Shutters are simple representations of blind/roller cover actuators. With XKNX y
 - `travel_time_down` seconds to reach lower end position. Default: 22
 - `travel_time_up` seconds to reach upper end position. Default: 22
 - `invert_updown` invert up/down binary payload. Default: False
+- `invert_stop` invert stop binary payload. Default: False
 - `invert_position` invert position percentage from / to KNX bus. Default: False
 - `invert_angle` invert angle from / to KNX bus. Default: False
 - `device_updated_cb` Callback for each update.

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -58,6 +58,7 @@ class Cover(Device):
         travel_time_down: float = DEFAULT_TRAVEL_TIME,
         travel_time_up: float = DEFAULT_TRAVEL_TIME,
         invert_updown: bool = False,
+        invert_stop: bool = False,
         invert_position: bool = False,
         invert_angle: bool = False,
         device_updated_cb: DeviceCallbackType[Cover] | None = None,
@@ -88,6 +89,7 @@ class Cover(Device):
             group_address=group_address_stop,
             sync_state=False,
             device_name=self.name,
+            invert=invert_stop,
             after_update_cb=None,
         )
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


In my KNX installation cover stopping signal is inverted. I don't know how standard it is, but since we already have flags to invert up/down, angle and position I think it will be good to have this as well.

I did not add tests since I saw that was not done for other invert flags like `invert_angle`.
I did not edit the changelog, don't want to mess it up.

Thanks for the awesome project!


## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)