### PR TITLE
Send L_Data_Extended frames for APDUs longer than 15 octets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ nav_order: 2
 
 ### Bugfixes
 
-- Send frames with an APDU longer than 15 octets as L_Data_Extended frames. The Frame Type is no longer stored in `CEMILData.flags`; it is derived from the NPDU length when serializing, exposed by the new `CEMILData.frame_type_standard` property and the new `CEMILData.npdu_length()` method. This fixes sending telegrams over KNX Data Secure with a payload of 2 octets or more (eg. DPT 9.x or DPT 232.600) - Data Secure adds 12 octets to the plain APDU, which no longer fits in a standard frame. Sending an APDU longer than 254 octets now raises `ConversionError` instead of `OverflowError`.
+- Send frames with an APDU longer than 15 octets as L_Data_Extended frames. The Frame Type flag of Ctrl1 is now derived from the NPDU length when serializing a `CEMILData` instead of always being set to standard frame. This fixes sending telegrams over KNX Data Secure with a payload of 2 octets or more (eg. DPT 9.x or DPT 232.600) - Data Secure adds 12 octets to the plain APDU, which no longer fits in a standard frame. Sending an APDU longer than 254 octets now raises `ConversionError` instead of `OverflowError`.
 
 ### Features
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,12 +8,18 @@ nav_order: 2
 
 # Unreleased changes
 
+### Bugfixes
+
+- Send frames with an APDU longer than 15 octets as L_Data_Extended frames. The Frame Type flag of Ctrl1 is now derived from the NPDU length when serializing a `CEMILData` instead of always being set to standard frame. This fixes sending telegrams over KNX Data Secure with a payload of 2 octets or more (eg. DPT 9.x or DPT 232.600) - Data Secure adds 12 octets to the plain APDU, which no longer fits in a standard frame. Sending an APDU longer than 254 octets now raises `ConversionError` instead of `OverflowError`.
+
 ### Features
 
 - Add `xknx.mcp`, a host-agnostic subpackage of async MCP tool functions for the KNX bus and data point types (`list_dpts`, `describe_dpt`, `encode_dpt_payload`, `decode_dpt_payload`, `get_connection_status`, `read_group_value`, `send_group_value_read`, `send_group_value_write`). Frozen, JSON-native dataclass I/O with per-field descriptions in `Annotated` metadata; carries no MCP SDK, Home Assistant or web-framework dependency, so a consumer wraps the functions into its own MCP transport.
 
 ### Protocol
 
+- Reject incoming CEMI L_Data frames with a non-zero Extended Frame Format field with `UnsupportedCEMIMessage`. LTE-HEE frames use zone addressing, so their address fields can not be parsed as `GroupAddress`. The Frame Type flag is still not validated against the NPDU length when parsing - a receiver shall be tolerant towards the used frame format.
+- `CEMIFlags.EXTENDED_FRAME_FORMAT` was removed; its value `0x0001` was reserved, not an "extended frame format" indicator - `0x0000` is used for standard frames as well as for long extended frames. `CEMIFlags.LTE_FRAME_FORMAT` and `CEMIFlags.EXTENDED_FRAME_FORMAT_MASK` were added instead.
 - Add explicit length checks to every remaining APCI `from_knx` (and the top-level `APCI.from_knx` dispatcher) as defense-in-depth on top of the broad `except (IndexError, struct.error, ValueError)` added in 3.17.0: each service now raises `ConversionError` with a specific "Invalid length for A_X in CEMI" message for a truncated, malformed or overlong frame instead of relying solely on the generic dispatcher-level catch.
 
 # 3.17.0 APCIs and DPTs 2026-07-25

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ nav_order: 2
 
 ### Bugfixes
 
-- Send frames with an APDU longer than 15 octets as L_Data_Extended frames. The Frame Type flag of Ctrl1 is now derived from the NPDU length when serializing a `CEMILData` instead of always being set to standard frame. This fixes sending telegrams over KNX Data Secure with a payload of 2 octets or more (eg. DPT 9.x or DPT 232.600) - Data Secure adds 12 octets to the plain APDU, which no longer fits in a standard frame. Sending an APDU longer than 254 octets now raises `ConversionError` instead of `OverflowError`.
+- Send frames with an APDU longer than 15 octets as L_Data_Extended frames. The Frame Type is no longer stored in `CEMILData.flags`; it is derived from the NPDU length when serializing, exposed by the new `CEMILData.frame_type_standard` property and the new `CEMILData.npdu_length()` method. This fixes sending telegrams over KNX Data Secure with a payload of 2 octets or more (eg. DPT 9.x or DPT 232.600) - Data Secure adds 12 octets to the plain APDU, which no longer fits in a standard frame. Sending an APDU longer than 254 octets now raises `ConversionError` instead of `OverflowError`.
 
 ### Features
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -13,10 +13,11 @@ from xknx.cemi import (
     CEMIMPropWriteResponse,
 )
 from xknx.cemi.const import CEMIErrorCode
