### PR TITLE
fix: add explicit length checks to every APCI from_knx

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ nav_order: 2
 
 # Changelog
 
+# Unreleased changes
+
+### Protocol
+
+- Add explicit length checks to every remaining APCI `from_knx` (and the top-level `APCI.from_knx` dispatcher) as defense-in-depth on top of the broad `except (IndexError, struct.error, ValueError)` added in 3.17.0: each service now raises `ConversionError` with a specific "Invalid length for A_X in CEMI" message for a truncated, malformed or overlong frame instead of relying solely on the generic dispatcher-level catch.
+
 # 3.17.0 APCIs and DPTs 2026-07-25
 
 ### Deprecation notes

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -4,6 +4,10 @@ import pytest
 
 from xknx.dpt import DPTArray, DPTBinary
 from xknx.exceptions import ConversionError, UnsupportedAPCIService
+from xknx.secure.data_secure_asdu import (
+    SecurityAlgorithmIdentifier,
+    SecurityALService,
+)
 from xknx.telegram.address import GroupAddress, IndividualAddress
 from xknx.telegram.apci import (
     APCI,
@@ -83,6 +87,7 @@ from xknx.telegram.apci import (
     RouterStatusRead,
     RouterStatusResponse,
     RouterStatusWrite,
+    SecureAPDU,
     SystemNetworkParameterRead,
     SystemNetworkParameterResponse,
     SystemNetworkParameterWrite,
@@ -164,6 +169,11 @@ class TestGroupValueRead:
         payload = APCI.from_knx(bytes([0x00, 0x00]))
 
         assert payload == GroupValueRead()
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x00, 0x00, 0x00]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -268,6 +278,11 @@ class TestIndividualAddressWrite:
 
         assert payload == IndividualAddressWrite(IndividualAddress("1.2.3"))
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x00, 0xC0, 0x12]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = IndividualAddressWrite(IndividualAddress("1.2.3"))
@@ -296,6 +311,11 @@ class TestIndividualAddressRead:
         payload = APCI.from_knx(bytes([0x01, 0x00]))
 
         assert payload == IndividualAddressRead()
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0x00, 0x00]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -326,6 +346,11 @@ class TestIndividualAddressResponse:
 
         assert payload == IndividualAddressResponse()
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0x40, 0x00]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = IndividualAddressResponse()
@@ -355,6 +380,11 @@ class TestADCRead:
 
         assert payload == ADCRead(channel=2, count=4)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0x82]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = ADCRead(channel=1, count=3)
@@ -383,6 +413,11 @@ class TestADCResponse:
         payload = APCI.from_knx(bytes([0x01, 0xC2, 0x04, 0x03, 0xFF]))
 
         assert payload == ADCResponse(channel=2, count=4, value=1023)
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0xC2, 0x04, 0x03]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -1860,6 +1895,11 @@ class TestMemoryExtendedWrite:
             address=0x123456, count=3, data=bytes([0xAA, 0xBB, 0xCC])
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0xFB, 0x03, 0x12, 0x34]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = MemoryExtendedWrite(
@@ -1931,6 +1971,11 @@ class TestMemoryExtendedWriteResponse:
             return_code=1, address=0x123456, confirmation_data=bytes([0xAA, 0xBB])
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0xFC, 0x00, 0x12, 0x34]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = MemoryExtendedWriteResponse(return_code=0, address=0x123456)
@@ -1995,6 +2040,11 @@ class TestMemoryExtendedRead:
 
         assert payload == MemoryExtendedRead(address=0x123456, count=3)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0xFD, 0x03, 0x12, 0x34]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = MemoryExtendedRead(address=0x123456, count=3)
@@ -2040,6 +2090,11 @@ class TestMemoryExtendedReadResponse:
         assert payload == MemoryExtendedReadResponse(
             return_code=0, address=0x123456, data=bytes([0xAA, 0xBB, 0xCC])
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x01, 0xFE, 0x00, 0x12, 0x34]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2095,6 +2150,11 @@ class TestMemoryRead:
 
         assert payload == MemoryRead(address=0x1234, count=11)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0x0B, 0x12]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = MemoryRead(address=0x1234, count=11)
