### PR TITLE
Implement A_UserMemoryBit_Write and A_MemoryBit_Write APCI parsing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ nav_order: 2
 - Fix A_Restart parsing to distinguish Basic Restart from Master Reset (restart_type bit was ignored, silently dropping erase_code/channel_number on relay). Add A_Restart_Response parsing for the Master Reset confirmation.
 - Add A_PropertyExtValue_Read, A_PropertyExtValue_Response, A_PropertyExtValue_WriteCon, A_PropertyExtValue_WriteConRes, A_PropertyExtValue_WriteUnCon, A_PropertyExtValue_InfoReport, A_PropertyExtDescription_Read and A_PropertyExtDescription_Response APCI service parsing.
 - Recognize A_RouterStatus_Read/Response/Write APCI services; these are a legacy EIB/BCU1-era coupler status service with no PDU definition in the current Application Layer spec and are not planned for implementation - configure couplers via the Router Object properties (`A_PropertyValue_Read`/`A_PropertyValue_Write`) instead.
+- Add A_UserMemoryBit_Write and A_MemoryBit_Write APCI service parsing.
 
 ### Devices
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -28,6 +28,7 @@ from xknx.telegram.apci import (
     IndividualAddressSerialResponse,
     IndividualAddressSerialWrite,
     IndividualAddressWrite,
+    MemoryBitWrite,
     MemoryExtendedRead,
     MemoryExtendedReadResponse,
     MemoryExtendedWrite,
@@ -60,6 +61,7 @@ from xknx.telegram.apci import (
     SystemNetworkParameterWrite,
     UserManufacturerInfoRead,
     UserManufacturerInfoResponse,
+    UserMemoryBitWrite,
     UserMemoryRead,
     UserMemoryResponse,
     UserMemoryWrite,
@@ -2517,6 +2519,86 @@ class TestRestartMasterResetResponse:
         )
 
 
+class TestUserMemoryBitWrite:
+    """Test class for UserMemoryBitWrite objects."""
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = UserMemoryBitWrite(
+            address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11, 0x22])
+        )
+
+        assert payload.calculated_length() == 8
+        assert payload.calculated_length() == len(payload.to_knx()) - 1
+
+    def test_from_knx(self) -> None:
+        """Test the from_knx method."""
+        payload = APCI.from_knx(
+            bytes([0x02, 0xC4, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22])
+        )
+
+        assert payload == UserMemoryBitWrite(
+            address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11, 0x22])
+        )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a mismatched number/length."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            # number=2 but only 1 octet of and_data/xor_data follows
+            APCI.from_knx(bytes([0x02, 0xC4, 0x02, 0x12, 0x34, 0xAA, 0x11]))
+
+    def test_from_knx_too_short(self) -> None:
+        """Test from_knx raises ConversionError for an APDU shorter than the header."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC4, 0x02]))
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method."""
+        payload = UserMemoryBitWrite(
+            address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11, 0x22])
+        )
+
+        assert payload.to_knx() == bytes(
+            [0x02, 0xC4, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22]
+        )
+
+    def test_round_trip(self) -> None:
+        """Test from_knx().to_knx() reproduces the original frame exactly."""
+        raw = bytes([0x02, 0xC4, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22])
+
+        assert APCI.from_knx(raw).to_knx() == raw
+
+    def test_to_knx_address_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range address."""
+        payload = UserMemoryBitWrite(
+            address=0x10000, and_data=bytes([0xAA]), xor_data=bytes([0x11])
+        )
+
+        with pytest.raises(ConversionError, match=r".*Address.*"):
+            payload.to_knx()
+
+    def test_to_knx_mismatched_data_length(self) -> None:
+        """Test to_knx raises ConversionError when and_data/xor_data lengths differ."""
+        payload = UserMemoryBitWrite(
+            address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11])
+        )
+
+        with pytest.raises(
+            ConversionError, match=r".*and_data and xor_data.*same length.*"
+        ):
+            payload.to_knx()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        payload = UserMemoryBitWrite(
+            address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11, 0x22])
+        )
+
+        assert str(payload) == (
+            '<UserMemoryBitWrite address="0x1234" and_data="aabb" xor_data="1122" />'
+        )
+
+
 class TestUserManufacturerInfoRead:
     """Test class for UserManufacturerInfoRead objects."""
 
@@ -2784,6 +2866,103 @@ class TestRouterStatusWrite:
     def test_str(self) -> None:
         """Test the __str__ method."""
         assert str(RouterStatusWrite()) == "<RouterStatusWrite (not implemented) />"
+
+
+class TestMemoryBitWrite:
+    """Test class for MemoryBitWrite objects."""
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = MemoryBitWrite(
+            memory_address=0x1234,
+            and_data=bytes([0xAA, 0xBB]),
+            xor_data=bytes([0x11, 0x22]),
+        )
+
+        assert payload.calculated_length() == 8
+        assert payload.calculated_length() == len(payload.to_knx()) - 1
+
+    def test_from_knx(self) -> None:
+        """Test the from_knx method."""
+        payload = APCI.from_knx(
+            bytes([0x03, 0xD0, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22])
+        )
+
+        assert payload == MemoryBitWrite(
+            memory_address=0x1234,
+            and_data=bytes([0xAA, 0xBB]),
+            xor_data=bytes([0x11, 0x22]),
+        )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a mismatched number/length."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            # number=2 but only 1 octet of and_data/xor_data follows
+            APCI.from_knx(bytes([0x03, 0xD0, 0x02, 0x12, 0x34, 0xAA, 0x11]))
+
+    def test_from_knx_too_short(self) -> None:
+        """Test from_knx raises ConversionError for an APDU shorter than the header."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD0, 0x02]))
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method."""
+        payload = MemoryBitWrite(
+            memory_address=0x1234,
+            and_data=bytes([0xAA, 0xBB]),
+            xor_data=bytes([0x11, 0x22]),
+        )
+
+        assert payload.to_knx() == bytes(
+            [0x03, 0xD0, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22]
+        )
+
+    def test_round_trip(self) -> None:
+        """Test from_knx().to_knx() reproduces the original frame exactly."""
+        raw = bytes([0x03, 0xD0, 0x02, 0x12, 0x34, 0xAA, 0xBB, 0x11, 0x22])
+
+        assert APCI.from_knx(raw).to_knx() == raw
+
+    def test_to_knx_address_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError for an out of range address."""
+        payload = MemoryBitWrite(
+            memory_address=0x10000, and_data=bytes([0xAA]), xor_data=bytes([0x11])
+        )
+
+        with pytest.raises(ConversionError, match=r".*Memory address.*"):
+            payload.to_knx()
+
+    def test_to_knx_number_out_of_range(self) -> None:
+        """Test to_knx raises ConversionError when and_data exceeds 255 octets."""
+        payload = MemoryBitWrite(
+            memory_address=0x1234, and_data=bytes(256), xor_data=bytes(256)
+        )
+
+        with pytest.raises(ConversionError, match=r".*Number.*"):
+            payload.to_knx()
+
+    def test_to_knx_mismatched_data_length(self) -> None:
+        """Test to_knx raises ConversionError when and_data/xor_data lengths differ."""
+        payload = MemoryBitWrite(
+            memory_address=0x1234, and_data=bytes([0xAA, 0xBB]), xor_data=bytes([0x11])
+        )
+
+        with pytest.raises(
+            ConversionError, match=r".*and_data and xor_data.*same length.*"
+        ):
+            payload.to_knx()
+
+    def test_str(self) -> None:
+        """Test the __str__ method."""
+        payload = MemoryBitWrite(
+            memory_address=0x1234,
+            and_data=bytes([0xAA, 0xBB]),
+            xor_data=bytes([0x11, 0x22]),
+        )
+
+        assert str(payload) == (
+            '<MemoryBitWrite memory_address="0x1234" and_data="aabb" xor_data="1122" />'
+        )
 
 
 class TestAuthorizeRequest:

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -97,6 +97,8 @@ class APCIUserService(Enum):
     USER_MEMORY_RESPONSE = 0x02C1
     USER_MEMORY_WRITE = 0x02C2
 
