### PR TITLE
mcp: enrich DPT summaries/decoding (follow-up to #1876)

### DIFF
--- a/test/mcp_tests/tools_test.py
+++ b/test/mcp_tests/tools_test.py
@@ -88,6 +88,23 @@ async def test_describe_dpt_by_number_and_name() -> None:
     assert by_name.dpt.dpt == "9.001"
 
 
+async def test_describe_dpt_semantics() -> None:
+    """Enum, complex and string DPTs expose their extra semantics."""
+    switch = await describe_dpt("1.001")  # enum
+    assert switch.dpt is not None
+    assert switch.dpt.enum_values == ["OFF", "ON"]
+    assert switch.dpt.schema is None
+
+    controlled = await describe_dpt("2.001")  # complex
+    assert controlled.dpt is not None
+    assert controlled.dpt.schema is not None
+    assert {f["name"] for f in controlled.dpt.schema} == {"control", "value"}
+
+    string = await describe_dpt("16.000")  # string: payload_length is the max length
+    assert string.dpt is not None
+    assert string.dpt.payload_length == 14
+
+
 async def test_describe_dpt_unknown() -> None:
     """An unknown identifier returns a not-found result."""
     result = await describe_dpt("999.999")
@@ -206,12 +223,16 @@ async def test_decode_dpt_payload() -> None:
 
     # Test DPT 1.001 (DPTBinary)
     switch_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=[1], value_type="1.001"))
-    assert switch_result.value == "Switch.ON"
+    assert switch_result.value == "ON"
     assert switch_result.value_type == "1.001"
 
     # Test DPT 1.001 with integer payload directly
     switch_int_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=1, value_type="1.001"))
-    assert switch_int_result.value == "Switch.ON"
+    assert switch_int_result.value == "ON"
+
+    # A complex DPT decodes to its JSON-native as_dict() form.
+    complex_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=[3], value_type="2.001"))
+    assert complex_result.value == {"control": True, "value": "on"}
 
     # An empty payload for a 6-bit (DPTBinary) DPT is rejected.
     with pytest.raises(ValueError, match="Empty payload"):

--- a/test/mcp_tests/tools_test.py
+++ b/test/mcp_tests/tools_test.py
@@ -92,7 +92,7 @@ async def test_describe_dpt_semantics() -> None:
     """Enum, complex and string DPTs expose their extra semantics."""
     switch = await describe_dpt("1.001")  # enum
     assert switch.dpt is not None
-    assert switch.dpt.enum_values == ["OFF", "ON"]
+    assert switch.dpt.options == ["off", "on"]
     assert switch.dpt.schema is None
 
     controlled = await describe_dpt("2.001")  # complex
@@ -223,12 +223,12 @@ async def test_decode_dpt_payload() -> None:
 
     # Test DPT 1.001 (DPTBinary)
     switch_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=[1], value_type="1.001"))
-    assert switch_result.value == "ON"
+    assert switch_result.value == "on"
     assert switch_result.value_type == "1.001"
 
     # Test DPT 1.001 with integer payload directly
     switch_int_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=1, value_type="1.001"))
-    assert switch_int_result.value == "ON"
+    assert switch_int_result.value == "on"
 
     # A complex DPT decodes to its JSON-native as_dict() form.
     complex_result = await decode_dpt_payload(DecodeDptPayloadInput(payload=[3], value_type="2.001"))

--- a/xknx/mcp/tools.py
+++ b/xknx/mcp/tools.py
@@ -15,7 +15,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar
 
 from xknx.core.connection_state import XknxConnectionState
-from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric
+from xknx.dpt import (
+    DPTArray,
+    DPTBase,
+    DPTBinary,
+    DPTComplex,
+    DPTComplexData,
+    DPTEnum,
+    DPTEnumData,
+    DPTNumeric,
+)
 from xknx.tools import (
     group_value_read,
     group_value_write,
@@ -69,20 +78,23 @@ def _summarize_dpt(dpt: type[DPTBase]) -> DptSummary:
         value_min=value_min,
         value_max=value_max,
         resolution=resolution,
+        payload_length=dpt.payload_length,
+        enum_values=(
+            [member.name for member in dpt.get_valid_values()]
+            if issubclass(dpt, DPTEnum)
+            else None
+        ),
+        schema=(
+            [dict(field) for field in dpt.get_dict_schema()]
+            if issubclass(dpt, DPTComplex)
+            else None
+        ),
     )
 
 