@@ -2137,6 +2197,11 @@ class TestMemoryWrite:
         assert payload == MemoryWrite(
             address=0x1234, count=3, data=bytes([0xAA, 0xBB, 0xCC])
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0x83, 0x12]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2186,6 +2251,11 @@ class TestMemoryResponse:
         assert payload == MemoryResponse(
             address=0x1234, count=3, data=bytes([0xAA, 0xBB, 0xCC])
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0x43, 0x12]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2239,6 +2309,11 @@ class TestDeviceDescriptorRead:
 
         assert payload == DeviceDescriptorRead(13)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0x0D, 0x00]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = DeviceDescriptorRead(13)
@@ -2275,6 +2350,11 @@ class TestDeviceDescriptorResponse:
 
         assert payload == DeviceDescriptorResponse(descriptor=13, value=123)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0x4D, 0x00]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = DeviceDescriptorResponse(descriptor=13, value=123)
@@ -2310,6 +2390,11 @@ class TestUserMemoryRead:
         payload = APCI.from_knx(bytes([0x02, 0xC0, 0x1B, 0x23, 0x45]))
 
         assert payload == UserMemoryRead(address=0x12345, count=11)
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC0, 0x1B, 0x23]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2355,6 +2440,11 @@ class TestUserMemoryWrite:
         assert payload == UserMemoryWrite(
             address=0x12345, count=3, data=bytes([0xAA, 0xBB, 0xCC])
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC2, 0x13, 0x23]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2413,6 +2503,11 @@ class TestUserMemoryResponse:
         assert payload == UserMemoryResponse(
             address=0x12345, count=3, data=bytes([0xAA, 0xBB, 0xCC])
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC1, 0x13, 0x23]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2548,6 +2643,11 @@ class TestRestart:
 
         assert payload == Restart()
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0x80, 0x00]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = Restart()
@@ -2677,6 +2777,11 @@ class TestUserManufacturerInfoRead:
 
         assert payload == UserManufacturerInfoRead()
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC5, 0x00]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = UserManufacturerInfoRead()
@@ -2707,6 +2812,11 @@ class TestUserManufacturerInfoResponse:
         assert payload == UserManufacturerInfoResponse(
             manufacturer_id=123, data=b"\x12\x34"
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC6, 0x7B, 0x12]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2743,6 +2853,11 @@ class TestFunctionPropertyCommand:
         assert payload == FunctionPropertyCommand(
             object_index=1, property_id=4, data=b"\x12\x34"
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC7, 0x01]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -2784,6 +2899,11 @@ class TestFunctionPropertyStateRead:
             object_index=1, property_id=4, data=b"\x12\x34"
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC8, 0x01]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = FunctionPropertyStateRead(
@@ -2824,6 +2944,11 @@ class TestFunctionPropertyStateResponse:
             object_index=1, property_id=4, return_code=8, data=b"\x12\x34"
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x02, 0xC9, 0x01, 0x04]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = FunctionPropertyStateResponse(
@@ -2859,6 +2984,11 @@ class TestFilterTableOpen:
         payload = APCI.from_knx(bytes((0x03, 0xC0)))
 
         assert payload == FilterTableOpen()
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for an APDU with trailing garbage."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes((0x03, 0xC0, 0x00)))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -3471,6 +3601,11 @@ class TestAuthorizeRequest:
 
         assert payload == AuthorizeRequest(key=12345678)
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD1, 0x00, 0x00, 0xBC, 0x61]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = AuthorizeRequest(key=12345678)
@@ -3499,6 +3634,11 @@ class TestAuthorizeResponse:
         payload = APCI.from_knx(bytes([0x03, 0xD2, 0x7B]))
 
         assert payload == AuthorizeResponse(level=123)
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD2]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -3634,6 +3774,11 @@ class TestPropertyValueRead:
             object_index=1, property_id=4, count=2, start_index=8
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD5, 0x01, 0x04, 0x20]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = PropertyValueRead(
@@ -3682,6 +3827,11 @@ class TestPropertyValueWrite:
         assert payload == PropertyValueWrite(
             object_index=1, property_id=4, count=2, start_index=8, data=b"\x12\x34"
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD7, 0x01, 0x04, 0x20]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -3734,6 +3884,11 @@ class TestPropertyValueResponse:
             object_index=1, property_id=4, count=2, start_index=8, data=b"\x12\x34"
         )
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD6, 0x01, 0x04, 0x20]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = PropertyValueResponse(
@@ -3784,6 +3939,11 @@ class TestPropertyDescriptionRead:
         assert payload == PropertyDescriptionRead(
             object_index=1, property_id=4, property_index=8
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD8, 0x01, 0x04]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -3836,6 +3996,11 @@ class TestPropertyDescriptionResponse:
             max_count=5,
             access=7,
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xD9, 0x01, 0x04, 0x08, 0x03, 0x00, 0x05]))
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -4044,6 +4209,11 @@ class TestIndividualAddressSerialRead:
 
         assert payload == IndividualAddressSerialRead(b"\xaa\xbb\xcc\x11\x22\x33")
 
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(bytes([0x03, 0xDC, 0xAA, 0xBB, 0xCC, 0x11, 0x22]))
+
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
         payload = IndividualAddressSerialRead(b"\xaa\xbb\xcc\x11\x22\x33")