+    USER_MEMORY_BIT_WRITE = 0x02C4
+
     USER_MANUFACTURER_INFO_READ = 0x02C5
     USER_MANUFACTURER_INFO_RESPONSE = 0x02C6
 
@@ -111,6 +113,9 @@ class APCIExtendedService(Enum):
     ROUTER_STATUS_READ = 0x03CD
     ROUTER_STATUS_RESPONSE = 0x03CE
     ROUTER_STATUS_WRITE = 0x03CF
+
+    # not for future use
+    MEMORY_BIT_WRITE = 0x03D0
 
     AUTHORIZE_REQUEST = 0x03D1
     AUTHORIZE_RESPONSE = 0x03D2
@@ -281,6 +286,8 @@ class APCI(ABC):
                 return UserMemoryResponse.from_knx(raw)
             if apci == APCIUserService.USER_MEMORY_WRITE.value:
                 return UserMemoryWrite.from_knx(raw)
+            if apci == APCIUserService.USER_MEMORY_BIT_WRITE.value:
+                return UserMemoryBitWrite.from_knx(raw)
             if apci == APCIUserService.USER_MANUFACTURER_INFO_READ.value:
                 return UserManufacturerInfoRead.from_knx(raw)
             if apci == APCIUserService.USER_MANUFACTURER_INFO_RESPONSE.value:
