### PR TITLE
feat: A_SystemNetworkParameter_Read & A_SystemNetworkParameter_Response

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Protocol
+
+- Add A_SystemNetworkParameter_Read and A_SystemNetworkParameter_Response APCI service parsing.
+
 ### DPT
 
 - Add DPT 2 definitions

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -39,6 +39,7 @@ from xknx.telegram.apci import (
     PropertyValueWrite,
     Restart,
     SystemNetworkParameterRead,
+    SystemNetworkParameterResponse,
     UserManufacturerInfoRead,
     UserManufacturerInfoResponse,
     UserMemoryRead,
@@ -313,7 +314,7 @@ class TestSystemNetworkParameterRead:
             object_type=0, property_id=0, operand=bytes.fromhex("00b001")
         )
 
-        assert payload.calculated_length() == 5
+        assert payload.calculated_length() == 6
 
     def test_from_knx(self) -> None:
         """
@@ -356,6 +357,68 @@ class TestSystemNetworkParameterRead:
         assert str(payload) == (
             '<SystemNetworkParameterRead object_type="0" property_id="0" '
             'operand="00b001" />'
+        )
+
+
+class TestSystemNetworkParameterResponse:
+    """Test class for SystemNetworkParameterResponse objects."""
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = SystemNetworkParameterResponse(
+            object_type=11,
+            property_id=5,
+            test_info_and_result=bytes.fromhex("0099aabbcc"),
+        )
+
+        assert payload.calculated_length() == 8
+
+    def test_from_knx(self) -> None:
+        """Test the from_knx method."""
+        payload = APCI.from_knx(bytes.fromhex("01c90b050099aabbcc"))
+
+        assert payload == SystemNetworkParameterResponse(
+            object_type=11,
+            property_id=5,
+            test_info_and_result=bytes.fromhex("0099aabbcc"),
+        )
+
+    def test_from_knx_does_not_strip_reserved_bits(self) -> None:
+        """
+        Test from_knx keeps the reserved 4 bits as-is in test_info_and_result.
+
+        Unlike SystemNetworkParameterRead, the reserved nibble here is not
+        masked out yet - see the NOTE in the class docstring.
+        """
+        payload = APCI.from_knx(bytes.fromhex("01c90b05f099aabbcc"))
+
+        assert payload == SystemNetworkParameterResponse(
+            object_type=11,
+            property_id=5,
+            test_info_and_result=bytes.fromhex("f099aabbcc"),
+        )
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method."""
+        payload = SystemNetworkParameterResponse(
+            object_type=11,
+            property_id=5,
+            test_info_and_result=bytes.fromhex("0099aabbcc"),
+        )
+
+        assert payload.to_knx() == bytes.fromhex("01c90b050099aabbcc")
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        payload = SystemNetworkParameterResponse(
+            object_type=11,
+            property_id=5,
+            test_info_and_result=bytes.fromhex("0099aabbcc"),
+        )
+
+        assert str(payload) == (
+            '<SystemNetworkParameterResponse object_type="11" property_id="5" '
+            'test_info_and_result="0099aabbcc" />'
         )
 
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -340,6 +340,13 @@ class TestSystemNetworkParameterRead:
             object_type=0, property_id=0, operand=bytes.fromhex("00b001")
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        # only 4 octets (TPCI/APCI, APCI, object_type, property_id) - the
+        # reserved/operand octet is missing.
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes.fromhex("01c80000"))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method round-trips the raw ETS frame."""
         payload = SystemNetworkParameterRead(
@@ -397,6 +404,13 @@ class TestSystemNetworkParameterResponse:
             property_id=5,
             test_info_and_result=bytes.fromhex("f099aabbcc"),
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        # only 4 octets (TPCI/APCI, APCI, object_type, property_id) - the
+        # reserved octet is missing.
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes.fromhex("01c90b05"))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -311,7 +311,7 @@ class TestSystemNetworkParameterRead:
     def test_calculated_length(self) -> None:
         """Test the test_calculated_length method."""
         payload = SystemNetworkParameterRead(
-            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+            object_type=0, property_id=11, test_info=bytes.fromhex("01")
         )
 
         assert payload.calculated_length() == 6
@@ -321,49 +321,78 @@ class TestSystemNetworkParameterRead:
         Test the from_knx method.
 
         Real world frame observed via ETS bus monitor (system broadcast,
-        src 0.0.1, dst 0/0/0): APCI 0x1C8, object_type=0, property_id=0,
-        operand=00 b0 01.
+        src 0.0.1, dst 0/0/0): APCI 0x1C8, object_type=0 (Device Object),
+        property_id=11 (PID_SERIAL_NUMBER), test_info=01 - the standard
+        "which devices are in programming mode" system broadcast.
         """
         payload = APCI.from_knx(bytes.fromhex("01c8000000b001"))
 
         assert payload == SystemNetworkParameterRead(
-            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+            object_type=0, property_id=11, test_info=bytes.fromhex("01")
         )
 
     def test_from_knx_strips_reserved_bits(self) -> None:
