### PR TITLE
feat: A_SystemNetworkParameter_Write

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ nav_order: 2
 
 ### Protocol
 
-- Add A_SystemNetworkParameter_Read and A_SystemNetworkParameter_Response APCI service parsing.
+- Add A_SystemNetworkParameter_Read, A_SystemNetworkParameter_Response and A_SystemNetworkParameter_Write APCI service parsing.
 
 ### DPT
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -40,6 +40,7 @@ from xknx.telegram.apci import (
     Restart,
     SystemNetworkParameterRead,
     SystemNetworkParameterResponse,
+    SystemNetworkParameterWrite,
     UserManufacturerInfoRead,
     UserManufacturerInfoResponse,
     UserMemoryRead,
@@ -511,6 +512,107 @@ class TestSystemNetworkParameterResponse:
         assert str(payload) == (
             '<SystemNetworkParameterResponse object_type="11" property_id="5" '
             'test_info_and_result="aabbcc" />'
+        )
+
+
+class TestSystemNetworkParameterWrite:
+    """Test class for SystemNetworkParameterWrite objects."""
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = SystemNetworkParameterWrite(
+            object_type=11, property_id=5, value=bytes.fromhex("aabbcc")
+        )
+
+        assert payload.calculated_length() == 8
+
+    def test_from_knx(self) -> None:
+        """Test the from_knx method."""
+        payload = APCI.from_knx(bytes.fromhex("01ca000b0050aabbcc"))
+
+        assert payload == SystemNetworkParameterWrite(
+            object_type=11, property_id=5, value=bytes.fromhex("aabbcc")
+        )
+
+    def test_from_knx_strips_reserved_bits(self) -> None:
+        """Test from_knx discards the reserved 4 bits instead of exposing them."""
+        # raw[5]=0x5f: upper nibble (0x5) completes property_id=5, lower
+        # nibble (0xf) is garbage reserved bits that must not leak into
+        # property_id or value.
+        payload = APCI.from_knx(bytes.fromhex("01ca000b005faabbcc"))
+
+        assert payload == SystemNetworkParameterWrite(
+            object_type=11, property_id=5, value=bytes.fromhex("aabbcc")
+        )
+
+    def test_from_knx_no_value(self) -> None:
+        """
+        Test from_knx accepts the minimum 6 octet APDU with no value.
+
+        Eg. a device signalling "unsupported object type / PID" by
+        echoing object_type=0xFFFF, property_id=0xFFF with no value.
+        """
+        payload = APCI.from_knx(bytes.fromhex("01cafffffff0"))
+
+        assert payload == SystemNetworkParameterWrite(
+            object_type=0xFFFF, property_id=0xFFF, value=b""
+        )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        # only 5 octets - the ASDU header (object_type + property_id +
+        # reserved) needs 4 octets after the 2 APCI header octets.
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes.fromhex("01ca000b00"))
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method."""
+        payload = SystemNetworkParameterWrite(
+            object_type=11, property_id=5, value=bytes.fromhex("aabbcc")
+        )
+
+        assert payload.to_knx() == bytes.fromhex("01ca000b0050aabbcc")
+
+    def test_round_trip(self) -> None:
+        """Test from_knx().to_knx() reproduces the original bytes exactly."""
+        raw = bytes.fromhex("01ca000b0050aabbcc")
+
+        assert APCI.from_knx(raw).to_knx() == raw
+
+    def test_round_trip_normalizes_reserved_bits(self) -> None:
+        """Test a frame with garbage reserved bits reserializes to its canonical form."""
+        dirty = bytes.fromhex("01ca000b005faabbcc")
+        canonical = bytes.fromhex("01ca000b0050aabbcc")
+
+        payload = APCI.from_knx(dirty)
+        reserialized = payload.to_knx()
+
+        assert reserialized == canonical
+        assert APCI.from_knx(bytes(reserialized)) == payload
+
+    def test_to_knx_object_type_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range object_type."""
+        payload = SystemNetworkParameterWrite(object_type=-1, property_id=0)
+
+        with pytest.raises(ConversionError, match=r".*Object type.*"):
+            payload.to_knx()
+
+    def test_to_knx_property_id_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range property_id."""
+        payload = SystemNetworkParameterWrite(object_type=0, property_id=-1)
+
+        with pytest.raises(ConversionError, match=r".*Property ID.*"):
+            payload.to_knx()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        payload = SystemNetworkParameterWrite(
+            object_type=11, property_id=5, value=bytes.fromhex("aabbcc")
+        )
+
+        assert str(payload) == (
+            '<SystemNetworkParameterWrite object_type="11" property_id="5" '
+            'value="aabbcc" />'
         )
 
 

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -54,6 +54,7 @@ class APCIService(Enum):
 
     SYSTEM_NETWORK_PARAMETER_READ = 0x1C8
     SYSTEM_NETWORK_PARAMETER_RESPONSE = 0x1C9
+    SYSTEM_NETWORK_PARAMETER_WRITE = 0x1CA
 
     MEMORY_EXTENDED_WRITE = 0x1FB
     MEMORY_EXTENDED_WRITE_RESPONSE = 0x1FC
@@ -167,6 +168,8 @@ class APCI(ABC):
                 return SystemNetworkParameterRead.from_knx(raw)
             if apci == APCIService.SYSTEM_NETWORK_PARAMETER_RESPONSE.value:
                 return SystemNetworkParameterResponse.from_knx(raw)
+            if apci == APCIService.SYSTEM_NETWORK_PARAMETER_WRITE.value:
+                return SystemNetworkParameterWrite.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE.value:
                 return MemoryExtendedWrite.from_knx(raw)
             if apci == APCIService.MEMORY_EXTENDED_WRITE_RESPONSE.value:
@@ -652,6 +655,60 @@ class SystemNetworkParameterResponse(APCI):
             f'<SystemNetworkParameterResponse object_type="{self.object_type}" '
             f'property_id="{self.property_id}" '
             f'test_info_and_result="{self.test_info_and_result.hex()}" />'
+        )
+
+
+@dataclass(slots=True)
+class SystemNetworkParameterWrite(APCI):
+    """
+    SystemNetworkParameterWrite service.
+
+    See KNX Specification 03_03_07 Application Layer §3.3.9
+    A_SystemNetworkParameter_Write.
+
+    Same header as SystemNetworkParameterRead/Response (16 bit object_type,
+    12 bit property_id, 4 reserved bits), followed by a PID-specific,
+    variable-length value to write.
+    """
+
+    CODE: ClassVar = APCIService.SYSTEM_NETWORK_PARAMETER_WRITE
+
+    object_type: int
+    property_id: int
+    value: bytes = b""
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 5 + len(self.value)
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> SystemNetworkParameterWrite:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_SystemNetworkParameter_Write in CEMI: {raw.hex()}"
+            )
+        object_type, property_id = _unpack_system_network_parameter_header(raw)
+
+        return cls(
+            object_type=object_type,
+            property_id=property_id,
+            value=raw[6:],
+        )
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        payload = _pack_system_network_parameter_header(
+            self.object_type, self.property_id
+        )
+
+        return encode_cmd_and_payload(self.CODE, appended_payload=payload + self.value)
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f'<SystemNetworkParameterWrite object_type="{self.object_type}" '
+            f'property_id="{self.property_id}" value="{self.value.hex()}" />'
         )
 
 


### PR DESCRIPTION

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Adds support for the A_SystemNetworkParameter_Write service (APCI 0x1CA), following the same 16 bit object_type / 12 bit property_id / 4 reserved bit header as the existing Read and Response services, plus a PID-specific variable-length value.



Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)