@@ -308,6 +315,8 @@ class APCI(ABC):
                 return RouterStatusResponse.from_knx(raw)
             if apci == APCIExtendedService.ROUTER_STATUS_WRITE.value:
                 return RouterStatusWrite.from_knx(raw)
+            if apci == APCIExtendedService.MEMORY_BIT_WRITE.value:
+                return MemoryBitWrite.from_knx(raw)
             if apci == APCIExtendedService.AUTHORIZE_REQUEST.value:
                 return AuthorizeRequest.from_knx(raw)
             if apci == APCIExtendedService.AUTHORIZE_RESPONSE.value:
@@ -2434,6 +2443,75 @@ class UserMemoryResponse(APCI):
 
 
 @dataclass(slots=True)
+class UserMemoryBitWrite(APCI):
+    """
+    UserMemoryBitWrite service.
+
+    See KNX Specification 03_03_07 Application Layer §3.5.6.4
+    A_UserMemoryBit_Write.
+
+    Payload contains a 1 byte number (octet count of the contiguous
+    block to modify, 1-5), a 2 byte memory_address, and_data and
+    xor_data - both `number` bytes long. Each result bit is computed as
+    (and_data_bit AND block_bit) XOR xor_data_bit, i.e. and_data=0/
+    xor_data=0 clears a bit, and_data=0/xor_data=1 sets it, and_data=1/
+    xor_data=0 leaves it unmodified and and_data=1/xor_data=1 inverts
+    it.
+    """
+
+    CODE: ClassVar = APCIUserService.USER_MEMORY_BIT_WRITE
+
+    address: int
+    and_data: bytes
+    xor_data: bytes
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 4 + len(self.and_data) + len(self.xor_data)
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> UserMemoryBitWrite:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_UserMemoryBit_Write in CEMI: {raw.hex()}"
+            )
+        number = raw[2]
+        if len(raw) != 5 + 2 * number:
+            raise ConversionError(
+                f"Invalid length for A_UserMemoryBit_Write in CEMI: {raw.hex()}"
+            )
+        address = (raw[3] << 8) | raw[4]
+        and_data = raw[5 : 5 + number]
+        xor_data = raw[5 + number : 5 + 2 * number]
+
+        return cls(address=address, and_data=and_data, xor_data=xor_data)
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        if not 0 <= self.address <= 0xFFFF:
+            raise ConversionError("Address out of range.")
+        number = len(self.and_data)
+        if not 0 <= number <= 0xFF:
+            raise ConversionError("Number out of range.")
+        if len(self.xor_data) != number:
+            raise ConversionError("and_data and xor_data must have the same length.")
+
+        payload = (
+            struct.pack("!BH", number, self.address) + self.and_data + self.xor_data
+        )
+
+        return encode_cmd_and_payload(self.CODE, appended_payload=payload)
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f'<UserMemoryBitWrite address="{hex(self.address)}" '
+            f'and_data="{self.and_data.hex()}" xor_data="{self.xor_data.hex()}" />'
+        )
+
+
+@dataclass(slots=True)
 class UserManufacturerInfoRead(APCI):
     """UserManufacturerInfoRead service."""
 