-        """Test from_knx masks out the reserved 4 bits instead of exposing them."""
-        # upper nibble of the byte after object_type/property_id is reserved
-        # (0xF here) and must not leak into operand.
-        payload = APCI.from_knx(bytes.fromhex("01c80000f0b001"))
+        """Test from_knx discards the reserved 4 bits instead of exposing them."""
+        # raw[4]=0x00 (PID high byte), raw[5]=0xbf: upper nibble (0xb)
+        # completes property_id=11, lower nibble (0xf) is garbage reserved
+        # bits that must not leak into property_id or test_info.
+        payload = APCI.from_knx(bytes.fromhex("01c8000000bf01"))
 
         assert payload == SystemNetworkParameterRead(
-            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+            object_type=0, property_id=11, test_info=bytes.fromhex("01")
+        )
+
+    def test_from_knx_no_test_info(self) -> None:
+        """
+        Test from_knx accepts the minimum 6 octet APDU with no test_info.
+
+        Eg. a device signalling "unsupported object type / PID" by
+        echoing object_type=0xFFFF, property_id=0xFFF with no test data.
+        """
+        payload = APCI.from_knx(bytes.fromhex("01c8fffffff0"))
+
+        assert payload == SystemNetworkParameterRead(
+            object_type=0xFFFF, property_id=0xFFF, test_info=b""
         )
 
     def test_from_knx_wrong_length(self) -> None:
         """Test from_knx raises ConversionError for a too-short APDU."""
-        # only 4 octets (TPCI/APCI, APCI, object_type, property_id) - the
-        # reserved/operand octet is missing.
+        # only 5 octets - the ASDU header (object_type + property_id +
+        # reserved) needs 4 octets after the 2 APCI header octets.
         with pytest.raises(ConversionError, match=r".*Invalid length.*"):