@@ -4089,6 +4259,15 @@ class TestIndividualAddressSerialResponse:
         assert payload == IndividualAddressSerialResponse(
             serial=b"\xaa\xbb\xcc\x11\x22\x33", address=IndividualAddress("1.2.3")
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(
+                bytes(
+                    [0x03, 0xDD, 0xAA, 0xBB, 0xCC, 0x11, 0x22, 0x33, 0x12, 0x03, 0x00]
+                )
+            )
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -4159,6 +4338,29 @@ class TestIndividualAddressSerialWrite:
         assert payload == IndividualAddressSerialWrite(
             serial=b"\xaa\xbb\xcc\x11\x22\x33", address=IndividualAddress("1.2.3")
         )
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(
+                bytes(
+                    [
+                        0x03,
+                        0xDE,
+                        0xAA,
+                        0xBB,
+                        0xCC,
+                        0x11,
+                        0x22,
+                        0x33,
+                        0x12,
+                        0x03,
+                        0x00,
+                        0x00,
+                        0x00,
+                    ]
+                )
+            )
 
     def test_to_knx(self) -> None:
         """Test the to_knx method."""
@@ -5348,6 +5550,44 @@ class TestFileStreamInfoReport:
 
         with pytest.raises(ConversionError, match=r".*sequence number.*"):
             payload.to_knx()
+
+
+class TestSecureAPDU:
+    """Test class for SecureAPDU objects."""
+
+    # APCI header (2) + scf (1) + sequence_number (6) + secured_apdu (2) + mac (4)
+    valid_raw = bytes.fromhex("03f100") + bytes(6) + b"\xaa\xbb" + b"\x11\x22\x33\x44"
+
+    def test_calculated_length(self) -> None:
+        """Test the test_calculated_length method."""
+        payload = APCI.from_knx(self.valid_raw)
+
+        assert payload.calculated_length() == 14
+        assert payload.calculated_length() == len(payload.to_knx()) - 1
+
+    def test_from_knx(self) -> None:
+        """Test the from_knx method."""
+        payload = APCI.from_knx(self.valid_raw)
+
+        assert isinstance(payload, SecureAPDU)
+        assert payload.scf.tool_access is False
+        assert payload.scf.algorithm == SecurityAlgorithmIdentifier.CCM_AUTHENTICATION
+        assert payload.scf.system_broadcast is False
+        assert payload.scf.service == SecurityALService.S_A_DATA
+        assert payload.secured_data.sequence_number_bytes == bytes(6)
+        assert payload.secured_data.secured_apdu == b"\xaa\xbb"
+        assert payload.secured_data.message_authentication_code == b"\x11\x22\x33\x44"
+
+    def test_from_knx_wrong_length(self) -> None:
+        """Test from_knx raises ConversionError for a too-short APDU."""
+        with pytest.raises(ConversionError, match=r".*Invalid length.*"):
+            APCI.from_knx(self.valid_raw[:12])
+
+    def test_to_knx(self) -> None:
+        """Test the to_knx method round-trips the raw frame exactly."""
+        payload = APCI.from_knx(self.valid_raw)
+
+        assert payload.to_knx() == self.valid_raw
 
     def test_str(self) -> None:
         """Test the __str__ method."""

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -463,7 +463,10 @@ class GroupValueRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> GroupValueRead:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_GroupValue_Read in CEMI: {raw.hex()}"
+            )
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -572,6 +575,10 @@ class IndividualAddressWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 4:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddress_Write in CEMI: {raw.hex()}"
+            )
         (raw_address,) = struct.unpack("!H", raw[2:])
         return cls(address=IndividualAddress(raw_address))
 
