### PR TITLE
Add DPT 4 (single character)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,8 +19,13 @@ nav_order: 2
 - Fix A_Restart parsing to distinguish Basic Restart from Master Reset (restart_type bit was ignored, silently dropping erase_code/channel_number on relay). Add A_Restart_Response parsing for the Master Reset confirmation.
 - Add A_PropertyExtValue_Read, A_PropertyExtValue_Response, A_PropertyExtValue_WriteCon, A_PropertyExtValue_WriteConRes, A_PropertyExtValue_WriteUnCon, A_PropertyExtValue_InfoReport, A_PropertyExtDescription_Read and A_PropertyExtDescription_Response APCI service parsing.
 
+### Devices
+
+- Notification: crop the message to the configured DPT's payload length instead of a hardcoded 14 characters (enables single-character DPT 4 notifications).
+
 ### DPT
 
+- Add DPT 4 (`DPTCharacter` 4.001 ASCII, `DPTCharacterLatin1` 4.002 ISO 8859-1) for single characters
 - Add DPT 2 definitions
 - Add generic DPT 1 (`DPT1BitBoolean`, value_type `"1bit"`) and generic DPT 2 (`DPT2BitBoolean`, value_type `"2bit"`) as boolean fallbacks used when a value only resolves to the DPT 1 / DPT 2 main number (e.g. an ETS project without a specific 1.yyy / 2.yyy subtype). They behave like `DPTBool` / `DPTBoolControl`.
 - Add DPT 243.600 (`DPT_Colour_Transition_xyY`), 249.600 (`DPT_Brightness_Colour_Temperature_Transition`), 250.600 (`DPT_Brightness_Colour_Temperature_Control`), 252.600 (`DPT_Relative_Control_RGBW`), 253.600 (`DPT_Relative_Control_xyY`) and 254.600 (`DPT_Relative_Control_RGB`)

--- a/test/devices_tests/notification_test.py
+++ b/test/devices_tests/notification_test.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from xknx import XKNX
 from xknx.devices import Notification
-from xknx.dpt import DPTArray, DPTBinary, DPTString
+from xknx.dpt import DPTArray, DPTBinary, DPTCharacter, DPTString
 from xknx.telegram import GroupAddress, Telegram
 from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
@@ -183,6 +183,21 @@ class TestNotification:
         assert telegram == Telegram(
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTString().to_knx("This is too lo")),
+        )
+
+    async def test_set_character(self) -> None:
+        """Test that a DPT 4 (single character) notification crops to payload_length."""
+        xknx = XKNX()
+        notification = Notification(
+            xknx, "Warning", group_address="1/2/3", value_type="character"
+        )
+        # message longer than 1 char gets cropped to the DPT's payload_length (1)
+        await notification.set("Hello")
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTCharacter.to_knx("H")),
         )
 
     #

--- a/test/dpt_tests/dpt_4_character_test.py
+++ b/test/dpt_tests/dpt_4_character_test.py
@@ -1,0 +1,85 @@
+"""Unit test for KNX character (DPT 4) object."""
+
+import pytest
+
+from xknx.dpt import DPTArray, DPTBase, DPTCharacter, DPTCharacterLatin1
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
+
+
+class TestDPTCharacter:
+    """Test class for KNX single character object."""
+
+    @pytest.mark.parametrize(
+        ("string", "raw"),
+        [
+            ("A", (65,)),
+            ("z", (122,)),
+            ("0", (48,)),
+            ("?", (63,)),
+            (" ", (32,)),
+            ("", (0,)),  # empty -> NUL byte, stripped on decode
+        ],
+    )
+    @pytest.mark.parametrize("test_dpt", [DPTCharacter, DPTCharacterLatin1])
+    def test_values(
+        self, string: str, raw: tuple[int, ...], test_dpt: type[DPTCharacter]
+    ) -> None:
+        """Test parsing and streaming ASCII-range characters for both subtypes."""
+        assert test_dpt.to_knx(string) == DPTArray(raw)
+        assert test_dpt.from_knx(DPTArray(raw)) == string
+
+    @pytest.mark.parametrize(
+        ("string", "knx_string", "raw"),
+        [
+            ("é", "?", (63,)),
+            ("ß", "?", (63,)),
+        ],
+    )
+    def test_to_knx_ascii_invalid_char(
+        self, string: str, knx_string: str, raw: tuple[int, ...]
+    ) -> None:
+        """Test streaming a non-ASCII character replaces it with a question mark."""
+        assert DPTCharacter.to_knx(string) == DPTArray(raw)
+        assert DPTCharacter.from_knx(DPTArray(raw)) == knx_string
+
+    @pytest.mark.parametrize(
+        ("string", "raw"),
+        [
+            ("é", (0xE9,)),
+            ("ÿ", (0xFF,)),
+            ("ä", (0xE4,)),
+        ],
+    )
+    def test_to_knx_latin_1(self, string: str, raw: tuple[int, ...]) -> None:
+        """Test streaming Latin-1 characters."""
+        assert DPTCharacterLatin1.to_knx(string) == DPTArray(raw)
+        assert DPTCharacterLatin1.from_knx(DPTArray(raw)) == string
+
+    def test_to_knx_too_long(self) -> None:
+        """Test serializing more than one character raises."""
+        with pytest.raises(ConversionError):
+            DPTCharacter.to_knx("AB")
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            (65, 66),  # two octets
+            (),  # zero octets
+        ],
+    )
+    def test_from_knx_wrong_parameter_length(self, raw: tuple[int, ...]) -> None:
+        """Test parsing with wrong payload length raises."""
+        with pytest.raises(CouldNotParseTelegram):
+            DPTCharacter.from_knx(DPTArray(raw))
+
+    def test_no_unit_of_measurement(self) -> None:
+        """Test that DPT 4 has no unit."""
+        assert DPTCharacter.unit is None
+        assert DPTCharacterLatin1.unit is None
+
+    def test_transcoder_lookup(self) -> None:
+        """Test lookup by DPT number and value_type."""
+        assert DPTBase.parse_transcoder("4.001") is DPTCharacter
+        assert DPTBase.parse_transcoder("4.002") is DPTCharacterLatin1
+        assert DPTBase.parse_transcoder("character") is DPTCharacter
+        assert DPTBase.parse_transcoder("character_latin_1") is DPTCharacterLatin1