@@ -2750,6 +2828,79 @@ class RouterStatusWrite(APCI):
     def __str__(self) -> str:
         """Return object as readable string."""
         return "<RouterStatusWrite (not implemented) />"
+
+
+@dataclass(slots=True)
+class MemoryBitWrite(APCI):
+    """
+    MemoryBitWrite service.
+
+    See KNX Specification 03_03_07 Application Layer §3.5.5
+    A_MemoryBit_Write. Marked "not for future use" by the coupler
+    services table, but fully defined - same layout as
+    A_UserMemoryBit_Write.
+
+    Payload contains a 1 byte number (octet count of the contiguous
+    block to modify, 1-5), a 2 byte memory_address, and_data and
+    xor_data - both `number` bytes long. Each result bit is computed as
+    (and_data_bit AND block_bit) XOR xor_data_bit, i.e. and_data=0/
+    xor_data=0 clears a bit, and_data=0/xor_data=1 sets it, and_data=1/
+    xor_data=0 leaves it unmodified and and_data=1/xor_data=1 inverts
+    it.
+    """
+
+    CODE: ClassVar = APCIExtendedService.MEMORY_BIT_WRITE
+
+    memory_address: int
+    and_data: bytes
+    xor_data: bytes
+
+    def calculated_length(self) -> int:
+        """Get length of APCI payload."""
+        return 4 + len(self.and_data) + len(self.xor_data)
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> MemoryBitWrite:
+        """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_MemoryBit_Write in CEMI: {raw.hex()}"
+            )
+        number = raw[2]
+        if len(raw) != 5 + 2 * number:
+            raise ConversionError(
+                f"Invalid length for A_MemoryBit_Write in CEMI: {raw.hex()}"
+            )
+        memory_address = (raw[3] << 8) | raw[4]
+        and_data = raw[5 : 5 + number]
+        xor_data = raw[5 + number : 5 + 2 * number]
+
+        return cls(memory_address=memory_address, and_data=and_data, xor_data=xor_data)
+
+    def to_knx(self) -> bytearray:
+        """Serialize to KNX/IP raw data."""
+        if not 0 <= self.memory_address <= 0xFFFF:
+            raise ConversionError("Memory address out of range.")
+        number = len(self.and_data)
+        if not 0 <= number <= 0xFF:
+            raise ConversionError("Number out of range.")
+        if len(self.xor_data) != number:
+            raise ConversionError("and_data and xor_data must have the same length.")
+
+        payload = (
+            struct.pack("!BH", number, self.memory_address)
+            + self.and_data
+            + self.xor_data
+        )
+
+        return encode_cmd_and_payload(self.CODE, appended_payload=payload)
+
+    def __str__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f'<MemoryBitWrite memory_address="{hex(self.memory_address)}" '
+            f'and_data="{self.and_data.hex()}" xor_data="{self.xor_data.hex()}" />'
+        )
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
## Summary

- Implements `A_UserMemoryBit_Write` (§3.5.6.4, APCI 0x2C4) and `A_MemoryBit_Write` (§3.5.5, APCI 0x3D0).
- Both modify 1-40 bits in a contiguous block of up to 5 octets: a 1 byte `number` (octet count), a 2 byte address, and `and_data`/`xor_data` (each `number` bytes). Each result bit is computed as `(and_data_bit AND block_bit) XOR xor_data_bit` - the two share an identical wire layout, differing only in which memory space they target (user memory vs. general memory).

Second in the stack splitting up the oversized APCI branch - based on #1869 (`kewde/apci-routerstatus`).

## Test plan

- [x] `TestUserMemoryBitWrite`/`TestMemoryBitWrite`: calculated_length invariant, from_knx (valid + too-short + mismatched-number-length), to_knx, round-trip, range validation (address/memory_address out of range, `and_data` >255 octets, `and_data`/`xor_data` length mismatch), `__str__`.
- [x] Full test suite (3446 passed), ruff, mypy clean.