@@ -597,7 +604,10 @@ class IndividualAddressRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressRead:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddress_Read in CEMI: {raw.hex()}"
+            )
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -627,7 +637,10 @@ class IndividualAddressResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressResponse:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddress_Response in CEMI: {raw.hex()}"
+            )
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -659,6 +672,8 @@ class ADCRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> ADCRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 3:
+            raise ConversionError(f"Invalid length for A_ADC_Read in CEMI: {raw.hex()}")
         channel, count = struct.unpack("!BB", raw[1:])
 
         return cls(
@@ -700,6 +715,10 @@ class ADCResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> ADCResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 5:
+            raise ConversionError(
+                f"Invalid length for A_ADC_Response in CEMI: {raw.hex()}"
+            )
         channel, count, value = struct.unpack("!BBH", raw[1:])
 
         return cls(
@@ -1844,6 +1863,10 @@ class MemoryExtendedWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryExtendedWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_MemoryExtended_Write in CEMI: {raw.hex()}"
+            )
         count = raw[2]
         address = int.from_bytes(raw[3:6], "big")
         data = raw[6:]
@@ -1894,6 +1917,10 @@ class MemoryExtendedWriteResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryExtendedWriteResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_MemoryExtended_Write_Response in CEMI: {raw.hex()}"
+            )
         return_code = raw[2]
         address = int.from_bytes(raw[3:6], "big")
         confirmation_data = raw[6:]
@@ -1945,6 +1972,10 @@ class MemoryExtendedRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryExtendedRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 6:
+            raise ConversionError(
+                f"Invalid length for A_MemoryExtended_Read in CEMI: {raw.hex()}"
+            )
         count = raw[2]
         address = int.from_bytes(raw[3:6], "big")
 
@@ -1994,6 +2025,10 @@ class MemoryExtendedReadResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryExtendedReadResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_MemoryExtended_Read_Response in CEMI: {raw.hex()}"
+            )
         return_code = raw[2]
         address = int.from_bytes(raw[3:6], "big")
         data = raw[6:]