+from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError, CouldNotParseCEMI, UnsupportedCEMIMessage
 from xknx.profile.const import ResourceKNXNETIPPropertyId, ResourceObjectType
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
-from xknx.telegram.apci import GroupValueRead
+from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 from xknx.telegram.tpci import TConnect, TDataBroadcast, TDataGroup
 
 
@@ -51,11 +52,11 @@ def get_data(
 
 def test_valid_command() -> None:
     """Test for valid frame parsing."""
-    raw = get_data(0x29, 0, 0x0080, 1, 1, 1, 0, [])
+    raw = get_data(0x29, 0, 0x8080, 1, 1, 1, 0, [])
     frame = CEMIFrame.from_knx(raw)
     assert frame.code == CEMIMessageCode.L_DATA_IND
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags == 0x0080
+    assert frame.data.flags == 0x8080
     assert frame.data.hops == 0
     assert frame.data.src_addr == IndividualAddress(1)
     assert frame.data.dst_addr == GroupAddress(1)
@@ -67,11 +68,11 @@ def test_valid_command() -> None:
 
 def test_valid_tpci_control() -> None:
     """Test for valid tpci control."""
-    raw = bytes((0x29, 0, 0, 0, 0, 0, 0, 0, 0, 0x80))
+    raw = bytes((0x29, 0, 0x80, 0, 0, 0, 0, 0, 0, 0x80))
     frame = CEMIFrame.from_knx(raw)
     assert frame.code == CEMIMessageCode.L_DATA_IND
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags == 0
+    assert frame.data.flags == 0x8000
     assert frame.data.hops == 0
     assert frame.data.payload is None
     assert frame.data.src_addr == IndividualAddress(0)
@@ -277,6 +278,93 @@ def test_telegram_unsupported_address() -> None:
             code=CEMIMessageCode.L_DATA_IND,
             data=CEMILData.init_from_telegram(Telegram(destination_address=object())),
         )