-def _concrete_dpts() -> list[type[DPTBase]]:
-    """Every concrete DPT transcoder (those with a main number), ordered by main then sub."""
-    seen: dict[str, type[DPTBase]] = {
-        dpt.dpt_number_str(): dpt
-        for dpt in DPTBase.dpt_class_tree()
-        if dpt.dpt_main_number is not None
-    }
-    return sorted(
-        seen.values(),
-        key=lambda dpt: (dpt.dpt_main_number or 0, dpt.dpt_sub_number or -1),
-    )
+def _dpt_haystack(dpt: type[DPTBase]) -> str:
+    """Return the lower-cased text a ``list_dpts`` text filter matches against."""
+    return f"{dpt.dpt_number_str()}\n{dpt.value_type or ''}\n{dpt.unit or ''}".lower()
 
 
 async def list_dpts(filters: DptFilter | None = None) -> DptListResult:
@@ -90,20 +102,19 @@ async def list_dpts(filters: DptFilter | None = None) -> DptListResult:
     filters = filters or DptFilter()
     needle = filters.text.lower() if filters.text else None
 
-    matches: list[DptSummary] = []
-    for dpt in _concrete_dpts():
-        if filters.main is not None and dpt.dpt_main_number != filters.main:
-            continue
-        summary = _summarize_dpt(dpt)
-        if needle is not None and needle not in (
-            f"{summary.dpt}\n{summary.value_type or ''}\n{summary.unit or ''}".lower()
-        ):
-            continue
-        matches.append(summary)
+    # dpt_class_tree() already yields only concrete transcoders (each with a
+    # main number); filter, then order by DPT number.
+    matches = [
+        dpt
+        for dpt in DPTBase.dpt_class_tree()
+        if (filters.main is None or dpt.dpt_main_number == filters.main)
+        and (needle is None or needle in _dpt_haystack(dpt))
+    ]
+    matches.sort(key=lambda dpt: (dpt.dpt_main_number or 0, dpt.dpt_sub_number or -1))
 
     window, limit_reached = _paginate(matches, filters.limit, filters.offset)
     return DptListResult(
-        dpts=window,
+        dpts=[_summarize_dpt(dpt) for dpt in window],
         total_count=len(matches),
         offset=filters.offset,
         next_offset=filters.offset + len(window) if limit_reached else None,
@@ -141,9 +152,14 @@ def _jsonify(value: object) -> GroupValue:
     Coerce a decoded bus value into a JSON-native shape.
 
     ``read_group_value`` returns Python natives (a DPT transcoder's ``from_knx``
-    output, or the raw payload value). Tuples become lists; anything not already
-    JSON-native (e.g. an enum or dataclass from a complex DPT) is stringified.
+    output, or the raw payload value). Complex DPT values become their
+    ``as_dict()`` form and enum values their member name; tuples become lists;
+    anything else JSON-native passes through, and the rest is stringified.
     """
+    if isinstance(value, DPTComplexData):
+        return value.as_dict()
+    if isinstance(value, DPTEnumData):
+        return value.name
     if isinstance(value, tuple):
         return [_jsonify(item) for item in value]
     if value is None or isinstance(value, bool | int | float | str | list | dict):
@@ -193,7 +209,12 @@ async def send_group_value_write(xknx: XKNX, request: GroupValueWriteInput) -> S
 
 
 async def encode_dpt_payload(request: EncodeDptPayloadInput) -> EncodeDptPayloadResult:
-    """Encode a value using a specific DPT into its raw payload bytes."""
+    """
+    Encode a value using a specific DPT into its raw payload bytes.
+
+    Raises :exc:`ValueError` if ``value_type`` matches no DPT and
+    :exc:`~xknx.exceptions.ConversionError` if ``value`` cannot be encoded with it.
+    """
     transcoder = DPTBase.get_dpt(request.value_type)
     encoded = transcoder.to_knx(request.value)
     payload = list(encoded.value) if isinstance(encoded, DPTArray) else [encoded.value]
@@ -201,7 +222,12 @@ async def encode_dpt_payload(request: EncodeDptPayloadInput) -> EncodeDptPayload
 
 
 async def decode_dpt_payload(request: DecodeDptPayloadInput) -> DecodeDptPayloadResult:
-    """Decode a raw payload (byte list, or a single int for 6-bit DPTs) with a DPT."""
+    """
+    Decode a raw payload (byte list, or a single int for 6-bit DPTs) with a DPT.
+
+    Raises :exc:`ValueError` if ``value_type`` matches no DPT and
+    :exc:`~xknx.exceptions.ConversionError` if the payload is invalid for it.
+    """
     transcoder = DPTBase.get_dpt(request.value_type)
     values = [request.payload] if isinstance(request.payload, int) else list(request.payload)
     raw: DPTArray | DPTBinary

--- a/xknx/mcp/tools.py
+++ b/xknx/mcp/tools.py
@@ -79,8 +79,8 @@ def _summarize_dpt(dpt: type[DPTBase]) -> DptSummary:
         value_max=value_max,
         resolution=resolution,
         payload_length=dpt.payload_length,
-        enum_values=(
-            [member.name for member in dpt.get_valid_values()]
+        options=(
+            [member.name.lower() for member in dpt.get_valid_values()]
             if issubclass(dpt, DPTEnum)
             else None
         ),
@@ -153,13 +153,14 @@ def _jsonify(value: object) -> GroupValue:
 
     ``read_group_value`` returns Python natives (a DPT transcoder's ``from_knx``
     output, or the raw payload value). Complex DPT values become their
-    ``as_dict()`` form and enum values their member name; tuples become lists;
+    ``as_dict()`` form and enum values their lower-cased member name (matching HA,
+    the Group Monitor and the ``as_dict()`` enum form); tuples become lists;
     anything else JSON-native passes through, and the rest is stringified.
     """
     if isinstance(value, DPTComplexData):
         return value.as_dict()
     if isinstance(value, DPTEnumData):