-            APCI.from_knx(bytes.fromhex("01c80000"))
+            APCI.from_knx(bytes.fromhex("01c8000000"))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method round-trips the raw ETS frame."""
         payload = SystemNetworkParameterRead(
-            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+            object_type=0, property_id=11, test_info=bytes.fromhex("01")
         )
 
         assert payload.to_knx() == bytes.fromhex("01c8000000b001")
 
+    def test_to_knx_object_type_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range object_type."""
+        payload = SystemNetworkParameterRead(object_type=0x10000, property_id=0)
+
+        with pytest.raises(ConversionError, match=r".*Object type.*"):
+            payload.to_knx()
+
+    def test_to_knx_property_id_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range property_id."""
+        payload = SystemNetworkParameterRead(object_type=0, property_id=0x1000)
+
+        with pytest.raises(ConversionError, match=r".*Property ID.*"):
+            payload.to_knx()
+
     def test_str(self) -> None:
         """Test the __str__ method."""
         payload = SystemNetworkParameterRead(
-            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+            object_type=0, property_id=11, test_info=bytes.fromhex("01")
         )
 
         assert str(payload) == (
-            '<SystemNetworkParameterRead object_type="0" property_id="0" '
-            'operand="00b001" />'
+            '<SystemNetworkParameterRead object_type="0" property_id="11" '
+            'test_info="01" />'
         )
 
 
@@ -373,66 +402,81 @@ class TestSystemNetworkParameterResponse:
     def test_calculated_length(self) -> None:
         """Test the test_calculated_length method."""
         payload = SystemNetworkParameterResponse(
-            object_type=11,
-            property_id=5,
-            test_info_and_result=bytes.fromhex("0099aabbcc"),
+            object_type=11, property_id=5, test_info_and_result=bytes.fromhex("aabbcc")
         )
 
         assert payload.calculated_length() == 8
 
     def test_from_knx(self) -> None:
         """Test the from_knx method."""
-        payload = APCI.from_knx(bytes.fromhex("01c90b050099aabbcc"))
+        payload = APCI.from_knx(bytes.fromhex("01c9000b0050aabbcc"))
 
         assert payload == SystemNetworkParameterResponse(
-            object_type=11,
-            property_id=5,
-            test_info_and_result=bytes.fromhex("0099aabbcc"),
+            object_type=11, property_id=5, test_info_and_result=bytes.fromhex("aabbcc")
         )
 
-    def test_from_knx_does_not_strip_reserved_bits(self) -> None:
-        """
-        Test from_knx keeps the reserved 4 bits as-is in test_info_and_result.
-
-        Unlike SystemNetworkParameterRead, the reserved nibble here is not
-        masked out yet - see the NOTE in the class docstring.
-        """
-        payload = APCI.from_knx(bytes.fromhex("01c90b05f099aabbcc"))
+    def test_from_knx_strips_reserved_bits(self) -> None:
+        """Test from_knx discards the reserved 4 bits instead of exposing them."""
+        # raw[5]=0x5f: upper nibble (0x5) completes property_id=5, lower
+        # nibble (0xf) is garbage reserved bits that must not leak into
+        # property_id or test_info_and_result.
+        payload = APCI.from_knx(bytes.fromhex("01c9000b005faabbcc"))
 
         assert payload == SystemNetworkParameterResponse(
-            object_type=11,
-            property_id=5,
-            test_info_and_result=bytes.fromhex("f099aabbcc"),
+            object_type=11, property_id=5, test_info_and_result=bytes.fromhex("aabbcc")
+        )
+
+    def test_from_knx_no_test_info_and_result(self) -> None:
+        """
+        Test from_knx accepts the minimum 6 octet APDU with no trailing data.
+
+        Eg. a device signalling "unsupported object type / PID" by
+        echoing object_type=0xFFFF, property_id=0xFFF with no test data.
+        """
+        payload = APCI.from_knx(bytes.fromhex("01c9fffffff0"))
+
+        assert payload == SystemNetworkParameterResponse(
+            object_type=0xFFFF, property_id=0xFFF, test_info_and_result=b""
         )
 
     def test_from_knx_wrong_length(self) -> None:
         """Test from_knx raises ConversionError for a too-short APDU."""
-        # only 4 octets (TPCI/APCI, APCI, object_type, property_id) - the
-        # reserved octet is missing.
+        # only 5 octets - the ASDU header (object_type + property_id +
+        # reserved) needs 4 octets after the 2 APCI header octets.
         with pytest.raises(ConversionError, match=r".*Invalid length.*"):
-            APCI.from_knx(bytes.fromhex("01c90b05"))
+            APCI.from_knx(bytes.fromhex("01c9000b00"))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = SystemNetworkParameterResponse(
-            object_type=11,
-            property_id=5,
-            test_info_and_result=bytes.fromhex("0099aabbcc"),
+            object_type=11, property_id=5, test_info_and_result=bytes.fromhex("aabbcc")
         )
 
-        assert payload.to_knx() == bytes.fromhex("01c90b050099aabbcc")
+        assert payload.to_knx() == bytes.fromhex("01c9000b0050aabbcc")
+
+    def test_to_knx_object_type_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range object_type."""
+        payload = SystemNetworkParameterResponse(object_type=-1, property_id=0)
+
+        with pytest.raises(ConversionError, match=r".*Object type.*"):
+            payload.to_knx()
+
+    def test_to_knx_property_id_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range property_id."""
+        payload = SystemNetworkParameterResponse(object_type=0, property_id=-1)
+
+        with pytest.raises(ConversionError, match=r".*Property ID.*"):
+            payload.to_knx()
 
     def test_str(self) -> None:
         """Test the __str__ method."""
         payload = SystemNetworkParameterResponse(
-            object_type=11,
-            property_id=5,
-            test_info_and_result=bytes.fromhex("0099aabbcc"),
+            object_type=11, property_id=5, test_info_and_result=bytes.fromhex("aabbcc")
         )
 
         assert str(payload) == (
             '<SystemNetworkParameterResponse object_type="11" property_id="5" '
-            'test_info_and_result="0099aabbcc" />'
+            'test_info_and_result="aabbcc" />'
         )
 
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -38,6 +38,7 @@ from xknx.telegram.apci import (
     PropertyValueResponse,
     PropertyValueWrite,
     Restart,
+    SystemNetworkParameterRead,
     UserManufacturerInfoRead,
     UserManufacturerInfoResponse,
     UserMemoryRead,
@@ -301,6 +302,61 @@ class TestADCResponse:
         payload = ADCResponse(channel=1, count=3, value=456)
 
         assert str(payload) == '<ADCResponse channel="1" count="3" value="456" />'
+
+
+class TestSystemNetworkParameterRead:
+    """Test class for SystemNetworkParameterRead objects."""
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = SystemNetworkParameterRead(
+            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+        )
+
+        assert payload.calculated_length() == 5
+
+    def test_from_knx(self) -> None:
+        """
+        Test the from_knx method.
+
+        Real world frame observed via ETS bus monitor (system broadcast,
+        src 0.0.1, dst 0/0/0): APCI 0x1C8, object_type=0, property_id=0,
+        operand=00 b0 01.
+        """
+        payload = APCI.from_knx(bytes.fromhex("01c8000000b001"))
+
+        assert payload == SystemNetworkParameterRead(
+            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+        )
+
+    def test_from_knx_strips_reserved_bits(self) -> None:
+        """Test from_knx masks out the reserved 4 bits instead of exposing them."""
+        # upper nibble of the byte after object_type/property_id is reserved
+        # (0xF here) and must not leak into operand.
+        payload = APCI.from_knx(bytes.fromhex("01c80000f0b001"))
+
+        assert payload == SystemNetworkParameterRead(
+            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+        )
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method round-trips the raw ETS frame."""
+        payload = SystemNetworkParameterRead(
+            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+        )
+
+        assert payload.to_knx() == bytes.fromhex("01c8000000b001")
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        payload = SystemNetworkParameterRead(
+            object_type=0, property_id=0, operand=bytes.fromhex("00b001")
+        )
+
+        assert str(payload) == (
+            '<SystemNetworkParameterRead object_type="0" property_id="0" '
+            'operand="00b001" />'
+        )
 
 
 class TestMemoryExtendedWrite:

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -370,6 +370,23 @@ class TestSystemNetworkParameterRead:
 
         assert payload.to_knx() == bytes.fromhex("01c8000000b001")
 