+
+
+def _cemi_l_data_from_payload(payload: GroupValueWrite) -> bytes:
+    """Serialize a group write telegram to raw CEMI L_Data bytes."""
+    return CEMILData.init_from_telegram(
+        Telegram(destination_address=GroupAddress(1), payload=payload),
+        src_addr=IndividualAddress(1),
+    ).to_knx()
+
+
+@pytest.mark.parametrize(
+    "apdu_payload_length,expected_npdu_len,expected_frame_type",
+    [
+        (1, 2, CEMIFlags.FRAME_TYPE_STANDARD),
+        # 15 octets after the TPCI octet is the maximum of a standard frame
+        (14, 15, CEMIFlags.FRAME_TYPE_STANDARD),
+        (15, 16, CEMIFlags.FRAME_TYPE_EXTENDED),
+        (253, 254, CEMIFlags.FRAME_TYPE_EXTENDED),
+    ],
+)
+def test_frame_type_from_npdu_length(
+    apdu_payload_length: int, expected_npdu_len: int, expected_frame_type: int
+) -> None:
+    """Test Frame Type flag is derived from the NPDU length."""
+    raw = _cemi_l_data_from_payload(
+        GroupValueWrite(DPTArray(bytes(apdu_payload_length)))
+    )
+    assert raw[6] == expected_npdu_len
+    assert (raw[0] << 8) & CEMIFlags.FRAME_TYPE_STANDARD == expected_frame_type
+
+
+def test_frame_type_overrides_flags() -> None:
+    """Test Frame Type flag of `flags` is overridden by the payload length."""
+    long_payload = GroupValueWrite(DPTArray(bytes(15)))
+    short_payload = GroupValueWrite(DPTArray(bytes(1)))
+    cemi_data = CEMILData(
+        # standard frame flag set although the payload requires an extended frame
+        flags=CEMIFlags.FRAME_TYPE_STANDARD | CEMIFlags.DESTINATION_GROUP_ADDRESS,
+        src_addr=IndividualAddress(1),
+        dst_addr=GroupAddress(1),
+        tpci=TDataGroup(),
+        payload=long_payload,
+    )
+    assert not cemi_data.to_knx()[0] & 0x80
+    # `flags` is not modified by serialization
+    assert cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
+
+    cemi_data.flags = CEMIFlags.DESTINATION_GROUP_ADDRESS  # extended frame flag
+    cemi_data.payload = short_payload
+    assert cemi_data.to_knx()[0] & 0x80
+
+
+def test_npdu_length_exceeded() -> None:
+    """Test APDU too long for a single frame."""
+    with pytest.raises(ConversionError, match=r".*APDU too long for a single frame.*"):
+        _cemi_l_data_from_payload(GroupValueWrite(DPTArray(bytes(254))))
+
+
+def test_extended_frame_format_not_supported() -> None:
+    """Test parsing of LTE-HEE and reserved Extended Frame Formats."""
+    raw = get_data(
+        0x29,
+        0,
+        CEMIFlags.FRAME_TYPE_EXTENDED
+        | CEMIFlags.DESTINATION_GROUP_ADDRESS
+        | CEMIFlags.LTE_FRAME_FORMAT,
+        1,
+        1,
+        1,
+        0,
+        [],
+    )
+    with pytest.raises(
+        UnsupportedCEMIMessage, match=r".*Extended Frame Format not supported.*"
+    ):
+        CEMIFrame.from_knx(raw)
+
+
+def test_frame_type_not_validated_when_parsing() -> None:
+    """Test tolerance towards the Frame Type flag when parsing - 3/6/3 §4.1.5.2.3."""
+    # standard frame flag with a 17 octet NPDU; eg. AN158 v07 Annex A example
+    raw = get_data(0x29, 0, 0x8080, 1, 1, 17, 0x0080, list(range(16)))
+    frame = CEMIFrame.from_knx(raw)
+    assert isinstance(frame.data, CEMILData)
+    assert frame.data.payload == GroupValueWrite(DPTArray(bytes(range(16))))
+    # serializing it again corrects the Frame Type flag
+    assert not frame.to_knx()[2] & 0x80
 
 
 def get_prop(

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -302,9 +302,21 @@ def test_frame_type_from_npdu_length(
     apdu_payload_length: int, expected_npdu_len: int, expected_frame_type: int
 ) -> None:
     """Test Frame Type flag is derived from the NPDU length."""
-    raw = _cemi_l_data_from_payload(
-        GroupValueWrite(DPTArray(bytes(apdu_payload_length)))
+    cemi_data = CEMILData.init_from_telegram(
+        Telegram(
+            destination_address=GroupAddress(1),
+            payload=GroupValueWrite(DPTArray(bytes(apdu_payload_length))),
+        ),
+        src_addr=IndividualAddress(1),
     )
+    # the Frame Type is not stored in `flags`
+    assert not cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
+    assert cemi_data.npdu_length() == expected_npdu_len
+    assert cemi_data.frame_type_standard == (
+        expected_frame_type == CEMIFlags.FRAME_TYPE_STANDARD
+    )
+
+    raw = cemi_data.to_knx()
     assert raw[6] == expected_npdu_len
     assert (raw[0] << 8) & CEMIFlags.FRAME_TYPE_STANDARD == expected_frame_type
 
@@ -321,12 +333,28 @@ def test_frame_type_overrides_flags() -> None:
         tpci=TDataGroup(),
         payload=long_payload,
     )
+    assert not cemi_data.frame_type_standard
     assert not cemi_data.to_knx()[0] & 0x80
     # `flags` is not modified by serialization
     assert cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
 
     cemi_data.flags = CEMIFlags.DESTINATION_GROUP_ADDRESS  # extended frame flag
     cemi_data.payload = short_payload
+    assert cemi_data.frame_type_standard
+    assert cemi_data.to_knx()[0] & 0x80
+
+
+def test_npdu_length_control_tpdu() -> None:
+    """Test a control TPDU has no NPDU and is sent as standard frame."""
+    cemi_data = CEMILData(
+        flags=0,
+        src_addr=IndividualAddress(1),
+        dst_addr=IndividualAddress(2),
+        tpci=TConnect(),
+        payload=None,
+    )
+    assert cemi_data.npdu_length() == 0
+    assert cemi_data.frame_type_standard
     assert cemi_data.to_knx()[0] & 0x80
 
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -302,21 +302,9 @@ def test_frame_type_from_npdu_length(
     apdu_payload_length: int, expected_npdu_len: int, expected_frame_type: int
 ) -> None:
     """Test Frame Type flag is derived from the NPDU length."""
-    cemi_data = CEMILData.init_from_telegram(
-        Telegram(
-            destination_address=GroupAddress(1),
-            payload=GroupValueWrite(DPTArray(bytes(apdu_payload_length))),
-        ),
-        src_addr=IndividualAddress(1),
+    raw = _cemi_l_data_from_payload(
+        GroupValueWrite(DPTArray(bytes(apdu_payload_length)))
     )
-    # the Frame Type is not stored in `flags`
-    assert not cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
-    assert cemi_data.npdu_length() == expected_npdu_len
-    assert cemi_data.frame_type_standard == (
-        expected_frame_type == CEMIFlags.FRAME_TYPE_STANDARD
-    )
-
-    raw = cemi_data.to_knx()
     assert raw[6] == expected_npdu_len
     assert (raw[0] << 8) & CEMIFlags.FRAME_TYPE_STANDARD == expected_frame_type
 
@@ -333,28 +321,12 @@ def test_frame_type_overrides_flags() -> None:
         tpci=TDataGroup(),
         payload=long_payload,
     )
-    assert not cemi_data.frame_type_standard
     assert not cemi_data.to_knx()[0] & 0x80
     # `flags` is not modified by serialization
     assert cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
 
     cemi_data.flags = CEMIFlags.DESTINATION_GROUP_ADDRESS  # extended frame flag
     cemi_data.payload = short_payload
-    assert cemi_data.frame_type_standard
-    assert cemi_data.to_knx()[0] & 0x80
-
-
-def test_npdu_length_control_tpdu() -> None:
-    """Test a control TPDU has no NPDU and is sent as standard frame."""
-    cemi_data = CEMILData(
-        flags=0,
-        src_addr=IndividualAddress(1),
-        dst_addr=IndividualAddress(2),
-        tpci=TConnect(),
-        payload=None,
-    )
-    assert cemi_data.npdu_length() == 0
-    assert cemi_data.frame_type_standard
     assert cemi_data.to_knx()[0] & 0x80
 
 

--- a/test/secure_tests/data_secure_test.py
+++ b/test/secure_tests/data_secure_test.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.cemi import CEMIFlags, CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTArray
 from xknx.exceptions import DataSecureError
 from xknx.secure.data_secure import is_data_secure
@@ -189,6 +189,43 @@ class TestDataSecure:
 
         assert secured_frame_data.to_knx() == bytes.fromhex(
             "bce0500104000e03f11000254ae1cb67cd184afe5744"
+        )
+
+    def test_data_secure_group_send_extended(self) -> None:
+        """Test outgoing DataSecure group communication requiring an extended frame."""
+        # https://github.com/XKNX/xknx/issues/1868
+        # 5 octet plain APDU + 12 octets Data Secure overhead exceed the 15 octets
+        # a standard frame can carry - it has to be sent as L_Data_Extended frame.
+        self.data_secure._sequence_number_sending = 160170101607
+
+        test_telegram = Telegram(
+            destination_address=GroupAddress("0/4/0"),
+            payload=apci.GroupValueWrite(DPTArray((255, 0, 5))),
+        )
+        test_cemi_data = CEMILData.init_from_telegram(
+            test_telegram, src_addr=self.xknx.current_address
+        )
+        secured_frame_data = self.data_secure.outgoing_cemi(test_cemi_data)
+        assert isinstance(secured_frame_data, CEMILData)
+        assert isinstance(secured_frame_data.payload, apci.SecureAPDU)
+
+        raw = secured_frame_data.to_knx()
+        assert raw[6] == 17  # NPDU length
+        assert raw[0] == 0x3C  # Ctrl1: extended frame; not 0xBC
+        assert raw == bytes.fromhex(
+            "3ce0500104001103f11000254ae1cb67cd98e577b519be47bb"
+        )
+
+        # the Frame Type flag is not part of the CCM MAC, so the frame decrypts
+        # although `secured_frame_data.flags` still holds the standard frame flag
+        incoming_cemi = CEMIFrame.from_knx(b"\x29\x00" + raw)
+        assert isinstance(incoming_cemi.data, CEMILData)
+        self.data_secure._individual_address_table[self.xknx.current_address] = 1
+        plain_cemi_data = self.data_secure.received_cemi(incoming_cemi.data)
+        assert plain_cemi_data.telegram() == Telegram(
+            destination_address=GroupAddress("0/4/0"),
+            source_address=self.xknx.current_address,
+            payload=apci.GroupValueWrite(DPTArray((255, 0, 5))),
         )
 
     def test_data_secure_group_receive(
@@ -441,14 +478,23 @@ class TestDataSecure:
         )
         assert outgoing_signed_cemi_data.payload.secured_data is not None
 
+        outgoing_raw = outgoing_signed_cemi_data.to_knx()
+        # 4 octet plain APDU + 12 octets Data Secure overhead doesn't fit in a
+        # standard frame - it is serialized as L_Data_Extended frame
+        assert outgoing_raw[6] == 16
+        assert not outgoing_raw[0] & CEMIFlags.FRAME_TYPE_STANDARD >> 8
+
         # create new cemi to avoid mixed bytearray / byte parts
-        incoming_cemi = CEMIFrame.from_knx(
-            b"\x11\x00" + outgoing_signed_cemi_data.to_knx()
-        )
+        incoming_cemi = CEMIFrame.from_knx(b"\x11\x00" + outgoing_raw)
         assert isinstance(incoming_cemi.data, CEMILData)
         # receive same cemi - fake individual address table entry
         self.data_secure._individual_address_table[incoming_cemi.data.src_addr] = 1
-        assert self.data_secure.received_cemi(incoming_cemi.data) == test_cemi.data
+        # compare telegrams: `test_cemi.data.flags` still holds the default standard
+        # Frame Type while the serialized frame was sent as extended frame
+        assert (
+            self.data_secure.received_cemi(incoming_cemi.data).telegram()
+            == test_cemi.data.telegram()
+        )
 
         # Test wrong MAC
         self.data_secure._individual_address_table[incoming_cemi.data.src_addr] = 1

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -735,7 +735,7 @@ class TestStringRepresentations:
         assert (
             str(cemi_frame)
             == '<CEMIFrame code="L_DATA_IND" info="CEMIInfo("")" data="CEMILData(src_addr="IndividualAddress("1.2.3")" '
-            'dst_addr="GroupAddress("1/2/5")" flags="0011110011100000" tpci="TDataGroup()" '
+            'dst_addr="GroupAddress("1/2/5")" flags="1011110011100000" tpci="TDataGroup()" '
             'payload="<GroupValueWrite value="<DPTBinary value="7" />" />")" />'
         )
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -735,7 +735,7 @@ class TestStringRepresentations:
         assert (
             str(cemi_frame)
             == '<CEMIFrame code="L_DATA_IND" info="CEMIInfo("")" data="CEMILData(src_addr="IndividualAddress("1.2.3")" '
-            'dst_addr="GroupAddress("1/2/5")" flags="1011110011100000" tpci="TDataGroup()" '
+            'dst_addr="GroupAddress("1/2/5")" flags="0011110011100000" tpci="TDataGroup()" '
             'payload="<GroupValueWrite value="<DPTBinary value="7" />" />")" />'
         )
 

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -27,7 +27,13 @@ from xknx.telegram import GroupAddress, IndividualAddress, Telegram
 from xknx.telegram.apci import APCI
 from xknx.telegram.tpci import TPCI, TDataBroadcast
 
-from .const import CEMIErrorCode, CEMIFlags, CEMIMessageCode
+from .const import (
+    MAX_NPDU_LENGTH,
+    STANDARD_FRAME_MAX_NPDU_LENGTH,
+    CEMIErrorCode,
+    CEMIFlags,
+    CEMIMessageCode,
+)
 
 
 class CEMIInfo:
@@ -138,6 +144,7 @@ class CEMILData(CEMIData):
     ) -> CEMILData:
         """Return CEMILData from a Telegram."""
         flags = (
+            # default; the Frame Type is derived from the NPDU length in `to_knx()`
             CEMIFlags.FRAME_TYPE_STANDARD
             | CEMIFlags.DO_NOT_REPEAT
             | CEMIFlags.BROADCAST
@@ -191,8 +198,24 @@ class CEMILData(CEMIData):
             tpdu[0] |= self.tpci.to_knx()
             npdu_len = self.payload.calculated_length()
 
+        if npdu_len > MAX_NPDU_LENGTH:
+            raise ConversionError(
+                f"APDU too long for a single frame: {npdu_len} octets; "
+                f"maximum is {MAX_NPDU_LENGTH}"
+            )
+        # The Frame Type is a function of the NPDU length: an L_Data_Standard frame
+        # can carry at most 15 octets after the TPCI octet, and an L_Data_Extended
+        # frame shall not be used when a standard frame suffices - 3/2/2 §2.2.5.1.
+        # Derived here instead of when the frame is created because the payload may
+        # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
+        flags = (
+            self.flags | CEMIFlags.FRAME_TYPE_STANDARD
+            if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
+            else self.flags & ~CEMIFlags.FRAME_TYPE_STANDARD
+        )
+
         return (
-            self.flags.to_bytes(2, "big")
+            flags.to_bytes(2, "big")
             + self.src_addr.to_knx()
             + self.dst_addr.to_knx()
             + npdu_len.to_bytes(1, "big")
@@ -211,6 +234,18 @@ class CEMILData(CEMIData):
         flags = int.from_bytes(raw[0:2], "big")
 
         src_addr = IndividualAddress.from_knx(raw[2:4])
+
+        # The Extended Frame Format defines how the address fields are to be
+        # interpreted - 3/2/2 §2.2.5.3. Only 0000b (standard and long frames) is
+        # supported; 01xxb are LTE-HEE zone addressed frames, the rest is reserved.
+        # The Frame Type flag itself is deliberately not validated against the NPDU
+        # length: "any receiver shall be tolerant towards the use of the Frame
+        # Format" - 3/6/3 §4.1.5.2.3.
+        if _eff := flags & CEMIFlags.EXTENDED_FRAME_FORMAT_MASK:
+            raise UnsupportedCEMIMessage(
+                f"Extended Frame Format not supported: {_eff:#06b} "
+                f"from {src_addr} in CEMI: {raw.hex()}"
+            )
 
         _dst_is_group_address = bool(flags & CEMIFlags.DESTINATION_GROUP_ADDRESS)
         dst_addr: GroupAddress | IndividualAddress = (

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -129,28 +129,6 @@ class CEMILData(CEMIData):
         # Setting new hops
         self.flags |= val << 4
 
-    def npdu_length(self) -> int:
-        """Get number of NPDU octets; the TPCI octet is not included."""
-        if self.tpci.control:
-            return 0
-        if not isinstance(self.payload, APCI):
-            raise ConversionError(
-                f"Invalid payload set for data TPDU: {type(self.payload)}"
-            )
-        return self.payload.calculated_length()
-
-    @property
-    def frame_type_standard(self) -> bool:
-        """
-        Return True if this is serialized as L_Data_Standard frame.
-
-        The Frame Type is not stored in `flags` for frames created by XKNX; it is a
-        function of the NPDU length. An L_Data_Standard frame can carry at most 15
-        octets after the TPCI octet and an L_Data_Extended frame shall not be used
-        when a standard frame suffices - 3/2/2 §2.2.4 and §2.2.5.1.
-        """
-        return self.npdu_length() <= STANDARD_FRAME_MAX_NPDU_LENGTH
-
     def calculated_length(self) -> int:
         """Get length of KNX/IP body."""
         if not self.tpci.control and self.payload is not None:
@@ -165,10 +143,10 @@ class CEMILData(CEMIData):
         src_addr: IndividualAddress | None = None,
     ) -> CEMILData:
         """Return CEMILData from a Telegram."""
-        # the Frame Type is not set here; it is derived from the NPDU length
-        # when serializing - see `frame_type_standard`
         flags = (
-            CEMIFlags.DO_NOT_REPEAT
+            # default; the Frame Type is derived from the NPDU length in `to_knx()`
+            CEMIFlags.FRAME_TYPE_STANDARD
+            | CEMIFlags.DO_NOT_REPEAT
             | CEMIFlags.BROADCAST
             | CEMIFlags.NO_ACK_REQUESTED
             | CEMIFlags.CONFIRM_NO_ERROR
@@ -210,6 +188,7 @@ class CEMILData(CEMIData):
         tpdu: bytes | bytearray
         if self.tpci.control:
             tpdu = self.tpci.to_knx().to_bytes(1, "big")
+            npdu_len = 0
         else:
             if not isinstance(self.payload, APCI):
                 raise ConversionError(
@@ -217,19 +196,21 @@ class CEMILData(CEMIData):
                 )
             tpdu = self.payload.to_knx()
             tpdu[0] |= self.tpci.to_knx()
-        npdu_len = self.npdu_length()
+            npdu_len = self.payload.calculated_length()
 
         if npdu_len > MAX_NPDU_LENGTH:
             raise ConversionError(
                 f"APDU too long for a single frame: {npdu_len} octets; "
                 f"maximum is {MAX_NPDU_LENGTH}"
             )
-        # The Frame Type is derived from the NPDU length, not taken from `flags` -
-        # the payload may have been replaced after the frame was created, eg. when
-        # it was wrapped in a SecureAPDU by Data Secure.
+        # The Frame Type is a function of the NPDU length: an L_Data_Standard frame
+        # can carry at most 15 octets after the TPCI octet, and an L_Data_Extended
+        # frame shall not be used when a standard frame suffices - 3/2/2 §2.2.5.1.
+        # Derived here instead of when the frame is created because the payload may
+        # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
         flags = (
             self.flags | CEMIFlags.FRAME_TYPE_STANDARD
-            if self.frame_type_standard
+            if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
             else self.flags & ~CEMIFlags.FRAME_TYPE_STANDARD
         )
 
@@ -343,7 +324,7 @@ class CEMILData(CEMIData):
             "CEMILData("
             f'src_addr="{self.src_addr.__repr__()}" '
             f'dst_addr="{self.dst_addr.__repr__()}" '
-            f'flags="{self.flags:016b}" '
+            f'flags="{self.flags:16b}" '
             f'tpci="{self.tpci}" '
             f'payload="{self.payload}")'
         )

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -129,6 +129,28 @@ class CEMILData(CEMIData):
         # Setting new hops
         self.flags |= val << 4
 
+    def npdu_length(self) -> int:
+        """Get number of NPDU octets; the TPCI octet is not included."""
+        if self.tpci.control:
+            return 0
+        if not isinstance(self.payload, APCI):
+            raise ConversionError(
+                f"Invalid payload set for data TPDU: {type(self.payload)}"
+            )
+        return self.payload.calculated_length()
+
+    @property
+    def frame_type_standard(self) -> bool:
+        """
+        Return True if this is serialized as L_Data_Standard frame.
+
+        The Frame Type is not stored in `flags` for frames created by XKNX; it is a
+        function of the NPDU length. An L_Data_Standard frame can carry at most 15
+        octets after the TPCI octet and an L_Data_Extended frame shall not be used
+        when a standard frame suffices - 3/2/2 §2.2.4 and §2.2.5.1.
+        """
+        return self.npdu_length() <= STANDARD_FRAME_MAX_NPDU_LENGTH
+
     def calculated_length(self) -> int:
         """Get length of KNX/IP body."""
         if not self.tpci.control and self.payload is not None:
@@ -143,10 +165,10 @@ class CEMILData(CEMIData):
         src_addr: IndividualAddress | None = None,
     ) -> CEMILData:
         """Return CEMILData from a Telegram."""
+        # the Frame Type is not set here; it is derived from the NPDU length
+        # when serializing - see `frame_type_standard`
         flags = (
-            # default; the Frame Type is derived from the NPDU length in `to_knx()`
-            CEMIFlags.FRAME_TYPE_STANDARD
-            | CEMIFlags.DO_NOT_REPEAT
+            CEMIFlags.DO_NOT_REPEAT
             | CEMIFlags.BROADCAST
             | CEMIFlags.NO_ACK_REQUESTED
             | CEMIFlags.CONFIRM_NO_ERROR
@@ -188,7 +210,6 @@ class CEMILData(CEMIData):
         tpdu: bytes | bytearray
         if self.tpci.control:
             tpdu = self.tpci.to_knx().to_bytes(1, "big")
-            npdu_len = 0
         else:
             if not isinstance(self.payload, APCI):
                 raise ConversionError(
@@ -196,21 +217,19 @@ class CEMILData(CEMIData):
                 )
             tpdu = self.payload.to_knx()
             tpdu[0] |= self.tpci.to_knx()
-            npdu_len = self.payload.calculated_length()
+        npdu_len = self.npdu_length()
 
         if npdu_len > MAX_NPDU_LENGTH:
             raise ConversionError(
                 f"APDU too long for a single frame: {npdu_len} octets; "
                 f"maximum is {MAX_NPDU_LENGTH}"
             )
-        # The Frame Type is a function of the NPDU length: an L_Data_Standard frame
-        # can carry at most 15 octets after the TPCI octet, and an L_Data_Extended
-        # frame shall not be used when a standard frame suffices - 3/2/2 §2.2.5.1.
-        # Derived here instead of when the frame is created because the payload may
-        # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
+        # The Frame Type is derived from the NPDU length, not taken from `flags` -
+        # the payload may have been replaced after the frame was created, eg. when
+        # it was wrapped in a SecureAPDU by Data Secure.
         flags = (
             self.flags | CEMIFlags.FRAME_TYPE_STANDARD
-            if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
+            if self.frame_type_standard
             else self.flags & ~CEMIFlags.FRAME_TYPE_STANDARD
         )
 
@@ -324,7 +343,7 @@ class CEMILData(CEMIData):
             "CEMILData("
             f'src_addr="{self.src_addr.__repr__()}" '
             f'dst_addr="{self.dst_addr.__repr__()}" '
-            f'flags="{self.flags:16b}" '
+            f'flags="{self.flags:016b}" '
             f'tpci="{self.tpci}" '
             f'payload="{self.payload}")'
         )

--- a/xknx/cemi/const.py
+++ b/xknx/cemi/const.py
@@ -2,6 +2,13 @@
 
 from enum import Enum, IntEnum
 
+# Maximum value of the NPDU length field. 255 is reserved as escape code.
+# See 3/2/2 Communication Medium TP1 §2.2.5.6 "Length (LG)".
+MAX_NPDU_LENGTH = 254
+# An L_Data_Standard frame encodes the NPDU length in 4 bit only.
+# Longer APDUs require an L_Data_Extended frame. See 3/2/2 §2.2.4 and §2.2.5.1.
+STANDARD_FRAME_MAX_NPDU_LENGTH = 15
+
 
 class CEMIMessageCode(Enum):
     """Enum class for CEMI Message Codes."""
@@ -43,7 +50,8 @@ class CEMIMessageCode(Enum):
 class CEMIFlags:
     """Enum class for CEMI Flags."""
 
-    # Bit 1/7
+    # Bit 1/7 - Frame Type (FT); see 3/6/3 EMI_IMI §4.1.4.3.2
+    # Derived from the NPDU length when serializing - see `CEMILData.to_knx`.
     FRAME_TYPE_EXTENDED = 0x0000
     FRAME_TYPE_STANDARD = 0x8000
 
@@ -80,9 +88,14 @@ class CEMIFlags:
     HOP_COUNT_NO = 0x0070
     HOP_COUNT_1ST = 0x0060
 
-    # Bit 0/3+2+1+0
+    # Bit 0/3+2+1+0 - Extended Frame Format (EFF); see 3/6/3 EMI_IMI §4.1.4.3.2
+    # and 3/2/2 Communication Medium TP1 §2.2.5.3.
+    # 0000b is used for L_Data_Standard frames as well as for long
+    # L_Data_Extended frames; 01xxb denotes LTE-HEE (zone addressed) frames.
+    # All other values are reserved.
     STANDARD_FRAME_FORMAT = 0x0000
-    EXTENDED_FRAME_FORMAT = 0x0001
+    LTE_FRAME_FORMAT = 0x0004
+    EXTENDED_FRAME_FORMAT_MASK = 0x000F
 
 
 class CEMIErrorCode(IntEnum):


### PR DESCRIPTION
## Description

`CEMILData.init_from_telegram()` hardcoded `CEMIFlags.FRAME_TYPE_STANDARD` and `to_knx()` never revisited that bit. An L_Data_Standard frame encodes the NPDU length in 4 bit only, so it can carry at most 15 octets after the TPCI octet (3/2/2 §2.2.4).

KNX Data Secure adds a fixed 12 octets to the plain APDU (`2 + 6 seq nr + plain APDU + 4 MAC`), so every secured group write with 2 or more octets of payload was serialized as a **standard** frame with an illegal length octet:

| plain payload | secured `npdu_len` | fits standard? |
|---|---|---|
| `GroupValueRead` / `DPTBinary` | 14 | yes |
| `DPTArray` 1 byte | 15 | yes (at the limit) |
| `DPTArray` 2 bytes (DPT 9.x) | 16 | **no** |
| `DPTArray` 3 bytes (DPT 232.600) | 17 | **no** |

The interface truncates such a frame to the 4 bit length field (`0x11 & 0x0F = 1`), so it came back as a 2 octet stub - a bare `03 f1` Secure APCI - which crashed `SecureAPDU.from_knx()` with an `IndexError`. That crash itself is already contained by f0d6eb94, but the illegal frame on the wire is not and the telegram never arrives. Plain (unsecured) frames were affected the same way for any APDU longer than 15 octets.

### Changes

- **Frame Type is derived from the NPDU length in `CEMILData.to_knx()`** - standard frame if the NPDU fits in 15 octets, extended frame otherwise. This has to happen at serialization time rather than in `init_from_telegram()`, because Data Secure replaces the payload *after* the `CEMILData` is created and `copy()`s its flags - which is exactly the case in #1868. `self.flags` is left untouched, so `to_knx()` stays free of side effects.
- **`ConversionError` for an NPDU longer than 254 octets** (255 is the escape code - 3/2/2 §2.2.5.6). This previously escaped as a bare `OverflowError` from `int.to_bytes`, which neither `CEMIHandler.send_telegram` nor `Tunnel` catches.
- **Parsing rejects a non-zero Extended Frame Format field** with `UnsupportedCEMIMessage`. LTE-HEE frames (EFF `01xxb`) use zone addressing, so their address fields can not be parsed as `GroupAddress` - they were silently mis-parsed as group telegrams before. The Frame Type flag itself is deliberately *not* validated against the NPDU length: "any receiver shall be tolerant towards the use of the Frame Format" (3/6/3 §4.1.5.2.3).
- **`CEMIFlags.EXTENDED_FRAME_FORMAT` removed.** Its value `0x0001` is a reserved EFF value, not an extended frame indicator - `0x0000` is used for standard frames *and* for long extended frames, `01xxb` denotes LTE. It was dead code. `LTE_FRAME_FORMAT` and `EXTENDED_FRAME_FORMAT_MASK` are added instead.

### Notes for reviewers

**The Data Secure MAC is not affected.** `block_0()` masks the 16 bit cEMI flags with `B0_AT_FIELD_FLAGS_MASK = 0b10001111`, which only reaches Ctrl2 (Address Type bit + EFF nibble) - Ctrl1, and therefore the Frame Type, is excluded from the CCM input. Two independent vectors already in the test suite confirm this empirically: the real-device group frame fixture has Ctrl1 `0x3C` (FT = 0) and the AN158 v07 Annex A example has Ctrl1 `0xB0` (FT = 1), and both verify today under a mask that drops the bit. `test_data_secure_group_send_extended` now also round-trips encrypt -> serialize -> parse -> decrypt across a flipped Frame Type.

**Two existing fixtures changed.** `test_valid_command` and `test_valid_tpci_control` used flags with FT = 0 together with a short payload, which is not a frame xknx would ever emit; their `to_knx() == raw` round trip now requires `FRAME_TYPE_STANDARD`. `test_data_secure_authentication_only` compares telegrams instead of whole `CEMILData` objects, because the pre-serialization frame still carries the default standard flag while the serialized frame went out as extended.

Verified end-to-end against the reported case - the boundary sits exactly where the spec puts it:

```
GroupValueRead         ctrl1=0xbc standard  npdu_len= 14
1 byte  (DPT 5.001)    ctrl1=0xbc standard  npdu_len= 15
2 bytes (DPT 9.001)    ctrl1=0x3c EXTENDED  npdu_len= 16
3 bytes (DPT 232.600)  ctrl1=0x3c EXTENDED  npdu_len= 17
14 bytes (DPT 16.000)  ctrl1=0x3c EXTENDED  npdu_len= 28
```

Fixes #1868

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
