### PR TITLE
fix: re-export ReturnCode from xknx.management.application_layer_enum

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,9 +8,9 @@ nav_order: 2
 
 # Unreleased changes
 
-### Breaking changes
+### Deprecation notes
 
-- Moved `ReturnCode` from `xknx.management.application_layer_enum` to `xknx.telegram.apci`; the old module is removed.
+- Moved `ReturnCode` from `xknx.management.application_layer_enum` to `xknx.telegram.apci`. The old module still re-exports it for backwards compatibility but is deprecated and will be removed in a future release.
 
 ### Protocol
 

--- a/xknx/management/application_layer_enum.py
+++ b/xknx/management/application_layer_enum.py
@@ -1,0 +1,5 @@
+"""Deprecated: kept for backwards compatibility, import ReturnCode from xknx.telegram.apci instead."""
+
+from xknx.telegram.apci import ReturnCode
+
+__all__ = ["ReturnCode"]


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->
ReturnCode moved to xknx.telegram.apci but the old module was removed outright, breaking downstream imports. Restore it as a deprecated re-export instead.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)