+    def test_round_trip(self) -> None:
+        """Test from_knx().to_knx() reproduces the original ETS frame exactly."""
+        raw = bytes.fromhex("01c8000000b001")
+
+        assert APCI.from_knx(raw).to_knx() == raw
+
+    def test_round_trip_normalizes_reserved_bits(self) -> None:
+        """Test a frame with garbage reserved bits reserializes to its canonical form."""
+        dirty = bytes.fromhex("01c8000000bf01")
+        canonical = bytes.fromhex("01c8000000b001")
+
+        payload = APCI.from_knx(dirty)
+        reserialized = payload.to_knx()
+
+        assert reserialized == canonical
+        assert APCI.from_knx(bytes(reserialized)) == payload
+
     def test_to_knx_object_type_out_of_range(self) -> None:
         """Test to_knx raises ConversionError for an out of range object_type."""
         payload = SystemNetworkParameterRead(object_type=0x10000, property_id=0)
@@ -453,6 +470,23 @@ class TestSystemNetworkParameterResponse:
         )
 
         assert payload.to_knx() == bytes.fromhex("01c9000b0050aabbcc")
+
+    def test_round_trip(self) -> None:
+        """Test from_knx().to_knx() reproduces the original bytes exactly."""
+        raw = bytes.fromhex("01c9000b0050aabbcc")
+
+        assert APCI.from_knx(raw).to_knx() == raw
+
+    def test_round_trip_normalizes_reserved_bits(self) -> None:
+        """Test a frame with garbage reserved bits reserializes to its canonical form."""
+        dirty = bytes.fromhex("01c9000b005faabbcc")
+        canonical = bytes.fromhex("01c9000b0050aabbcc")
+
+        payload = APCI.from_knx(dirty)
+        reserialized = payload.to_knx()
+
+        assert reserialized == canonical
+        assert APCI.from_knx(bytes(reserialized)) == payload
 
     def test_to_knx_object_type_out_of_range(self) -> None:
         """Test to_knx raises ConversionError for an out of range object_type."""

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -507,6 +507,35 @@ class ADCResponse(APCI):
         return f'<ADCResponse channel="{self.channel}" count="{self.count}" value="{self.value}" />'
 
 
