### PR TITLE
fix: use Extended Frame Format when outgoing NPDU exceeds 15 octets

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ nav_order: 2
 ### Protocol
 
 - Add explicit length checks to every remaining APCI `from_knx` (and the top-level `APCI.from_knx` dispatcher) as defense-in-depth on top of the broad `except (IndexError, struct.error, ValueError)` added in 3.17.0: each service now raises `ConversionError` with a specific "Invalid length for A_X in CEMI" message for a truncated, malformed or overlong frame instead of relying solely on the generic dispatcher-level catch.
+- Fix `CEMILData.to_knx()` always encoding outgoing frames as Standard Frame Format, which only fits 15 octets of NPDU. A KNX Data Secure secured payload regularly exceeds that once its SCF/sequence-number/MAC overhead is added, producing a truncated frame on the wire. Frames whose NPDU exceeds 15 octets now switch to Extended Frame Format.
 
 # 3.17.0 APCIs and DPTs 2026-07-25
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -13,10 +13,11 @@ from xknx.cemi import (
     CEMIMPropWriteResponse,
 )
 from xknx.cemi.const import CEMIErrorCode
+from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError, CouldNotParseCEMI, UnsupportedCEMIMessage
 from xknx.profile.const import ResourceKNXNETIPPropertyId, ResourceObjectType
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram
-from xknx.telegram.apci import GroupValueRead
+from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 from xknx.telegram.tpci import TConnect, TDataBroadcast, TDataGroup
 
 
@@ -63,6 +64,55 @@ def test_valid_command() -> None:
     assert frame.data.tpci == TDataGroup()
     assert frame.calculated_length() == 11
     assert frame.to_knx() == raw
+
+
+def test_frame_type_standard_at_boundary() -> None:
+    """NPDU of exactly 15 octets still fits Standard Frame Format."""
+    cemi_data = CEMILData(
+        flags=CEMIFlags.FRAME_TYPE_STANDARD,
+        src_addr=IndividualAddress(1),
+        dst_addr=GroupAddress(1),
+        tpci=TDataGroup(),
+        payload=GroupValueWrite(DPTArray((0,) * 14)),
+    )
+    assert cemi_data.payload.calculated_length() == 15
+    raw = cemi_data.to_knx()
+    assert int.from_bytes(raw[0:2], "big") & CEMIFlags.FRAME_TYPE_STANDARD
+
+
+def test_frame_type_switches_to_extended_for_long_payload() -> None:
+    """NPDU longer than 15 octets (eg. Data Secure) requires Extended Frame Format."""
+    cemi_data = CEMILData(
+        flags=CEMIFlags.FRAME_TYPE_STANDARD,
+        src_addr=IndividualAddress(1),
+        dst_addr=GroupAddress(1),
+        tpci=TDataGroup(),
+        payload=GroupValueWrite(DPTArray((0,) * 15)),
+    )
+    assert cemi_data.payload.calculated_length() == 16
+    raw = cemi_data.to_knx()
+    assert not (int.from_bytes(raw[0:2], "big") & CEMIFlags.FRAME_TYPE_STANDARD)
+    # the object itself reflects the frame type actually put on the wire
+    assert not (cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD)
+
+
+def test_frame_type_roundtrip_max_npdu_length() -> None:
+    """NPDU of 255 octets - the maximum a single length byte can encode - roundtrips."""
+    cemi_data = CEMILData(
+        flags=CEMIFlags.FRAME_TYPE_STANDARD | CEMIFlags.DESTINATION_GROUP_ADDRESS,
+        src_addr=IndividualAddress(1),
+        dst_addr=GroupAddress(1),
+        tpci=TDataGroup(),
+        payload=GroupValueWrite(DPTArray((0,) * 254)),
+    )
+    assert cemi_data.payload.calculated_length() == 255
+    raw = cemi_data.to_knx()
+    assert raw[6] == 255
+    assert not (int.from_bytes(raw[0:2], "big") & CEMIFlags.FRAME_TYPE_STANDARD)
+
+    parsed = CEMILData.from_knx(raw)
+    assert parsed == cemi_data
+    assert parsed.to_knx() == raw
 
 
 def test_valid_tpci_control() -> None:

--- a/test/secure_tests/data_secure_test.py
+++ b/test/secure_tests/data_secure_test.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.cemi import CEMIFlags, CEMIFrame, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTArray
 from xknx.exceptions import DataSecureError
 from xknx.secure.data_secure import is_data_secure
@@ -448,7 +448,17 @@ class TestDataSecure:
         assert isinstance(incoming_cemi.data, CEMILData)
         # receive same cemi - fake individual address table entry
         self.data_secure._individual_address_table[incoming_cemi.data.src_addr] = 1
