### PR TITLE
Add generic DPT 1 and DPT 2 transcoders

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,7 @@ nav_order: 2
 ### DPT
 
 - Add DPT 2 definitions
+- Add generic DPT 1 (`DPT1BitBoolean`, value_type `"1bit"`) as a boolean fallback used when a value only resolves to the DPT 1 main number (e.g. an ETS project without a specific 1.yyy subtype). Behaves like `DPTBool`.
 - Add DPT 243.600 (`DPT_Colour_Transition_xyY`), 249.600 (`DPT_Brightness_Colour_Temperature_Transition`), 250.600 (`DPT_Brightness_Colour_Temperature_Control`), 252.600 (`DPT_Relative_Control_RGBW`), 253.600 (`DPT_Relative_Control_xyY`) and 254.600 (`DPT_Relative_Control_RGB`)
 
 # 3.16.0 Complex schema 2026-06-19

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,7 +21,7 @@ nav_order: 2
 ### DPT
 
 - Add DPT 2 definitions
-- Add generic DPT 1 (`DPT1BitBoolean`, value_type `"1bit"`) as a boolean fallback used when a value only resolves to the DPT 1 main number (e.g. an ETS project without a specific 1.yyy subtype). Behaves like `DPTBool`.
+- Add generic DPT 1 (`DPT1BitBoolean`, value_type `"1bit"`) and generic DPT 2 (`DPT2BitBoolean`, value_type `"2bit"`) as boolean fallbacks used when a value only resolves to the DPT 1 / DPT 2 main number (e.g. an ETS project without a specific 1.yyy / 2.yyy subtype). They behave like `DPTBool` / `DPTBoolControl`.
 - Add DPT 243.600 (`DPT_Colour_Transition_xyY`), 249.600 (`DPT_Brightness_Colour_Temperature_Transition`), 250.600 (`DPT_Brightness_Colour_Temperature_Control`), 252.600 (`DPT_Relative_Control_RGBW`), 253.600 (`DPT_Relative_Control_xyY`) and 254.600 (`DPT_Relative_Control_RGB`)
 
 # 3.16.0 Complex schema 2026-06-19

--- a/test/dpt_tests/dpt_1_test.py
+++ b/test/dpt_tests/dpt_1_test.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import pytest
 