+def _pack_system_network_parameter_header(object_type: int, property_id: int) -> bytes:
+    """
+    Serialize the A_SystemNetworkParameter_Read/Response ASDU header.
+
+    16 bit object_type, then a 12 bit property_id followed by 4 reserved
+    bits (always emitted as 0). See KNX Specification 03_03_07
+    Application Layer §3.3.8.
+    """
+    if not 0 <= object_type <= 0xFFFF:
+        raise ConversionError("Object type out of range.")
+    if not 0 <= property_id <= 0xFFF:
+        raise ConversionError("Property ID out of range.")
+    return struct.pack("!HH", object_type, property_id << 4)
+
+
+def _unpack_system_network_parameter_header(raw: bytes) -> tuple[int, int]:
+    """
+    Parse the A_SystemNetworkParameter_Read/Response ASDU header.
+
+    `raw` shall be the complete APDU (raw[2:4] is the 16 bit object_type,
+    raw[4] and the upper nibble of raw[5] form the 12 bit property_id, the
+    lower nibble of raw[5] is reserved and discarded). See KNX
+    Specification 03_03_07 Application Layer §3.3.8.
+    """
+    object_type = (raw[2] << 8) | raw[3]
+    property_id = (raw[4] << 4) | (raw[5] >> 4)
+    return object_type, property_id
+
+
 @dataclass(slots=True)
 class SystemNetworkParameterRead(APCI):
     """
@@ -517,55 +546,51 @@ class SystemNetworkParameterRead(APCI):
 
     APCI 0x1C8 falls within the same 4 bit service nibble (0b0111) that is
     otherwise used for A_ADC_Response, but is a distinct, dedicated service.
-    Payload contains the interface object type, the Property ID and a
-    PID-specific, variable-length operand used eg. by ETS to discover
-    devices and system parameters via broadcast.
-
-    The 4 bits directly following object_type/property_id are reserved
-    (always 0) and are stripped from `operand` rather than exposed.
+    Payload contains a 16 bit interface object type, a 12 bit Property ID
+    and a PID-specific, variable-length test_info used eg. by ETS to
+    discover devices and system parameters via broadcast.
     """
 
     CODE: ClassVar = APCIService.SYSTEM_NETWORK_PARAMETER_READ
 
     object_type: int
     property_id: int
