### PR TITLE
Recognize A_RouterStatus_Read/Response/Write APCI services

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ nav_order: 2
 - Add A_FunctionPropertyExtCommand, A_FunctionPropertyExtState_Read and A_FunctionPropertyExtState_Response APCI service parsing.
 - Fix A_Restart parsing to distinguish Basic Restart from Master Reset (restart_type bit was ignored, silently dropping erase_code/channel_number on relay). Add A_Restart_Response parsing for the Master Reset confirmation.
 - Add A_PropertyExtValue_Read, A_PropertyExtValue_Response, A_PropertyExtValue_WriteCon, A_PropertyExtValue_WriteConRes, A_PropertyExtValue_WriteUnCon, A_PropertyExtValue_InfoReport, A_PropertyExtDescription_Read and A_PropertyExtDescription_Response APCI service parsing.
+- Recognize A_RouterStatus_Read/Response/Write APCI services; these are a legacy EIB/BCU1-era coupler status service with no PDU definition in the current Application Layer spec and are not planned for implementation - configure couplers via the Router Object properties (`A_PropertyValue_Read`/`A_PropertyValue_Write`) instead.
 
 ### Devices
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -107,6 +107,23 @@ def test_invalid_tpci_apci(raw: bytes, err_msg: str) -> None:
             get_data(0x29, 0, 0, 0, 0, 1, 0x03C0, []),
             r".*APDU not supported*",
         ),
+        (
+            # A_RouterStatus_Read - legacy BCU coupler service, deliberately
+            # unimplemented; must be rejected cleanly, not crash the receive
+            # path with an uncaught NotImplementedError.
+            get_data(0x29, 0, 0, 0, 0, 1, 0x03CD, []),
+            r".*APDU not supported*",
+        ),
+        (
+            # A_RouterStatus_Response
+            get_data(0x29, 0, 0, 0, 0, 1, 0x03CE, []),
+            r".*APDU not supported*",
+        ),
+        (
+            # A_RouterStatus_Write
+            get_data(0x29, 0, 0, 0, 0, 1, 0x03CF, []),
+            r".*APDU not supported*",
+        ),
     ],
 )
 def test_unsupported_tpci_apci(raw: bytes, err_msg: str) -> None:

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -52,6 +52,9 @@ from xknx.telegram.apci import (
     RestartMasterReset,
     RestartMasterResetResponse,
     ReturnCode,
+    RouterStatusRead,
+    RouterStatusResponse,
+    RouterStatusWrite,
     SystemNetworkParameterRead,
     SystemNetworkParameterResponse,
     SystemNetworkParameterWrite,
@@ -2695,6 +2698,92 @@ class TestFunctionPropertyStateResponse:
             str(payload)
             == '<FunctionPropertyStateResponse object_index="1" property_id="4" return_code="8" data="1234" />'
         )