--- a/xknx/devices/notification.py
+++ b/xknx/devices/notification.py
@@ -56,7 +56,7 @@ class Notification(Device):
 
     async def set(self, message: str) -> None:
         """Set message."""
-        cropped_message = message[:14]
+        cropped_message = message[: self.remote_value.dpt_class.payload_length]
         self.remote_value.set(cropped_message)
 
     def process_group_write(self, telegram: Telegram) -> None:

--- a/xknx/dpt/__init__.py
+++ b/xknx/dpt/__init__.py
@@ -60,6 +60,7 @@ from .dpt_2 import (
     DPTSwitchControl,
 )
 from .dpt_3 import DPTControlBlinds, DPTControlDimming
+from .dpt_4 import DPTCharacter, DPTCharacterLatin1
 from .dpt_5 import (
     DPTAngle,
     DPTDecimalFactor,

--- a/xknx/dpt/dpt_4.py
+++ b/xknx/dpt/dpt_4.py
@@ -1,0 +1,36 @@
+"""Implementation of 3.4 Datapoint Types Character Set."""
+
+from __future__ import annotations
+
+from .dpt_16 import DPTString
+
+
+class DPTCharacter(DPTString):
+    """
+    Abstraction for KNX 1 Octet ASCII character.
+
+    A single character is encoded/decoded as a length-1 string, sharing the
+    logic of `DPTString` (DPT 16) with a 1-octet payload.
+
+    DPT 4.001
+    """
+
+    payload_length = 1
+    dpt_main_number = 4
+    dpt_sub_number = 1
+    value_type = "character"
+
+    _encoding = "ascii"
+
+
+class DPTCharacterLatin1(DPTCharacter):
+    """
+    Abstraction for KNX 1 Octet Latin-1 (ISO 8859-1) character.
+
+    DPT 4.002
+    """
+
+    dpt_main_number = 4
+    dpt_sub_number = 2
+    value_type = "character_latin_1"
+    _encoding = "latin_1"


### PR DESCRIPTION
## Summary

Adds DPT 4 "Character Set" (`A8`, a single 1-octet character):

- **`DPTCharacter`** (4.001, value_type `"character"`) — US-ASCII, non-encodable characters replaced with `?`.
- **`DPTCharacterLatin1`** (4.002, value_type `"character_latin_1"`) — ISO 8859-1.

Both are implemented as subclasses of `DPTString` (DPT 16) with `payload_length = 1` — a single character is just a length-1 string, so the existing encode/decode logic applies unchanged (same pattern as `DPTLatin1` for 16.001). `from_knx` returns a single-character `str`; `to_knx` rejects more than one character.

## Why inherit from `DPTString` instead of `DPTBase`

The Home Assistant KNX integration classifies every DPT in `DPTBase.dpt_class_tree()` by `issubclass` against `DPTNumeric` / `DPTEnum` / `DPTComplex` / `DPTString`, and raises `ValueError("Unsupported DPT class")` for anything else. A standalone `DPTBase` subclass would have broken `get_supported_dpts()` as soon as HA bumped xknx. Inheriting `DPTString` makes DPT 4 classify as a `"string"` DPT, so **HA and the knx-frontend need no changes**, and it's consistent with the KNX spec (DPT 16 string is an array of DPT 4 characters — the spec's 16.000 says "See 4.001").

## Notification device

`Notification.set()` previously cropped messages to a hardcoded 14 characters (DPT 16's length). Since a `DPTString` subtype with a different `payload_length` (DPT 4 → 1) can now be configured, it crops to the resolved DPT's `payload_length` instead. Default `DPTString` behavior (14) is unchanged.

## Tests

- New `dpt_4_character_test.py`: round-trips for both subtypes, ASCII `?`-replacement, Latin-1 characters, too-long / wrong-payload-length errors, no-unit, and transcoder lookup by number and value_type (100% coverage of `dpt_4.py`).
- `notification_test.py`: added `test_set_character` verifying a `value_type="character"` notification crops to one character; the existing 14-char crop test is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)