-    operand: bytes = b""
+    test_info: bytes = b""
 
     def calculated_length(self) -> int:
         """Get length of APCI payload."""
-        return 3 + len(self.operand)
+        return 5 + len(self.test_info)
 
     @classmethod
     def from_knx(cls, raw: bytes) -> SystemNetworkParameterRead:
         """Parse/deserialize from KNX/IP raw data."""
-        if len(raw) < 5:
+        if len(raw) < 6:
             raise ConversionError(
                 f"Invalid length for A_SystemNetworkParameter_Read in CEMI: {raw.hex()}"
             )
-        object_type, property_id = struct.unpack("!BB", raw[2:4])
-        # raw[4]'s upper 4 bits are reserved (always 0); only the lower 4
-        # bits belong to operand.
-        operand = bytes([raw[4] & 0x0F]) + raw[5:]
+        object_type, property_id = _unpack_system_network_parameter_header(raw)
 
         return cls(
             object_type=object_type,
             property_id=property_id,
-            operand=operand,
+            test_info=raw[6:],
         )
 
     def to_knx(self) -> bytearray:
         """Serialize to KNX/IP raw data."""
-        payload = struct.pack("!BB", self.object_type, self.property_id)
+        payload = _pack_system_network_parameter_header(
+            self.object_type, self.property_id
+        )
 
         return encode_cmd_and_payload(
-            self.CODE, appended_payload=payload + self.operand
+            self.CODE, appended_payload=payload + self.test_info
         )
 
     def __str__(self) -> str:
         """Return object as readable string."""
         return (
             f'<SystemNetworkParameterRead object_type="{self.object_type}" '
-            f'property_id="{self.property_id}" operand="{self.operand.hex()}" />'
+            f'property_id="{self.property_id}" test_info="{self.test_info.hex()}" />'
         )
 
 
@@ -577,17 +602,13 @@ class SystemNetworkParameterResponse(APCI):
     See KNX Specification 03_03_07 Application Layer §3.3.8
     A_SystemNetworkParameter_Response.
 