+
+
+class TestRouterStatusRead:
+    """Test class for RouterStatusRead objects."""
+
+    def test_from_knx_dispatches_and_raises_conversion_error(self) -> None:
+        """
+        Test the APCI is routed to the class, which raises ConversionError.
+
+        A real legacy frame must be rejected as UnsupportedCEMIMessage by
+        CEMILData.from_knx instead of crashing the receive path.
+        """
+        with pytest.raises(ConversionError, match=r".*A_RouterStatus_Read.*"):
+            APCI.from_knx(bytes((0x03, 0xCD)))
+
+    def test_to_knx_raises_not_implemented(self) -> None:
+        """Test to_knx raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Read.*"):
+            RouterStatusRead().to_knx()
+
+    def test_calculated_length_raises_not_implemented(self) -> None:
+        """Test calculated_length raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Read.*"):
+            RouterStatusRead().calculated_length()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        assert str(RouterStatusRead()) == "<RouterStatusRead (not implemented) />"
+
+
+class TestRouterStatusResponse:
+    """Test class for RouterStatusResponse objects."""
+
+    def test_from_knx_dispatches_and_raises_conversion_error(self) -> None:
+        """
+        Test the APCI is routed to the class, which raises ConversionError.
+
+        A real legacy frame must be rejected as UnsupportedCEMIMessage by
+        CEMILData.from_knx instead of crashing the receive path.
+        """
+        with pytest.raises(ConversionError, match=r".*A_RouterStatus_Response.*"):
+            APCI.from_knx(bytes((0x03, 0xCE)))
+
+    def test_to_knx_raises_not_implemented(self) -> None:
+        """Test to_knx raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Response.*"):
+            RouterStatusResponse().to_knx()
+
+    def test_calculated_length_raises_not_implemented(self) -> None:
+        """Test calculated_length raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Response.*"):
+            RouterStatusResponse().calculated_length()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        assert (
+            str(RouterStatusResponse()) == "<RouterStatusResponse (not implemented) />"
+        )
+
+
+class TestRouterStatusWrite:
+    """Test class for RouterStatusWrite objects."""
+
+    def test_from_knx_dispatches_and_raises_conversion_error(self) -> None:
+        """
+        Test the APCI is routed to the class, which raises ConversionError.
+
+        A real legacy frame must be rejected as UnsupportedCEMIMessage by
+        CEMILData.from_knx instead of crashing the receive path.
+        """
+        with pytest.raises(ConversionError, match=r".*A_RouterStatus_Write.*"):
+            APCI.from_knx(bytes((0x03, 0xCF)))
+
+    def test_to_knx_raises_not_implemented(self) -> None:
+        """Test to_knx raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Write.*"):
+            RouterStatusWrite().to_knx()
+
+    def test_calculated_length_raises_not_implemented(self) -> None:
+        """Test calculated_length raises NotImplementedError."""
+        with pytest.raises(NotImplementedError, match=r".*A_RouterStatus_Write.*"):
+            RouterStatusWrite().calculated_length()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        assert str(RouterStatusWrite()) == "<RouterStatusWrite (not implemented) />"
 
 
 class TestAuthorizeRequest:

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -108,6 +108,10 @@ class APCIUserService(Enum):
 class APCIExtendedService(Enum):
     """Enum class for extended APCI services."""
 
+    ROUTER_STATUS_READ = 0x03CD
+    ROUTER_STATUS_RESPONSE = 0x03CE
+    ROUTER_STATUS_WRITE = 0x03CF
+
     AUTHORIZE_REQUEST = 0x03D1
     AUTHORIZE_RESPONSE = 0x03D2
 
@@ -298,6 +302,12 @@ class APCI(ABC):
                 return RestartMasterResetResponse.from_knx(raw)
             return Restart.from_knx(raw)
         if service == APCIService.ESCAPE.value:
+            if apci == APCIExtendedService.ROUTER_STATUS_READ.value:
+                return RouterStatusRead.from_knx(raw)
+            if apci == APCIExtendedService.ROUTER_STATUS_RESPONSE.value:
+                return RouterStatusResponse.from_knx(raw)
+            if apci == APCIExtendedService.ROUTER_STATUS_WRITE.value:
+                return RouterStatusWrite.from_knx(raw)
             if apci == APCIExtendedService.AUTHORIZE_REQUEST.value:
                 return AuthorizeRequest.from_knx(raw)
             if apci == APCIExtendedService.AUTHORIZE_RESPONSE.value:
@@ -2605,6 +2615,141 @@ class FunctionPropertyStateResponse(APCI):
     def __str__(self) -> str:
         """Return object as readable string."""
         return f'<FunctionPropertyStateResponse object_index="{self.object_index}" property_id="{self.property_id}" return_code="{self.return_code}" data="{self.data.hex()}" />'
+
+
+@dataclass(slots=True)
+class RouterStatusRead(APCI):
+    """
+    RouterStatusRead service.
+
+    APCI 0x3CD, A_RouterStatus_Read. NOT IMPLEMENTED - and not planned:
+    this is a legacy EIB/BCU1-era line coupler management service, not
+    part of the current Application Layer spec (03_03_07 lists the
+    APCI code with no PDU/payload definition - the coupler status byte
+    was a BCU1/BCU2 hardware memory register, documented only in
+    manufacturer-era EIB Bus Coupling Unit memory maps, not the KNX
+    standard). Modern ETS configures couplers exclusively through the
+    Router Object (Interface Object Type 6) properties
+    (PID_MAIN_LCGRPCONFIG/PID_SUB_LCGRPCONFIG, PID_MAIN_LCCONFIG/
+    PID_SUB_LCCONFIG, PID_ROUTETABLE_CONTROL, PID_LINE_STATUS - see
+    AN161 Coupler Model 2.0) via A_PropertyValue_Read/Write - implement
+    against that instead of this APCI. Kept as a stub only so the APCI
+    code table is complete and dispatch doesn't misroute it. from_knx
+    raises ConversionError so a real incoming frame is rejected as
+    UnsupportedCEMIMessage; calculated_length/to_knx raise
+    NotImplementedError since there's no legitimate way to construct an
+    instance to send.
+    """
+
+    CODE: ClassVar = APCIExtendedService.ROUTER_STATUS_READ
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        raise NotImplementedError(
+            "A_RouterStatus_Read is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> RouterStatusRead:
+        """Parse/deserialize from KNX/IP raw data."""
+        # Rejected as UnsupportedCEMIMessage by CEMILData.from_knx instead of
+        # crashing the receive path - see class docstring.
+        raise ConversionError(f"A_RouterStatus_Read is not supported: {raw.hex()}")
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        raise NotImplementedError(
+            "A_RouterStatus_Read is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return "<RouterStatusRead (not implemented) />"
+
+
+@dataclass(slots=True)
+class RouterStatusResponse(APCI):
+    """
+    RouterStatusResponse service.
+
+    APCI 0x3CE, A_RouterStatus_Response. NOT IMPLEMENTED - see
+    RouterStatusRead's docstring: this is a legacy EIB/BCU1-era coupler
+    status readout with no current Application Layer PDU spec. Use the
+    Router Object's PID_LINE_STATUS (and related PIDs) via
+    A_PropertyValue_Read instead.
+    """
+
+    CODE: ClassVar = APCIExtendedService.ROUTER_STATUS_RESPONSE
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        raise NotImplementedError(
+            "A_RouterStatus_Response is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> RouterStatusResponse:
+        """Parse/deserialize from KNX/IP raw data."""
+        # Rejected as UnsupportedCEMIMessage by CEMILData.from_knx instead of
+        # crashing the receive path - see class docstring.
+        raise ConversionError(f"A_RouterStatus_Response is not supported: {raw.hex()}")
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        raise NotImplementedError(
+            "A_RouterStatus_Response is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return "<RouterStatusResponse (not implemented) />"
+
+
+@dataclass(slots=True)
+class RouterStatusWrite(APCI):
+    """
+    RouterStatusWrite service.
+
+    APCI 0x3CF, canonically A_Write_Router_Status_Request in the
+    coding table (BCU alias "LcGroupWrite" - Line Coupler Group config
+    write). NOT IMPLEMENTED - see RouterStatusRead's docstring: this
+    set a BCU1-generation coupler's group-telegram routing mode (route
+    all / block all / use filter table), a hardware register with no
+    current Application Layer PDU spec. Use the Router Object's
+    PID_MAIN_LCGRPCONFIG/PID_SUB_LCGRPCONFIG via A_PropertyValue_Write
+    instead.
+    """
+
+    CODE: ClassVar = APCIExtendedService.ROUTER_STATUS_WRITE
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        raise NotImplementedError(
+            "A_RouterStatus_Write is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> RouterStatusWrite:
+        """Parse/deserialize from KNX/IP raw data."""
+        # Rejected as UnsupportedCEMIMessage by CEMILData.from_knx instead of
+        # crashing the receive path - see class docstring.
+        raise ConversionError(f"A_RouterStatus_Write is not supported: {raw.hex()}")
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        raise NotImplementedError(
+            "A_RouterStatus_Write is a legacy BCU coupler service with no current "
+            "Application Layer spec definition - see class docstring."
+        )
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return "<RouterStatusWrite (not implemented) />"
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary

- Adds `ROUTER_STATUS_READ`/`RESPONSE`/`WRITE` (APCI 0x3CD-0x3CF) to `APCIExtendedService` and wires them into `APCI.from_knx`'s dispatcher.
- Deliberately leaves them unimplemented: this is a legacy EIB/BCU1-era line coupler status register (BCU alias "LcGroupWrite" for the write) with no PDU definition in the current Application Layer spec (03_03_07 only reserves the APCI codes). Modern ETS configures couplers exclusively through the Router Object (Interface Object Type 6) properties via `A_PropertyValue_Read`/`Write` instead (see AN161 Coupler Model 2.0).
- `from_knx` raises `ConversionError` so a real legacy frame on the bus is rejected as `UnsupportedCEMIMessage`, matching how every other unrecognized service is handled - not an uncaught crash. `calculated_length`/`to_knx` raise `NotImplementedError` since there's no legitimate way to construct one of these objects to send.

This is the first of a stack of small PRs splitting up a previous oversized branch that tried to add ~20 APCI services at once. This one stands alone since it doesn't add any new dispatch entries the other PRs would conflict with.

## Test plan

- [x] Added `TestRouterStatusRead/Response/Write` covering dispatch (`ConversionError`), direct construction (`NotImplementedError` for `to_knx`/`calculated_length`), and `__str__`.
- [x] Added 3 cases to the existing `test_unsupported_tpci_apci` CEMI-layer parametrization confirming a full L_Data frame using these APCI codes parses to `UnsupportedCEMIMessage`, not a crash.
- [x] Full test suite (3427 passed), ruff, mypy clean.