-        return value.name
+        return value.name.lower()
     if isinstance(value, tuple):
         return [_jsonify(item) for item in value]
     if value is None or isinstance(value, bool | int | float | str | list | dict):

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -44,7 +44,7 @@ class DptSummary:
     value_max: float | None
     resolution: float | None
     payload_length: int | None  # DPTArray byte / DPTBinary bit length; e.g. string max length
-    enum_values: list[str] | None  # for enum DPTs: the valid value names
+    options: list[str] | None  # enum DPTs: lower-cased value names, as in a complex DPT's enum-field schema
     schema: list[dict[str, Any]] | None  # for complex DPTs: the field schema of the dict form
 
 

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -43,6 +43,9 @@ class DptSummary:
     value_min: float | None
     value_max: float | None
     resolution: float | None
+    payload_length: int | None  # DPTArray byte / DPTBinary bit length; e.g. string max length
+    enum_values: list[str] | None  # for enum DPTs: the valid value names
+    schema: list[dict[str, Any]] | None  # for complex DPTs: the field schema of the dict form
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

Follow-up to #1876 addressing @farmio's post-approval review notes (the "after-merge" DPT refinements). Kept as a separate PR so #1876 can merge as approved.

> ⚠️ **Stacked on #1876.** It branches off `#1876`'s head, so until that merges this PR's diff also shows #1876's commits — **review the last commit only** (`mcp: enrich DPT summaries/decoding and simplify list_dpts`). Once #1876 merges, this collapses to just that commit. Happy to rebase/retarget then.

## Changes (top commit)

- **Richer `DptSummary`** — adds `payload_length`, `options` (enum DPTs, via `get_valid_values()`, lower-cased names) and `schema` (complex DPTs, via `get_dict_schema()`). `describe_dpt("1.001")` now lists `["off", "on"]`, `describe_dpt("2.001")` carries its field schema, and `describe_dpt("16.000")` reports the 14-char max length.
- **Better value decoding** — `_jsonify` renders complex DPT values with `as_dict()` and enum values with their lower-cased member `name` (e.g. `"on"` not `"Switch.ON"`), instead of a bare `str()`.
- **Simpler `list_dpts`** — iterates `dpt_class_tree()` directly (already only concrete transcoders, each with a main number) and sorts the filtered list, dropping the redundant `_concrete_dpts()` helper and main-number guard; only the returned page is summarised.
- **Docstrings** — `encode_dpt_payload` / `decode_dpt_payload` now document the raised `ValueError` (unknown `value_type`) and `ConversionError` (bad value/payload).

Maps to @farmio's inline comments on `tools.py` lines 72/151, 80/102, and 199. Passes ruff / mypy / pylint / codespell; new tests cover the enum/complex/string summaries and complex/enum decoding — `xknx.mcp` stays at 100% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)