@@ -2044,6 +2079,10 @@ class MemoryRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 4:
+            raise ConversionError(
+                f"Invalid length for A_Memory_Read in CEMI: {raw.hex()}"
+            )
         count, address = struct.unpack("!BH", raw[1:])
 
         return cls(
@@ -2095,6 +2134,10 @@ class MemoryWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 4:
+            raise ConversionError(
+                f"Invalid length for A_Memory_Write in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 4
 
         count, address, data = struct.unpack(f"!BH{size}s", raw[1:])
@@ -2150,6 +2193,10 @@ class MemoryResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> MemoryResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 4:
+            raise ConversionError(
+                f"Invalid length for A_Memory_Response in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 4
 
         count, address, data = struct.unpack(f"!BH{size}s", raw[1:])
@@ -2198,6 +2245,10 @@ class DeviceDescriptorRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> DeviceDescriptorRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_DeviceDescriptor_Read in CEMI: {raw.hex()}"
+            )
         return cls(descriptor=raw[1] & 0x3F)
 
     def to_knx(self) -> bytearray:
@@ -2232,6 +2283,10 @@ class DeviceDescriptorResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> DeviceDescriptorResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 4:
+            raise ConversionError(
+                f"Invalid length for A_DeviceDescriptor_Response in CEMI: {raw.hex()}"
+            )
         descriptor, value = struct.unpack("!BH", raw[1:])
 
         return cls(descriptor=descriptor & 0x3F, value=value)
@@ -2274,7 +2329,8 @@ class Restart(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> Restart:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(f"Invalid length for A_Restart in CEMI: {raw.hex()}")
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -2407,6 +2463,10 @@ class UserMemoryRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> UserMemoryRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 5:
+            raise ConversionError(
+                f"Invalid length for A_UserMemory_Read in CEMI: {raw.hex()}"
+            )
         byte0, address = struct.unpack("!BH", raw[2:])
 
         return cls(
@@ -2459,6 +2519,10 @@ class UserMemoryWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> UserMemoryWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 5:
+            raise ConversionError(
+                f"Invalid length for A_UserMemory_Write in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 5
 
         byte0, address, data = struct.unpack(f"!BH{size}s", raw[2:])
@@ -2515,6 +2579,10 @@ class UserMemoryResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> UserMemoryResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 5:
+            raise ConversionError(
+                f"Invalid length for A_UserMemory_Response in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 5
 
         byte0, address, data = struct.unpack(f"!BH{size}s", raw[2:])
@@ -2627,7 +2695,10 @@ class UserManufacturerInfoRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> UserManufacturerInfoRead:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_UserManufacturerInfo_Read in CEMI: {raw.hex()}"
+            )
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -2656,6 +2727,10 @@ class UserManufacturerInfoResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> UserManufacturerInfoResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 5:
+            raise ConversionError(
+                f"Invalid length for A_UserManufacturerInfo_Response in CEMI: {raw.hex()}"
+            )
         manufacturer_id, data = struct.unpack("!B2s", raw[2:])
         return cls(manufacturer_id=manufacturer_id, data=data)
 
@@ -2687,6 +2762,10 @@ class FunctionPropertyCommand(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> FunctionPropertyCommand:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 4:
+            raise ConversionError(
+                f"Invalid length for A_FunctionProperty_Command in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 4
         object_index, property_id, data = struct.unpack(f"!BB{size}s", raw[2:])
         return cls(
@@ -2726,6 +2805,10 @@ class FunctionPropertyStateRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> FunctionPropertyStateRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 4:
+            raise ConversionError(
+                f"Invalid length for A_FunctionPropertyState_Read in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 4
         object_index, property_id, data = struct.unpack(f"!BB{size}s", raw[2:])
         return cls(
@@ -2766,6 +2849,10 @@ class FunctionPropertyStateResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> FunctionPropertyStateResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 5:
+            raise ConversionError(
+                f"Invalid length for A_FunctionPropertyState_Response in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 5
         (
             object_index,
@@ -2818,7 +2905,10 @@ class FilterTableOpen(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> FilterTableOpen:
         """Parse/deserialize from KNX/IP raw data."""
-        # Nothing to parse, but must be implemented explicitly.
+        if len(raw) != 2:
+            raise ConversionError(
+                f"Invalid length for A_FilterTable_Open in CEMI: {raw.hex()}"
+            )
         return cls()
 
     def to_knx(self) -> bytearray:
@@ -3437,6 +3527,10 @@ class AuthorizeRequest(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> AuthorizeRequest:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 7:
+            raise ConversionError(
+                f"Invalid length for A_Authorize_Request in CEMI: {raw.hex()}"
+            )
         _, key = struct.unpack("!BI", raw[2:])
         return cls(key=key)
 
@@ -3466,6 +3560,10 @@ class AuthorizeResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> AuthorizeResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 3:
+            raise ConversionError(
+                f"Invalid length for A_Authorize_Response in CEMI: {raw.hex()}"
+            )
         (level,) = struct.unpack("!B", raw[2:])
         return cls(level=level)
 
@@ -3596,6 +3694,10 @@ class PropertyValueRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> PropertyValueRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 6:
+            raise ConversionError(
+                f"Invalid length for A_PropertyValue_Read in CEMI: {raw.hex()}"
+            )
         (
             object_index,
             property_id,
@@ -3676,6 +3778,10 @@ class PropertyValueWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> PropertyValueWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_PropertyValue_Write in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 6
         (
             object_index,
@@ -3729,6 +3835,10 @@ class PropertyValueResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> PropertyValueResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 6:
+            raise ConversionError(
+                f"Invalid length for A_PropertyValue_Response in CEMI: {raw.hex()}"
+            )
         size = len(raw) - 6
         (
             object_index,
@@ -3792,6 +3902,10 @@ class PropertyDescriptionRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> PropertyDescriptionRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 5:
+            raise ConversionError(
+                f"Invalid length for A_PropertyDescription_Read in CEMI: {raw.hex()}"
+            )
         object_index, property_id, property_index = struct.unpack("!BBB", raw[2:])
         return cls(
             object_index=object_index,
@@ -3832,6 +3946,10 @@ class PropertyDescriptionResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> PropertyDescriptionResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 9:
+            raise ConversionError(
+                f"Invalid length for A_PropertyDescription_Response in CEMI: {raw.hex()}"
+            )
         (
             object_index,
             property_id,
@@ -4013,6 +4131,10 @@ class IndividualAddressSerialRead(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressSerialRead:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 8:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddressSerialNumber_Read in CEMI: {raw.hex()}"
+            )
         (serial,) = struct.unpack("!6s", raw[2:])
         return cls(serial=serial)
 
@@ -4046,6 +4168,10 @@ class IndividualAddressSerialResponse(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressSerialResponse:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 12:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddressSerialNumber_Response in CEMI: {raw.hex()}"
+            )
         serial, raw_address, _ = struct.unpack("!6sHH", raw[2:])
         return cls(
             serial=serial,
@@ -4082,6 +4208,10 @@ class IndividualAddressSerialWrite(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> IndividualAddressSerialWrite:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) != 14:
+            raise ConversionError(
+                f"Invalid length for A_IndividualAddressSerialNumber_Write in CEMI: {raw.hex()}"
+            )
         serial, raw_address, _ = struct.unpack("!6sHI", raw[2:])
         return cls(
             serial=serial,
@@ -5050,6 +5180,8 @@ class SecureAPDU(APCI):
     @classmethod
     def from_knx(cls, raw: bytes) -> SecureAPDU:
         """Parse/deserialize from KNX/IP raw data."""
+        if len(raw) < 13:
+            raise ConversionError(f"Invalid length for A_Sec in CEMI: {raw.hex()}")
         return cls(
             scf=SecurityControlField.from_knx(raw[2]),
             secured_data=SecureData.from_knx(raw[3:]),


### PR DESCRIPTION
## Description

While #1871 closed the crash risk with a broad `except (IndexError, struct.error, ValueError)` wrapper around the whole `APCI.from_knx` dispatcher, this adds explicit `if len(raw) != N: raise ConversionError(...)` (or minimum-length) checks to every remaining `from_knx` method that lacked one, as defense-in-depth on top of it.

Each service now raises a specific `Invalid length for A_X in CEMI: ...` message for a malformed frame instead of relying solely on the generic dispatcher-level catch-all, matching the convention already established for the services that had this from prior PRs. Every added line has a matching regression test.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)