-    Same header as SystemNetworkParameterRead (object_type, property_id,
-    then a byte whose upper 4 bits are reserved). Beyond that, the PDU
-    has two variable-length fields, operand and test_result, with no
-    length indicator on the wire separating them - the boundary is only
-    known if the original request's operand length is known. Since APCI
-    parsing here is stateless, both are kept together as
-    `test_info_and_result` instead of guessing a split.
-
-    NOTE: unlike SystemNetworkParameterRead, the reserved 4 bits here have
-    not been stripped out - `test_info_and_result[0]`'s upper nibble is
-    still the raw reserved value (expected 0), not masked off.
+    Same header as SystemNetworkParameterRead (16 bit object_type, 12 bit
+    property_id, 4 reserved bits). Beyond that, the PDU has two
+    variable-length fields, test_info and test_result, with no length
+    indicator on the wire separating them - the boundary is only known if
+    the original request's test_info length is known. Since APCI parsing
+    here is stateless, both are kept together as `test_info_and_result`
+    instead of guessing a split.
     """
 
     CODE: ClassVar = APCIService.SYSTEM_NETWORK_PARAMETER_RESPONSE
@@ -598,26 +619,28 @@ class SystemNetworkParameterResponse(APCI):
 
     def calculated_length(self) -> int:
         """Get length of APCI payload."""
-        return 3 + len(self.test_info_and_result)
+        return 5 + len(self.test_info_and_result)
 
     @classmethod
     def from_knx(cls, raw: bytes) -> SystemNetworkParameterResponse:
         """Parse/deserialize from KNX/IP raw data."""
-        if len(raw) < 5:
+        if len(raw) < 6:
             raise ConversionError(
                 f"Invalid length for A_SystemNetworkParameter_Response in CEMI: {raw.hex()}"
             )
-        object_type, property_id = struct.unpack("!BB", raw[2:4])
+        object_type, property_id = _unpack_system_network_parameter_header(raw)
 
         return cls(
             object_type=object_type,
             property_id=property_id,
-            test_info_and_result=raw[4:],
+            test_info_and_result=raw[6:],
         )
 
     def to_knx(self) -> bytearray:
         """Serialize to KNX/IP raw data."""
-        payload = struct.pack("!BB", self.object_type, self.property_id)
+        payload = _pack_system_network_parameter_header(
+            self.object_type, self.property_id
+        )
 
         return encode_cmd_and_payload(
             self.CODE, appended_payload=payload + self.test_info_and_result

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -52,6 +52,8 @@ class APCIService(Enum):
     ADC_READ = 0x0180
     ADC_RESPONSE = 0x1C0
 
+    SYSTEM_NETWORK_PARAMETER_READ = 0x1C8
+
     MEMORY_EXTENDED_WRITE = 0x1FB
     MEMORY_EXTENDED_WRITE_RESPONSE = 0x1FC
     MEMORY_EXTENDED_READ = 0x1FD
@@ -160,6 +162,8 @@ class APCI(ABC):
         if service == APCIService.ADC_READ.value:
             return ADCRead.from_knx(raw)
         if service == APCIService.ADC_RESPONSE.value:
+            if apci == APCIService.SYSTEM_NETWORK_PARAMETER_READ.value:
+                return SystemNetworkParameterRead.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE.value:
                 return MemoryExtendedWrite.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE_RESPONSE.value:
@@ -498,6 +502,68 @@ class ADCResponse(APCI):
     def __str__(self) -> str:
         """Return object as readable string."""
         return f'<ADCResponse channel="{self.channel}" count="{self.count}" value="{self.value}" />'
+
+
+@dataclass(slots=True)
+class SystemNetworkParameterRead(APCI):
+    """
+    SystemNetworkParameterRead service.
+
+    See KNX Specification 03_03_07 Application Layer §3.3.8
+    A_SystemNetworkParameter_Read.
+
+    APCI 0x1C8 falls within the same 4 bit service nibble (0b0111) that is
+    otherwise used for A_ADC_Response, but is a distinct, dedicated service.
+    Payload contains the interface object type, the Property ID and a
+    PID-specific operand used eg. by ETS to discover devices and system
+    parameters via broadcast.
+
+    The 4 bits directly following object_type/property_id are reserved
+    (always 0) and are stripped from `operand` rather than exposed.
+    """
+
+    CODE: ClassVar = APCIService.SYSTEM_NETWORK_PARAMETER_READ
+
+    object_type: int
+    property_id: int
+    operand: bytes = b""
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 2 + len(self.operand)
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> SystemNetworkParameterRead:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 5:
+            raise ConversionError(
+                f"Invalid length for A_SystemNetworkParameter_Read in CEMI: {raw.hex()}"
+            )
+        object_type, property_id = struct.unpack("!BB", raw[2:4])
+        # raw[4]'s upper 4 bits are reserved (always 0); only the lower 4
+        # bits belong to operand.
+        operand = bytes([raw[4] & 0x0F]) + raw[5:]
+
+        return cls(
+            object_type=object_type,
+            property_id=property_id,
+            operand=operand,
+        )
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        payload = struct.pack("!BB", self.object_type, self.property_id)
+
+        return encode_cmd_and_payload(
+            self.CODE, appended_payload=payload + self.operand
+        )
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f'<SystemNetworkParameterRead object_type="{self.object_type}" '
+            f'property_id="{self.property_id}" operand="{self.operand.hex()}" />'
+        )
 
 
 @dataclass(slots=True)

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -53,6 +53,7 @@ class APCIService(Enum):
     ADC_RESPONSE = 0x1C0
 
     SYSTEM_NETWORK_PARAMETER_READ = 0x1C8
+    SYSTEM_NETWORK_PARAMETER_RESPONSE = 0x1C9
 
     MEMORY_EXTENDED_WRITE = 0x1FB
     MEMORY_EXTENDED_WRITE_RESPONSE = 0x1FC
@@ -164,6 +165,8 @@ class APCI(ABC):
         if service == APCIService.ADC_RESPONSE.value:
             if apci == APCIService.SYSTEM_NETWORK_PARAMETER_READ.value:
                 return SystemNetworkParameterRead.from_knx(raw)
+            if apci == APCIService.SYSTEM_NETWORK_PARAMETER_RESPONSE.value:
+                return SystemNetworkParameterResponse.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE.value:
                 return MemoryExtendedWrite.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE_RESPONSE.value:
@@ -515,8 +518,8 @@ class SystemNetworkParameterRead(APCI):
     APCI 0x1C8 falls within the same 4 bit service nibble (0b0111) that is
     otherwise used for A_ADC_Response, but is a distinct, dedicated service.
     Payload contains the interface object type, the Property ID and a
-    PID-specific operand used eg. by ETS to discover devices and system
-    parameters via broadcast.
+    PID-specific, variable-length operand used eg. by ETS to discover
+    devices and system parameters via broadcast.
 
     The 4 bits directly following object_type/property_id are reserved
     (always 0) and are stripped from `operand` rather than exposed.
@@ -530,7 +533,7 @@ class SystemNetworkParameterRead(APCI):
 
     def calculated_length(self) -> int:
         """Get length of APCI payload."""
-        return 2 + len(self.operand)
+        return 3 + len(self.operand)
 
     @classmethod
     def from_knx(cls, raw: bytes) -> SystemNetworkParameterRead:
@@ -563,6 +566,69 @@ class SystemNetworkParameterRead(APCI):
         return (
             f'<SystemNetworkParameterRead object_type="{self.object_type}" '
             f'property_id="{self.property_id}" operand="{self.operand.hex()}" />'
+        )
+
+
+@dataclass(slots=True)
+class SystemNetworkParameterResponse(APCI):
+    """
+    SystemNetworkParameterResponse service.
+
+    See KNX Specification 03_03_07 Application Layer §3.3.8
+    A_SystemNetworkParameter_Response.
+
+    Same header as SystemNetworkParameterRead (object_type, property_id,
+    then a byte whose upper 4 bits are reserved). Beyond that, the PDU
+    has two variable-length fields, operand and test_result, with no
+    length indicator on the wire separating them - the boundary is only
+    known if the original request's operand length is known. Since APCI
+    parsing here is stateless, both are kept together as
+    `test_info_and_result` instead of guessing a split.
+
+    NOTE: unlike SystemNetworkParameterRead, the reserved 4 bits here have
+    not been stripped out - `test_info_and_result[0]`'s upper nibble is
+    still the raw reserved value (expected 0), not masked off.
+    """
+
+    CODE: ClassVar = APCIService.SYSTEM_NETWORK_PARAMETER_RESPONSE
+
+    object_type: int
+    property_id: int
+    test_info_and_result: bytes = b""
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 3 + len(self.test_info_and_result)
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> SystemNetworkParameterResponse:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 5:
+            raise ConversionError(
+                f"Invalid length for A_SystemNetworkParameter_Response in CEMI: {raw.hex()}"
+            )
+        object_type, property_id = struct.unpack("!BB", raw[2:4])
+
+        return cls(
+            object_type=object_type,
+            property_id=property_id,
+            test_info_and_result=raw[4:],
+        )
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        payload = struct.pack("!BB", self.object_type, self.property_id)
+
+        return encode_cmd_and_payload(
+            self.CODE, appended_payload=payload + self.test_info_and_result
+        )
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f'<SystemNetworkParameterResponse object_type="{self.object_type}" '
+            f'property_id="{self.property_id}" '
+            f'test_info_and_result="{self.test_info_and_result.hex()}" />'
         )
 
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

This PR adds two APCI's for read and responses for system network parameters.

Fixes #1021 (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)