-        assert self.data_secure.received_cemi(incoming_cemi.data) == test_cemi.data
+        decrypted_cemi_data = self.data_secure.received_cemi(incoming_cemi.data)
+        # The secured NPDU (16 octets here) exceeds what Standard Frame Format
+        # can carry, so the wire frame - and thus the decrypted result, which
+        # keeps the flags it was actually received with - uses Extended Frame
+        # Format. `test_cemi.data` never went through serialization, so it
+        # still carries its original (smaller, plaintext-sized) frame type.
+        assert decrypted_cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD == 0
+        assert decrypted_cemi_data.src_addr == test_cemi.data.src_addr
+        assert decrypted_cemi_data.dst_addr == test_cemi.data.dst_addr
+        assert decrypted_cemi_data.tpci == test_cemi.data.tpci
+        assert decrypted_cemi_data.payload == test_cemi.data.payload
 
         # Test wrong MAC
         self.data_secure._individual_address_table[incoming_cemi.data.src_addr] = 1

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -190,6 +190,14 @@ class CEMILData(CEMIData):
             tpdu = self.payload.to_knx()
             tpdu[0] |= self.tpci.to_knx()
             npdu_len = self.payload.calculated_length()
+            if npdu_len > CEMIFlags.MAX_STANDARD_FRAME_NPDU_LENGTH:
+                # Standard Frame Format only fits up to 15 octets of NPDU - eg.
+                # Data Secure regularly exceeds that once its overhead is added.
+                # `to_knx()` is only ever called on outgoing frames (never on
+                # frames parsed from `from_knx()`), so updating `self.flags`
+                # here keeps the object consistent with what is actually put
+                # on the wire, instead of just patching the returned bytes.
+                self.flags &= 0xFFFF ^ CEMIFlags.FRAME_TYPE_STANDARD
 
         return (
             self.flags.to_bytes(2, "big")

--- a/xknx/cemi/const.py
+++ b/xknx/cemi/const.py
@@ -46,6 +46,9 @@ class CEMIFlags:
     # Bit 1/7
     FRAME_TYPE_EXTENDED = 0x0000
     FRAME_TYPE_STANDARD = 0x8000
+    # Maximum NPDU (TPCI + APDU) length transportable in Standard Frame Format.
+    # Larger NPDUs (eg. KNX Data Secure payloads) require Extended Frame Format.
+    MAX_STANDARD_FRAME_NPDU_LENGTH = 15
 
     # Bit 1/6 - Reserved
 


### PR DESCRIPTION
## Description

`CEMILData.to_knx()` always encoded outgoing frames with the Standard Frame Format bit set, which only fits 15 octets of NPDU (TPCI + APDU). KNX Data Secure adds ~10 bytes of overhead (SCF + sequence number + MAC) on top of the plain APDU, so anything beyond a trivial payload overflows that cap - producing a truncated/malformed frame on the wire instead of a valid one.

This is exactly what was reported in #1868: a 1-bit secure `GroupValueWrite` worked fine, but a `232.600` (RGB, 3-byte) secure `GroupValueWrite` produced a truncated `L_Data.con` confirmation from the tunnelling interface, which then crashed the CEMI parser (separately hardened in #1871/#1877).

`IceTman007` correctly diagnosed the root cause in the issue thread: once the secured payload's NPDU exceeds 15 octets, the frame must use Extended Frame Format (max 254 octets) instead of Standard Frame Format - and this must be decided using the *final*, post-encryption payload size.

### Fix

`CEMILData.to_knx()` now switches to Extended Frame Format whenever the NPDU exceeds `CEMIFlags.MAX_STANDARD_FRAME_NPDU_LENGTH` (15). This is computed from `self.payload.calculated_length()` at serialization time - which, for Data Secure telegrams, is after `DataSecure._secure_data_cemi()` has already wrapped the payload in `SecureAPDU`, so the size used to pick the frame format is the one that actually goes out on the wire.

`to_knx()` is only ever called on outgoing frames in this codebase (never on frames parsed via `from_knx()`), so it mutates `self.flags` directly rather than just adjusting the returned bytes - the object stays internally consistent with what was actually transmitted, and the receive path (which must keep flags as a truthful record of what a device put on the wire) is untouched.

I verified the Frame-Type bit is not part of the KNX Data Secure CCM MAC's authenticated data (`B0_AT_FIELD_FLAGS_MASK` in `data_secure_asdu.py` masks out the byte it lives in), so this change cannot desync sender/receiver MAC computation. I also verified `CEMILData.from_knx()` already parses Extended-format NPDUs correctly (it just reads the length byte as-is, 0-255, with no branching on the frame-type flag) - only the outgoing encoder needed a fix.

### Verification

- New unit tests: NPDU at the 15-octet boundary stays Standard, 16 octets switches to Extended, and a full round-trip at the 255-octet ceiling (the max a single length byte encodes).
- Updated an existing Data Secure test whose expected value baked in the old (buggy) "frame type never changes" assumption.
- Full test suite passes (3740 tests), ruff and mypy clean.

Fixes #1868

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)