-from xknx.dpt import DPTArray, DPTBinary, DPTEnumData
+from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTEnumData
 from xknx.dpt.dpt_1 import (
     Ack,
     Alarm,
@@ -13,6 +13,7 @@ from xknx.dpt.dpt_1 import (
     ConsumerProducer,
     DayNight,
     DimSendStyle,
+    DPT1BitBoolean,
     DPT1BitEnum,
     DPTAck,
     DPTAlarm,
@@ -68,6 +69,7 @@ from xknx.exceptions import ConversionError, CouldNotParseTelegram
     [
         (DPTSwitch, Switch.OFF, Switch.ON),
         (DPTBool, Bool.FALSE, Bool.TRUE),
+        (DPT1BitBoolean, Bool.FALSE, Bool.TRUE),
         (DPTEnable, Enable.DISABLE, Enable.ENABLE),
         (DPTRamp, Ramp.NO_RAMP, Ramp.RAMP),
         (DPTAlarm, Alarm.NO_ALARM, Alarm.ALARM),
@@ -164,3 +166,20 @@ class TestDPT1:
             dpt.from_knx(DPTArray((1,)))
         with pytest.raises(CouldNotParseTelegram):
             dpt.from_knx(DPTBinary(2))
+
+
+class TestDPT1BitBoolean:
+    """Test the generic DPT 1 (1.*** boolean) transcoder."""
+
+    def test_transcoder_lookup(self) -> None:
+        """Generic DPT 1 is found by main number and value_type; subtypes still win."""
+        assert DPTBase.parse_transcoder(1) is DPT1BitBoolean
+        assert DPTBase.parse_transcoder("1bit") is DPT1BitBoolean
+        assert DPTBase.parse_transcoder("1.001") is DPTSwitch
+        assert DPTBase.parse_transcoder("1.002") is DPTBool
+
+    def test_generic_matches_dptbool(self) -> None:
+        """Generic DPT 1 decodes to the same Bool enum as DPTBool (1.002)."""
+        assert DPT1BitBoolean.from_knx(DPTBinary(1)) is Bool.TRUE
+        assert DPT1BitBoolean.from_knx(DPTBinary(0)) is Bool.FALSE
+        assert DPT1BitBoolean.to_knx(Bool.TRUE) == DPTBool.to_knx(Bool.TRUE)

--- a/test/dpt_tests/dpt_2_test.py
+++ b/test/dpt_tests/dpt_2_test.py
@@ -4,7 +4,14 @@ from typing import Any
 
 import pytest
 
-from xknx.dpt import DPTArray, DPTBinary, DPTBoolControl, DPTSwitchControl
+from xknx.dpt import (
+    DPT2BitBoolean,
+    DPTArray,
+    DPTBase,
+    DPTBinary,
+    DPTBoolControl,
+    DPTSwitchControl,
+)
 from xknx.dpt.dpt_1 import (
     Alarm,
     BinaryValue,
@@ -113,6 +120,7 @@ class TestBinaryControlData:
     [
         (DPTSwitchControl, SwitchControl, Switch.OFF, Switch.ON),
         (DPTBoolControl, BoolControl, Bool.FALSE, Bool.TRUE),
+        (DPT2BitBoolean, BoolControl, Bool.FALSE, Bool.TRUE),
         (DPTEnableControl, EnableControl, Enable.DISABLE, Enable.ENABLE),
         (DPTRampControl, RampControl, Ramp.NO_RAMP, Ramp.RAMP),
         (DPTAlarmControl, AlarmControl, Alarm.NO_ALARM, Alarm.ALARM),
@@ -222,3 +230,20 @@ class TestDPTBinaryControlSchema:
         schema = DPTBoolControl.get_dict_schema()
         value_field = next(f for f in schema if f["name"] == "value")
         assert value_field["options"] == ["false", "true"]
+
+
+class TestDPT2BitBoolean:
+    """Test the generic DPT 2 (2.*** boolean control) transcoder."""
+
+    def test_transcoder_lookup(self) -> None:
+        """Generic DPT 2 is found by main number and value_type; subtypes still win."""
+        assert DPTBase.parse_transcoder(2) is DPT2BitBoolean
+        assert DPTBase.parse_transcoder("2bit") is DPT2BitBoolean
+        assert DPTBase.parse_transcoder("2.001") is DPTSwitchControl
+        assert DPTBase.parse_transcoder("2.002") is DPTBoolControl
+
+    def test_generic_matches_dptboolcontrol(self) -> None:
+        """Generic DPT 2 decodes/encodes the same as DPTBoolControl (2.002)."""
+        value = BoolControl(control=True, value=Bool.TRUE)
+        assert DPT2BitBoolean.from_knx(DPTBinary(3)) == value
+        assert DPT2BitBoolean.to_knx(value) == DPTBoolControl.to_knx(value)

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -18,10 +18,12 @@ class TestRemoteValueSensor:
         assert RemoteValueSensor(xknx=xknx, value_type=9)
         assert RemoteValueSensor(xknx=xknx, value_type="9.021")
         assert RemoteValueSensor(xknx=xknx, value_type="string")
-        # generic DPT 1 (boolean) resolves by number and its "1bit" value_type,
-        # like the specific 1.yyy subtypes do
+        # generic DPT 1 / 2 (boolean) resolve by number and their "1bit"/"2bit"
+        # value_types, like the specific 1.yyy / 2.yyy subtypes do
         assert RemoteValueSensor(xknx=xknx, value_type=1)
         assert RemoteValueSensor(xknx=xknx, value_type="1bit")
+        assert RemoteValueSensor(xknx=xknx, value_type=2)
+        assert RemoteValueSensor(xknx=xknx, value_type="2bit")
 
     def test_wrong_value_type(self) -> None:
         """Test initializing with wrong value_type."""
@@ -31,8 +33,6 @@ class TestRemoteValueSensor:
         # "binary" is the ExposeSensor raw-bool magic, not a RemoteValueSensor DPT
         with pytest.raises(ConversionError):
             RemoteValueSensor(xknx=xknx, value_type="binary")
-        with pytest.raises(ConversionError):
-            RemoteValueSensor(xknx=xknx, value_type=2)
         with pytest.raises(ConversionError):
             RemoteValueSensor(xknx=xknx, value_type=None)
         with pytest.raises(ConversionError):

--- a/test/remote_value_tests/remote_value_sensor_test.py
+++ b/test/remote_value_tests/remote_value_sensor_test.py
@@ -18,16 +18,19 @@ class TestRemoteValueSensor:
         assert RemoteValueSensor(xknx=xknx, value_type=9)
         assert RemoteValueSensor(xknx=xknx, value_type="9.021")
         assert RemoteValueSensor(xknx=xknx, value_type="string")
+        # generic DPT 1 (boolean) resolves by number and its "1bit" value_type,
+        # like the specific 1.yyy subtypes do
+        assert RemoteValueSensor(xknx=xknx, value_type=1)
+        assert RemoteValueSensor(xknx=xknx, value_type="1bit")
 
     def test_wrong_value_type(self) -> None:
         """Test initializing with wrong value_type."""
         xknx = XKNX()
         with pytest.raises(ConversionError):
             RemoteValueSensor(xknx=xknx, value_type="wrong_value_type")
+        # "binary" is the ExposeSensor raw-bool magic, not a RemoteValueSensor DPT
         with pytest.raises(ConversionError):
             RemoteValueSensor(xknx=xknx, value_type="binary")
-        with pytest.raises(ConversionError):
-            RemoteValueSensor(xknx=xknx, value_type=1)
         with pytest.raises(ConversionError):
             RemoteValueSensor(xknx=xknx, value_type=2)
         with pytest.raises(ConversionError):

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -45,6 +45,7 @@ from .dpt_1 import (
     DPTWindowDoor,
 )
 from .dpt_2 import (
+    DPT2BitBoolean,
     DPTAlarmControl,
     DPTBinaryValueControl,
     DPTBoolControl,

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -16,6 +16,7 @@ from .dpt import (
     DPTNumeric,
 )
 from .dpt_1 import (
+    DPT1BitBoolean,
     DPTAck,
     DPTAlarm,
     DPTBinaryValue,

--- a/xknx/dpt/dpt_1.py
+++ b/xknx/dpt/dpt_1.py
@@ -56,6 +56,29 @@ class DPTBool(DPT1BitEnum[Bool]):
         return DPTBinary(value.value)
 
 
+class DPT1BitBoolean(DPT1BitEnum[Bool]):
+    """
+    Abstraction for a generic KNX 1-Bit boolean value (`FALSE`/`TRUE`).
+
+    This is the generic DPT 1 without a specific sub number. It behaves like
+    `DPTBool` and is used as fallback when an ETS project does not resolve to a
+    specific 1.yyy subtype. For semantic values (switch, up/down, …) use the
+    dedicated DPT 1.yyy classes.
+
+    DPT 1.***
+    """
+
+    dpt_main_number = 1
+    dpt_sub_number: int | None = None
+    value_type = "1bit"
+    data_type = Bool
+
+    @classmethod
+    def _to_knx(cls, value: Bool) -> DPTBinary:
+        """Return the raw KNX value for an Enum member."""
+        return DPTBinary(value.value)
+
+
 class Enable(DPTEnumData):
     """Enum for enable control."""
 

--- a/xknx/dpt/dpt_2.py
+++ b/xknx/dpt/dpt_2.py
@@ -228,6 +228,28 @@ class DPTBoolControl(_DPTBinaryControlBase[BoolControl]):
         return cls._encode_binary_control(value)
 
 
+class DPT2BitBoolean(_DPTBinaryControlBase[BoolControl]):
+    """
+    Abstraction for a generic KNX 2-bit boolean control value.
+
+    This is the generic DPT 2 without a specific sub number. It behaves like
+    `DPTBoolControl` and is used as fallback when a value only resolves to the
+    DPT 2 main number (e.g. an ETS project without a specific 2.yyy subtype).
+    For semantic values (switch, up/down, …) use the dedicated DPT 2.yyy classes.
+
+    DPT 2.***
+    """
+
+    data_type = BoolControl
+    dpt_main_number = 2
+    dpt_sub_number: int | None = None
+    value_type = "2bit"
+
+    @classmethod
+    def _to_knx(cls, value: BoolControl) -> DPTBinary:
+        return cls._encode_binary_control(value)
+
+
 class DPTEnableControl(_DPTBinaryControlBase[EnableControl]):
     """Abstraction for KNX 2-bit enable control. DPT 2.003."""
 


### PR DESCRIPTION
## Summary

Adds generic transcoders for DPT main numbers 1 and 2, used as a fallback when a value only resolves to the main number without a specific subtype (e.g. an ETS project that specifies DPT `1.*` / `2.*` without a concrete `1.yyy` / `2.yyy`).

- **`DPT1BitBoolean`** (value_type `"1bit"`) — a `DPT1BitEnum[Bool]` reusing the existing `Bool` enum; behaves exactly like `DPTBool` (1.002).
- **`DPT2BitBoolean`** (value_type `"2bit"`) — a `_DPTBinaryControlBase[BoolControl]` reusing the existing `BoolControl` data type; behaves exactly like `DPTBoolControl` (2.002).

Both are registered with `dpt_sub_number = None`, so `DPTBase.parse_transcoder(1)` / `parse_transcoder(2)` resolve to them, while `parse_transcoder("1.001")`, `"2.002"`, etc. still resolve to the specific subtypes (no shadowing).

## Why

When decoding group addresses from an ETS project (or any source) that only carries the DPT main number, there was previously no transcoder to fall back to — the value stayed undecoded. These generics provide a sensible boolean default while staying fully consistent with the existing specific subtypes (they return the same `Bool` / `BoolControl` values, so every consumer works with them unchanged).

## Notes for reviewers

- **value_type naming:** `"1bit"` / `"2bit"` follow the width-based naming of the numeric generics (`"1byte_unsigned"`, …). I deliberately did **not** reuse `"binary"` — that string is already the `ExposeSensor` magic identifier that routes to a raw-bool `RemoteValueSwitch`, and hijacking it would change that behavior.
- **`RemoteValueSensor`:** because these now resolve, `RemoteValueSensor(value_type=1)` / `value_type=2` (and `"1bit"`/`"2bit"`) no longer raise. The sensor test was updated accordingly. `"binary"` still raises there (it remains the ExposeSensor-only raw-bool path).
- **Behavior change worth flagging:** `parse_transcoder(1)` / `(2)` now return a transcoder instead of `None`, so the eager group-address/ETS decoder will decode bare main-number DPT 1/2 addresses to `Bool` / `BoolControl` rather than leaving them undecoded. This is the intended fallback; all existing tests pass with it.

## Tests

- `DPT1BitBoolean` / `DPT2BitBoolean` added to the existing parametrized DPT 1 / DPT 2 test suites (full to_knx/from_knx/dict coverage, identical to the specific subtypes).
- New focused tests for transcoder lookup (`parse_transcoder(1)` / `(2)` / `"1bit"` / `"2bit"`, and that subtypes still win) and that each generic matches its `.002` counterpart.
- Updated `remote_value_sensor_test` for the newly-resolvable value types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)