### PR TITLE
Refactor CEMILData.flags into a typed CEMIFlags dataclass

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,15 @@ nav_order: 2
 
 - Drop support for Python 3.10. XKNX requires Python 3.11 or newer now.
 - Remove `xknx.util`. Its only member was `asyncio_timeout` - a backport of `asyncio.timeout` for Python versions not providing it - so use `asyncio.timeout` directly.
+- `CEMILData.flags` is now a `CEMIFlags` object instead of a 16 bit `int`. `CEMIFlags` was previously a collection of bit constants; it is now a slotted dataclass holding the control field values that are independent state:
+  - `priority: CEMIPriority` - new `SYSTEM` / `NORMAL` / `URGENT` / `LOW` enum
+  - `repeat_on_error: bool`, `system_broadcast: bool` - named for the positive meaning; both are inverted on the wire
+  - `acknowledge_request: bool`
+  - `confirm_error: bool` - only meaningful in an L_Data.con frame
+  - `hop_count: int` - replaces the `CEMILData.hops` property, which was removed
+  Frame Type, Address Type and Extended Frame Format are no longer stored: they follow from the NPDU length, the destination address type and the supported frame formats, and are derived when serializing. `flags` therefore can no longer disagree with the frame that is put on the wire. The raw bit masks moved to `xknx.cemi.flags` as module level constants.
+- `CEMILData(flags=...)` is optional now and defaults to `CEMIFlags()` - low priority, hop count 6, no acknowledge request.
+- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `dst_is_group_address: bool` instead of `frame_flags: int`. Only the Address Type bit of Ctrl2 ever reached the CCM input; passing it explicitly removes the mask.
 
 ### Connection
 
@@ -73,7 +82,8 @@ nav_order: 2
 ### Protocol
 
 - Reject incoming CEMI L_Data frames with a non-zero Extended Frame Format field with `UnsupportedCEMIMessage`. LTE-HEE frames use zone addressing, so their address fields can not be parsed as `GroupAddress`. The Frame Type flag is still not validated against the NPDU length when parsing - a receiver shall be tolerant towards the used frame format.
-- `CEMIFlags.EXTENDED_FRAME_FORMAT` was removed; its value `0x0001` was reserved, not an "extended frame format" indicator - `0x0000` is used for standard frames as well as for long extended frames. `CEMIFlags.LTE_FRAME_FORMAT` and `CEMIFlags.EXTENDED_FRAME_FORMAT_MASK` were added instead.
+- `CEMIFlags.EXTENDED_FRAME_FORMAT` was removed; its value `0x0001` was reserved, not an "extended frame format" indicator - `0x0000` is used for standard frames as well as for long extended frames. `LTE_FRAME_FORMAT` and `EXTENDED_FRAME_FORMAT_MASK` were added instead.
+- The hop count is validated when serializing; a value outside `0..7` raises `ConversionError` instead of silently corrupting Ctrl2.
 - Add explicit length checks to every remaining APCI `from_knx` (and the top-level `APCI.from_knx` dispatcher) as defense-in-depth on top of the broad `except (IndexError, struct.error, ValueError)` added in 3.17.0: each service now raises `ConversionError` with a specific "Invalid length for A_X in CEMI" message for a truncated, malformed or overlong frame instead of relying solely on the generic dispatcher-level catch.
 
 ### Deprecation notes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,18 +12,6 @@ nav_order: 2
 
 - Drop support for Python 3.10. XKNX requires Python 3.11 or newer now.
 - Remove `xknx.util`. Its only member was `asyncio_timeout` - a backport of `asyncio.timeout` for Python versions not providing it - so use `asyncio.timeout` directly.
-- `CEMILData.flags` is now a `CEMIFlags` object instead of a 16 bit `int`. `CEMIFlags` was previously a collection of bit constants; it is now a slotted dataclass holding the control field values that are independent state:
-  - `priority: CEMIPriority` - new `SYSTEM` / `NORMAL` / `URGENT` / `LOW` enum
-  - `repeat_on_error: bool`, `system_broadcast: bool` - named for the positive meaning; both are inverted on the wire
-  - `acknowledge_request: bool`
-  - `confirm_error: bool` - only meaningful in an L_Data.con frame
-  - `hop_count: int` - replaces the `CEMILData.hops` property, which was removed
-  - `frame_type: CEMIFrameType` - informational; holds what was received and is ignored when serializing
-  - `frame_format: CEMIFrameFormat` - the Extended Frame Format, serialized as held; `STANDARD` for every frame xknx supports
-  The Frame Type of an outgoing frame is derived from its NPDU length and the Address Type from the type of the destination address (`CEMILData.address_type`), so neither can disagree with the frame that is put on the wire. `CEMIFrameType` and the new `CEMIAddressType` place their own bit via `to_knx()` / `from_knx()`; `CEMILData` composes the control field as `flags.to_knx() | frame_type.to_knx() | address_type.to_knx()`. Ctrl1 and Ctrl2 are handled as one 16 bit int, so `CEMIFlags.to_knx()` returns an `int` and `CEMIFlags.from_knx()` takes one. The remaining bit masks moved to `xknx.cemi.flags` as module level constants.
-- `CEMIFlags` has a compact `__str__` used in `CEMILData.__repr__` - eg. `LOW STANDARD hop_count=6`, listing only the boolean flags that are set. The full dataclass `__repr__` shows every field.
-- `CEMILData(flags=...)` is optional now and defaults to `CEMIFlags()` - low priority, hop count 6, no acknowledge request.
-- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` and `frame_format: CEMIFrameFormat` instead of `frame_flags: int`. Only those two fields of Ctrl2 ever reached the CCM input, so the B0 flags octet is `address_type.to_knx() | frame_format` and `B0_AT_FIELD_FLAGS_MASK` is gone.
 
 ### Connection
 
@@ -31,6 +19,8 @@ nav_order: 2
 
 ### Internals
 
+- `CEMILData.flags` is a `CEMIFlags` dataclass now instead of a 16 bit `int`, with a field per control field value: `priority` (new `CEMIPriority` enum), `repeat_on_error`, `system_broadcast` (both named for the positive meaning; inverted on the wire), `acknowledge_request`, `confirm_error`, `hop_count` - which replaces the removed `CEMILData.hops` property - and the received `frame_type` / `frame_format`. Frame Type and Address Type are derived when serializing, from the NPDU length and from the type of the destination address (`CEMILData.address_type`), so `flags` can no longer disagree with the frame that is put on the wire. `CEMILData(flags=...)` is optional now. The bit constants moved from `CEMIFlags` to `xknx.cemi.flags`.
+- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` and `frame_format: CEMIFrameFormat` instead of `frame_flags: int`. Only those two fields of Ctrl2 ever reached the CCM input; the value on the wire and the one fed to the MAC now come from the same place.
 - `RequestResponse` is now generic over the response body it awaits, eg. `class Connect(RequestResponse[ConnectResponse])`. `start()` gives way to `request()`, which returns that response instead of leaving it on the instance, and raises the new `RequestResponseError` when none arrived or the server answered with an error status.
 - `DescriptionQuery` and `SearchExtendedQuery` derive from `RequestResponse` now. Their `start()` and `gateway_descriptor` attribute are replaced by `request_gateway_descriptor()`.
 - `Telegram` is now generic over its `payload` type (`Telegram[GroupValueWrite]`, etc.), defaulting to `Telegram` behaving exactly as before when left unparametrized - `payload` is `None` only for that default/unparametrized case (control telegrams like ACK/Disconnect); parametrized as `Telegram[SomeAPCI]`, `payload` is `SomeAPCI`, never `None`. `Device.process()` now hands `process_group_write()`/`process_group_response()`/`process_group_read()` a `Telegram` narrowed to the APCI type it already verified via `isinstance`, propagated through `RemoteValue.process()` and every device's `process_group_*` override. No behavior change - `RemoteValue.process()` keeps its own `isinstance` check since, unlike the management case below, nothing enforces the payload type before it's called directly.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,11 +18,12 @@ nav_order: 2
   - `acknowledge_request: bool`
   - `confirm_error: bool` - only meaningful in an L_Data.con frame
   - `hop_count: int` - replaces the `CEMILData.hops` property, which was removed
-  - `frame_type: CEMIFrameType` and `frame_format: CEMIFrameFormat` - informational; they hold what was received and are ignored when serializing
+  - `frame_type: CEMIFrameType` - informational; holds what was received and is ignored when serializing
+  - `frame_format: CEMIFrameFormat` - the Extended Frame Format, serialized as held; `STANDARD` for every frame xknx supports
   The Frame Type of an outgoing frame is derived from its NPDU length and the Address Type from the type of the destination address (`CEMILData.address_type`), so neither can disagree with the frame that is put on the wire. `CEMIFrameType` and the new `CEMIAddressType` place their own bit via `to_knx()` / `from_knx()`; `CEMILData` composes the control field as `flags.to_knx() | frame_type.to_knx() | address_type.to_knx()`. Ctrl1 and Ctrl2 are handled as one 16 bit int, so `CEMIFlags.to_knx()` returns an `int` and `CEMIFlags.from_knx()` takes one. The remaining bit masks moved to `xknx.cemi.flags` as module level constants.
 - `CEMIFlags` has a compact `__str__` used in `CEMILData.__repr__` - eg. `LOW STANDARD hop_count=6`, listing only the boolean flags that are set. The full dataclass `__repr__` shows every field.
 - `CEMILData(flags=...)` is optional now and defaults to `CEMIFlags()` - low priority, hop count 6, no acknowledge request.
-- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` instead of `frame_flags: int`. Only the Address Type bit of Ctrl2 ever reached the CCM input, so the B0 flags octet is `address_type.to_knx()` and `B0_AT_FIELD_FLAGS_MASK` is gone.
+- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` and `frame_format: CEMIFrameFormat` instead of `frame_flags: int`. Only those two fields of Ctrl2 ever reached the CCM input, so the B0 flags octet is `address_type.to_knx() | frame_format` and `B0_AT_FIELD_FLAGS_MASK` is gone.
 
 ### Connection
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,10 +19,10 @@ nav_order: 2
   - `confirm_error: bool` - only meaningful in an L_Data.con frame
   - `hop_count: int` - replaces the `CEMILData.hops` property, which was removed
   - `frame_type: CEMIFrameType` and `frame_format: CEMIFrameFormat` - informational; they hold what was received and are ignored when serializing
-  The Frame Type of an outgoing frame is derived from its NPDU length and the Address Type from the type of the destination address (also available as `CEMILData.dst_is_group_address`), so neither can disagree with the frame that is put on the wire. The raw bit masks moved to `xknx.cemi.flags` as module level constants.
+  The Frame Type of an outgoing frame is derived from its NPDU length and the Address Type from the type of the destination address (`CEMILData.address_type`), so neither can disagree with the frame that is put on the wire. `CEMIFrameType` and the new `CEMIAddressType` place their own bit via `to_knx()` / `from_knx()`; `CEMILData` composes the control field as `flags.to_knx() | frame_type.to_knx() | address_type.to_knx()`. Ctrl1 and Ctrl2 are handled as one 16 bit int, so `CEMIFlags.to_knx()` returns an `int` and `CEMIFlags.from_knx()` takes one. The remaining bit masks moved to `xknx.cemi.flags` as module level constants.
 - `CEMIFlags` has a compact `__str__` used in `CEMILData.__repr__` - eg. `LOW STANDARD hop_count=6`, listing only the boolean flags that are set. The full dataclass `__repr__` shows every field.
 - `CEMILData(flags=...)` is optional now and defaults to `CEMIFlags()` - low priority, hop count 6, no acknowledge request.
-- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `dst_is_group_address: bool` instead of `frame_flags: int`. Only the Address Type bit of Ctrl2 ever reached the CCM input; passing it explicitly removes the mask.
+- `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` instead of `frame_flags: int`. Only the Address Type bit of Ctrl2 ever reached the CCM input, so the B0 flags octet is `address_type.to_knx()` and `B0_AT_FIELD_FLAGS_MASK` is gone.
 
 ### Connection
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,7 +18,9 @@ nav_order: 2
   - `acknowledge_request: bool`
   - `confirm_error: bool` - only meaningful in an L_Data.con frame
   - `hop_count: int` - replaces the `CEMILData.hops` property, which was removed
-  Frame Type, Address Type and Extended Frame Format are no longer stored: they follow from the NPDU length, the destination address type and the supported frame formats, and are derived when serializing. `flags` therefore can no longer disagree with the frame that is put on the wire. The raw bit masks moved to `xknx.cemi.flags` as module level constants.
+  - `frame_type: CEMIFrameType` and `frame_format: CEMIFrameFormat` - informational; they hold what was received and are ignored when serializing
+  The Frame Type of an outgoing frame is derived from its NPDU length and the Address Type from the type of the destination address (also available as `CEMILData.dst_is_group_address`), so neither can disagree with the frame that is put on the wire. The raw bit masks moved to `xknx.cemi.flags` as module level constants.
+- `CEMIFlags` has a compact `__str__` used in `CEMILData.__repr__` - eg. `LOW STANDARD hop_count=6`, listing only the boolean flags that are set. The full dataclass `__repr__` shows every field.
 - `CEMILData(flags=...)` is optional now and defaults to `CEMIFlags()` - low priority, hop count 6, no acknowledge request.
 - `xknx.secure.data_secure_asdu.block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `dst_is_group_address: bool` instead of `frame_flags: int`. Only the Address Type bit of Ctrl2 ever reached the CCM input; passing it explicitly removes the mask.
 
@@ -81,8 +83,8 @@ nav_order: 2
 
 ### Protocol
 
-- Reject incoming CEMI L_Data frames with a non-zero Extended Frame Format field with `UnsupportedCEMIMessage`. LTE-HEE frames use zone addressing, so their address fields can not be parsed as `GroupAddress`. The Frame Type flag is still not validated against the NPDU length when parsing - a receiver shall be tolerant towards the used frame format.
-- `CEMIFlags.EXTENDED_FRAME_FORMAT` was removed; its value `0x0001` was reserved, not an "extended frame format" indicator - `0x0000` is used for standard frames as well as for long extended frames. `LTE_FRAME_FORMAT` and `EXTENDED_FRAME_FORMAT_MASK` were added instead.
+- Reject incoming CEMI L_Data frames with a non-standard Extended Frame Format field with `UnsupportedCEMIMessage`. LTE-HEE frames use zone addressing, so their address fields can not be parsed as `GroupAddress`; reserved encodings are rejected too. The Frame Type flag is still not validated against the NPDU length when parsing - a receiver shall be tolerant towards the used frame format.
+- `CEMIFlags.EXTENDED_FRAME_FORMAT` was removed; its value `0x0001` was reserved, not an "extended frame format" indicator - `0x0000` is used for standard frames as well as for long extended frames. The `CEMIFrameFormat` enum covers the field instead, resolving the whole `01xxb` range to `LTE_HEE`.
 - The hop count is validated when serializing; a value outside `0..7` raises `ConversionError` instead of silently corrupting Ctrl2.
 - Add explicit length checks to every remaining APCI `from_knx` (and the top-level `APCI.from_knx` dispatcher) as defense-in-depth on top of the broad `except (IndexError, struct.error, ValueError)` added in 3.17.0: each service now raises `ConversionError` with a specific "Invalid length for A_X in CEMI" message for a truncated, malformed or overlong frame instead of relying solely on the generic dispatcher-level catch.
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -14,11 +14,7 @@ from xknx.cemi import (
     CEMIPriority,
 )
 from xknx.cemi.const import CEMIErrorCode
-from xknx.cemi.flags import (
-    DESTINATION_GROUP_ADDRESS,
-    FRAME_TYPE_STANDARD,
-    LTE_FRAME_FORMAT,
-)
+from xknx.cemi.flags import DESTINATION_GROUP_ADDRESS, FRAME_TYPE_STANDARD
 from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError, CouldNotParseCEMI, UnsupportedCEMIMessage
 from xknx.profile.const import ResourceKNXNETIPPropertyId, ResourceObjectType
@@ -365,21 +361,30 @@ def test_npdu_length_exceeded() -> None:
         _cemi_l_data_from_payload(GroupValueWrite(DPTArray(bytes(254))))
 
 
-def test_extended_frame_format_not_supported() -> None:
+@pytest.mark.parametrize(
+    "eff,err_msg",
+    [
+        # 01xxb - LTE-HEE zone addressed frames
+        (0b0100, r".*Extended Frame Format not supported: LTE_HEE.*"),
+        (0b0111, r".*Extended Frame Format not supported: LTE_HEE.*"),
+        # reserved
+        (0b0001, r".*Reserved Extended Frame Format: 0b0001.*"),
+        (0b1111, r".*Reserved Extended Frame Format: 0b1111.*"),
+    ],
+)
+def test_extended_frame_format_not_supported(eff: int, err_msg: str) -> None:
     """Test parsing of LTE-HEE and reserved Extended Frame Formats."""
     raw = get_data(
         0x29,
         0,
-        (DESTINATION_GROUP_ADDRESS | LTE_FRAME_FORMAT),  # Ctrl2; Ctrl1 = extended
+        (DESTINATION_GROUP_ADDRESS | eff),  # Ctrl2; Ctrl1 = extended frame
         1,
         1,
         1,
         0,
         [],
     )
-    with pytest.raises(
-        UnsupportedCEMIMessage, match=r".*Extended Frame Format not supported.*"
-    ):
+    with pytest.raises(UnsupportedCEMIMessage, match=err_msg):
         CEMIFrame.from_knx(raw)
 
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -11,8 +11,14 @@ from xknx.cemi import (
     CEMIMPropReadResponse,
     CEMIMPropWriteRequest,
     CEMIMPropWriteResponse,
+    CEMIPriority,
 )
 from xknx.cemi.const import CEMIErrorCode
+from xknx.cemi.flags import (
+    DESTINATION_GROUP_ADDRESS,
+    FRAME_TYPE_STANDARD,
+    LTE_FRAME_FORMAT,
+)
 from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError, CouldNotParseCEMI, UnsupportedCEMIMessage
 from xknx.profile.const import ResourceKNXNETIPPropertyId, ResourceObjectType
@@ -56,8 +62,12 @@ def test_valid_command() -> None:
     frame = CEMIFrame.from_knx(raw)
     assert frame.code == CEMIMessageCode.L_DATA_IND
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags == 0x8080
-    assert frame.data.hops == 0
+    assert frame.data.flags == CEMIFlags(
+        priority=CEMIPriority.SYSTEM,
+        repeat_on_error=True,
+        system_broadcast=True,
+        hop_count=0,
+    )
     assert frame.data.src_addr == IndividualAddress(1)
     assert frame.data.dst_addr == GroupAddress(1)
     assert frame.data.payload == GroupValueRead()
@@ -72,8 +82,12 @@ def test_valid_tpci_control() -> None:
     frame = CEMIFrame.from_knx(raw)
     assert frame.code == CEMIMessageCode.L_DATA_IND
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags == 0x8000
-    assert frame.data.hops == 0
+    assert frame.data.flags == CEMIFlags(
+        priority=CEMIPriority.SYSTEM,
+        repeat_on_error=True,
+        system_broadcast=True,
+        hop_count=0,
+    )
     assert frame.data.payload is None
     assert frame.data.src_addr == IndividualAddress(0)
     assert frame.data.dst_addr == IndividualAddress(0)
@@ -182,7 +196,6 @@ def test_invalid_payload() -> None:
     frame = CEMIFrame(
         code=CEMIMessageCode.L_DATA_IND,
         data=CEMILData(
-            flags=0,
             src_addr=IndividualAddress(0),
             dst_addr=IndividualAddress(0),
             tpci=TDataGroup(),
@@ -257,8 +270,8 @@ def test_telegram_group_address() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_GROUP_ADDRESS
-    assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_LOW
+    assert frame.data.dst_is_group_address
+    assert frame.data.flags == CEMIFlags(priority=CEMIPriority.LOW)
     # test CEMIFrame.telegram property
     assert frame.data.telegram() == _telegram
 
@@ -271,8 +284,8 @@ def test_telegram_broadcast() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_GROUP_ADDRESS
-    assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_SYSTEM
+    assert frame.data.dst_is_group_address
+    assert frame.data.flags == CEMIFlags(priority=CEMIPriority.SYSTEM)
     assert frame.data.tpci == TDataBroadcast()
     # test CEMIFrame.telegram property
     assert frame.data.telegram() == _telegram
@@ -286,9 +299,9 @@ def test_telegram_individual_address() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.flags & 0x0080 == CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS
-    assert frame.data.flags & 0x0C00 == CEMIFlags.PRIORITY_SYSTEM
-    assert frame.data.flags & 0x0200 == CEMIFlags.NO_ACK_REQUESTED
+    assert not frame.data.dst_is_group_address
+    assert frame.data.flags == CEMIFlags(priority=CEMIPriority.SYSTEM)
+    assert not frame.data.flags.acknowledge_request
     # test CEMIFrame.telegram property
     assert frame.data.telegram() == _telegram
 
@@ -311,45 +324,39 @@ def _cemi_l_data_from_payload(payload: GroupValueWrite) -> bytes:
 
 
 @pytest.mark.parametrize(
-    "apdu_payload_length,expected_npdu_len,expected_frame_type",
+    "apdu_payload_length,expected_npdu_len,expected_standard_frame",
     [
-        (1, 2, CEMIFlags.FRAME_TYPE_STANDARD),
+        (1, 2, True),
         # 15 octets after the TPCI octet is the maximum of a standard frame
-        (14, 15, CEMIFlags.FRAME_TYPE_STANDARD),
-        (15, 16, CEMIFlags.FRAME_TYPE_EXTENDED),
-        (253, 254, CEMIFlags.FRAME_TYPE_EXTENDED),
+        (14, 15, True),
+        (15, 16, False),
+        (253, 254, False),
     ],
 )
 def test_frame_type_from_npdu_length(
-    apdu_payload_length: int, expected_npdu_len: int, expected_frame_type: int
+    apdu_payload_length: int, expected_npdu_len: int, expected_standard_frame: bool
 ) -> None:
     """Test Frame Type flag is derived from the NPDU length."""
     raw = _cemi_l_data_from_payload(
         GroupValueWrite(DPTArray(bytes(apdu_payload_length)))
     )
     assert raw[6] == expected_npdu_len
-    assert (raw[0] << 8) & CEMIFlags.FRAME_TYPE_STANDARD == expected_frame_type
+    assert bool(raw[0] & FRAME_TYPE_STANDARD) is expected_standard_frame
 
 
-def test_frame_type_overrides_flags() -> None:
-    """Test Frame Type flag of `flags` is overridden by the payload length."""
-    long_payload = GroupValueWrite(DPTArray(bytes(15)))
-    short_payload = GroupValueWrite(DPTArray(bytes(1)))
+def test_frame_type_follows_payload() -> None:
+    """Test the Frame Type follows the current payload; it is not held by `flags`."""
     cemi_data = CEMILData(
-        # standard frame flag set although the payload requires an extended frame
-        flags=CEMIFlags.FRAME_TYPE_STANDARD | CEMIFlags.DESTINATION_GROUP_ADDRESS,
         src_addr=IndividualAddress(1),
         dst_addr=GroupAddress(1),
         tpci=TDataGroup(),
-        payload=long_payload,
+        payload=GroupValueWrite(DPTArray(bytes(15))),
     )
-    assert not cemi_data.to_knx()[0] & 0x80
-    # `flags` is not modified by serialization
-    assert cemi_data.flags & CEMIFlags.FRAME_TYPE_STANDARD
+    assert not cemi_data.to_knx()[0] & FRAME_TYPE_STANDARD
 
-    cemi_data.flags = CEMIFlags.DESTINATION_GROUP_ADDRESS  # extended frame flag
-    cemi_data.payload = short_payload
-    assert cemi_data.to_knx()[0] & 0x80
+    # replacing the payload - as Data Secure does - changes the Frame Type
+    cemi_data.payload = GroupValueWrite(DPTArray(bytes(1)))
+    assert cemi_data.to_knx()[0] & FRAME_TYPE_STANDARD
 
 
 def test_npdu_length_exceeded() -> None:
@@ -363,9 +370,7 @@ def test_extended_frame_format_not_supported() -> None:
     raw = get_data(
         0x29,
         0,
-        CEMIFlags.FRAME_TYPE_EXTENDED
-        | CEMIFlags.DESTINATION_GROUP_ADDRESS
-        | CEMIFlags.LTE_FRAME_FORMAT,
+        (DESTINATION_GROUP_ADDRESS | LTE_FRAME_FORMAT),  # Ctrl2; Ctrl1 = extended
         1,
         1,
         1,

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -3,8 +3,10 @@
 import pytest
 
 from xknx.cemi import (
+    CEMIAddressType,
     CEMIFlags,
     CEMIFrame,
+    CEMIFrameType,
     CEMILData,
     CEMIMessageCode,
     CEMIMPropReadRequest,
@@ -14,7 +16,6 @@ from xknx.cemi import (
     CEMIPriority,
 )
 from xknx.cemi.const import CEMIErrorCode
-from xknx.cemi.flags import DESTINATION_GROUP_ADDRESS, FRAME_TYPE_STANDARD
 from xknx.dpt import DPTArray
 from xknx.exceptions import ConversionError, CouldNotParseCEMI, UnsupportedCEMIMessage
 from xknx.profile.const import ResourceKNXNETIPPropertyId, ResourceObjectType
@@ -266,7 +267,7 @@ def test_telegram_group_address() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.dst_is_group_address
+    assert frame.data.address_type is CEMIAddressType.GROUP
     assert frame.data.flags == CEMIFlags(priority=CEMIPriority.LOW)
     # test CEMIFrame.telegram property
     assert frame.data.telegram() == _telegram
@@ -280,7 +281,7 @@ def test_telegram_broadcast() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert frame.data.dst_is_group_address
+    assert frame.data.address_type is CEMIAddressType.GROUP
     assert frame.data.flags == CEMIFlags(priority=CEMIPriority.SYSTEM)
     assert frame.data.tpci == TDataBroadcast()
     # test CEMIFrame.telegram property
@@ -295,7 +296,7 @@ def test_telegram_individual_address() -> None:
         data=CEMILData.init_from_telegram(_telegram),
     )
     assert isinstance(frame.data, CEMILData)
-    assert not frame.data.dst_is_group_address
+    assert frame.data.address_type is CEMIAddressType.INDIVIDUAL
     assert frame.data.flags == CEMIFlags(priority=CEMIPriority.SYSTEM)
     assert not frame.data.flags.acknowledge_request
     # test CEMIFrame.telegram property
@@ -337,7 +338,9 @@ def test_frame_type_from_npdu_length(
         GroupValueWrite(DPTArray(bytes(apdu_payload_length)))
     )
     assert raw[6] == expected_npdu_len
-    assert bool(raw[0] & FRAME_TYPE_STANDARD) is expected_standard_frame
+    assert (
+        CEMIFrameType.from_knx(raw[0] << 8) is CEMIFrameType.STANDARD
+    ) is expected_standard_frame
 
 
 def test_frame_type_follows_payload() -> None:
@@ -348,11 +351,11 @@ def test_frame_type_follows_payload() -> None:
         tpci=TDataGroup(),
         payload=GroupValueWrite(DPTArray(bytes(15))),
     )
-    assert not cemi_data.to_knx()[0] & FRAME_TYPE_STANDARD
+    assert CEMIFrameType.from_knx(cemi_data.to_knx()[0] << 8) is CEMIFrameType.EXTENDED
 
     # replacing the payload - as Data Secure does - changes the Frame Type
     cemi_data.payload = GroupValueWrite(DPTArray(bytes(1)))
-    assert cemi_data.to_knx()[0] & FRAME_TYPE_STANDARD
+    assert CEMIFrameType.from_knx(cemi_data.to_knx()[0] << 8) is CEMIFrameType.STANDARD
 
 
 def test_npdu_length_exceeded() -> None:
@@ -377,7 +380,7 @@ def test_extended_frame_format_not_supported(eff: int, err_msg: str) -> None:
     raw = get_data(
         0x29,
         0,
-        (DESTINATION_GROUP_ADDRESS | eff),  # Ctrl2; Ctrl1 = extended frame
+        (CEMIAddressType.GROUP.to_knx() | eff),  # Ctrl2; Ctrl1 = extended frame
         1,
         1,
         1,

--- a/test/cemi_tests/flags_test.py
+++ b/test/cemi_tests/flags_test.py
@@ -130,6 +130,15 @@ def test_composition(
     assert raw == control_field(*expected)
 
 
+def test_to_knx_serializes_frame_format() -> None:
+    """Test the Extended Frame Format is serialized as held, not as a constant."""
+    # Data Secure protects the Extended Frame Format - `block_0()` reads the same
+    # field, so the value on the wire and the one fed to the MAC can not diverge.
+    flags = CEMIFlags(frame_format=CEMIFrameFormat.LTE_HEE)
+    assert flags.to_knx() & 0b1111 == CEMIFrameFormat.LTE_HEE
+    assert CEMIFlags().to_knx() & 0b1111 == CEMIFrameFormat.STANDARD
+
+
 def test_to_knx_ignores_received_frame_type() -> None:
     """Test the Frame Type of a received frame is not used when serializing."""
     flags = CEMIFlags.from_knx(control_field(0x3C, 0xE0))

--- a/test/cemi_tests/flags_test.py
+++ b/test/cemi_tests/flags_test.py
@@ -1,0 +1,99 @@
+"""Tests for the cEMI L_Data control fields."""
+
+import pytest
+
+from xknx.cemi import CEMIFlags, CEMIPriority
+from xknx.exceptions import ConversionError
+
+
+@pytest.mark.parametrize(
+    "raw,flags",
+    [
+        (
+            # Ctrl1 0xBC: standard frame, do not repeat, broadcast, low priority
+            # Ctrl2 0xE0: group address, hop count 6, standard frame format
+            bytes((0xBC, 0xE0)),
+            CEMIFlags(priority=CEMIPriority.LOW, hop_count=6),
+        ),
+        (
+            # Ctrl1 0x3C: extended frame - not evaluated when parsing
+            bytes((0x3C, 0xE0)),
+            CEMIFlags(priority=CEMIPriority.LOW, hop_count=6),
+        ),
+        (
+            # Ctrl1 0xB0: system priority; Ctrl2 0x60: individual address
+            bytes((0xB0, 0x60)),
+            CEMIFlags(priority=CEMIPriority.SYSTEM, hop_count=6),
+        ),
+        (
+            # every optional flag set: repeat on error, system broadcast,
+            # acknowledge requested, confirm error, urgent priority, hop count 7
+            bytes((0b1000_1011, 0b0111_0000)),
+            CEMIFlags(
+                priority=CEMIPriority.URGENT,
+                repeat_on_error=True,
+                system_broadcast=True,
+                acknowledge_request=True,
+                confirm_error=True,
+                hop_count=7,
+            ),
+        ),
+    ],
+)
+def test_from_knx(raw: bytes, flags: CEMIFlags) -> None:
+    """Test parsing of Ctrl1 and Ctrl2."""
+    assert CEMIFlags.from_knx(raw) == flags
+
+
+@pytest.mark.parametrize(
+    "priority,ctrl1",
+    [
+        (CEMIPriority.SYSTEM, 0b1011_0000),
+        (CEMIPriority.NORMAL, 0b1011_0100),
+        (CEMIPriority.URGENT, 0b1011_1000),
+        (CEMIPriority.LOW, 0b1011_1100),
+    ],
+)
+def test_priority_to_knx(priority: CEMIPriority, ctrl1: int) -> None:
+    """Test priority encoding - 3/2/2 §2.2.2 Figure 28."""
+    raw = CEMIFlags(priority=priority).to_knx(
+        frame_type_standard=True, dst_is_group_address=False
+    )
+    assert raw[0] == ctrl1
+
+
+def test_to_knx_derived_fields() -> None:
+    """Test Frame Type and Address Type are supplied by the frame, not by `flags`."""
+    flags = CEMIFlags()
+    assert flags.to_knx(frame_type_standard=True, dst_is_group_address=True) == bytes(
+        (0xBC, 0xE0)
+    )
+    assert flags.to_knx(frame_type_standard=False, dst_is_group_address=True) == bytes(
+        (0x3C, 0xE0)
+    )
+    assert flags.to_knx(frame_type_standard=True, dst_is_group_address=False) == bytes(
+        (0xBC, 0x60)
+    )
+
+
+def test_round_trip() -> None:
+    """Test parsing and serializing yields the same octets."""
+    for ctrl1 in (0xBC, 0xB0, 0x9C, 0xBF):
+        for ctrl2 in (0xE0, 0x60, 0xF0, 0x00):
+            raw = bytes((ctrl1, ctrl2))
+            flags = CEMIFlags.from_knx(raw)
+            assert (
+                flags.to_knx(
+                    frame_type_standard=bool(ctrl1 & 0x80),
+                    dst_is_group_address=bool(ctrl2 & 0x80),
+                )
+                == raw
+            )
+
+
+@pytest.mark.parametrize("hop_count", [-1, 8, 255])
+def test_invalid_hop_count(hop_count: int) -> None:
+    """Test hop count out of range."""
+    flags = CEMIFlags(hop_count=hop_count)
+    with pytest.raises(ConversionError, match=r".*Hop count out of range.*"):
+        flags.to_knx(frame_type_standard=True, dst_is_group_address=True)

--- a/test/cemi_tests/flags_test.py
+++ b/test/cemi_tests/flags_test.py
@@ -2,22 +2,35 @@
 
 import pytest
 
-from xknx.cemi import CEMIFlags, CEMIFrameFormat, CEMIFrameType, CEMIPriority
+from xknx.cemi import (
+    CEMIAddressType,
+    CEMIFlags,
+    CEMIFrameFormat,
+    CEMIFrameType,
+    CEMIPriority,
+)
 from xknx.exceptions import ConversionError
 
 
+def control_field(ctrl1: int, ctrl2: int) -> int:
+    """Return Ctrl1 and Ctrl2 as one 16 bit control field."""
+    return ctrl1 << 8 | ctrl2
+
+
 @pytest.mark.parametrize(
-    "raw,flags",
+    "ctrl1,ctrl2,flags",
     [
         (
             # Ctrl1 0xBC: standard frame, do not repeat, broadcast, low priority
             # Ctrl2 0xE0: group address, hop count 6, standard frame format
-            bytes((0xBC, 0xE0)),
+            0xBC,
+            0xE0,
             CEMIFlags(priority=CEMIPriority.LOW, hop_count=6),
         ),
         (
             # Ctrl1 0x3C: extended frame - kept, but not evaluated
-            bytes((0x3C, 0xE0)),
+            0x3C,
+            0xE0,
             CEMIFlags(
                 priority=CEMIPriority.LOW,
                 hop_count=6,
@@ -26,13 +39,15 @@ from xknx.exceptions import ConversionError
         ),
         (
             # Ctrl1 0xB0: system priority; Ctrl2 0x60: individual address
-            bytes((0xB0, 0x60)),
+            0xB0,
+            0x60,
             CEMIFlags(priority=CEMIPriority.SYSTEM, hop_count=6),
         ),
         (
             # every optional flag set: repeat on error, system broadcast,
             # acknowledge requested, confirm error, urgent priority, hop count 7
-            bytes((0b1000_1011, 0b0111_0000)),
+            0b1000_1011,
+            0b0111_0000,
             CEMIFlags(
                 priority=CEMIPriority.URGENT,
                 repeat_on_error=True,
@@ -44,9 +59,9 @@ from xknx.exceptions import ConversionError
         ),
     ],
 )
-def test_from_knx(raw: bytes, flags: CEMIFlags) -> None:
-    """Test parsing of Ctrl1 and Ctrl2."""
-    assert CEMIFlags.from_knx(raw) == flags
+def test_from_knx(ctrl1: int, ctrl2: int, flags: CEMIFlags) -> None:
+    """Test parsing of the control field."""
+    assert CEMIFlags.from_knx(control_field(ctrl1, ctrl2)) == flags
 
 
 @pytest.mark.parametrize(
@@ -62,84 +77,96 @@ def test_from_knx(raw: bytes, flags: CEMIFlags) -> None:
 )
 def test_frame_format_from_knx(eff: int, frame_format: CEMIFrameFormat) -> None:
     """Test parsing of the Extended Frame Format field."""
-    assert CEMIFlags.from_knx(bytes((0xBC, 0xE0 | eff))).frame_format is frame_format
+    flags = CEMIFlags.from_knx(control_field(0xBC, 0xE0 | eff))
+    assert flags.frame_format is frame_format
 
 
 @pytest.mark.parametrize("eff", [0b0001, 0b0010, 0b0011, 0b1000, 0b1100, 0b1111])
 def test_reserved_frame_format(eff: int) -> None:
     """Test parsing of a reserved Extended Frame Format."""
     with pytest.raises(ConversionError, match=r".*Reserved Extended Frame Format.*"):
-        CEMIFlags.from_knx(bytes((0xBC, 0xE0 | eff)))
+        CEMIFlags.from_knx(control_field(0xBC, 0xE0 | eff))
 
 
 @pytest.mark.parametrize(
     "priority,ctrl1",
     [
-        (CEMIPriority.SYSTEM, 0b1011_0000),
-        (CEMIPriority.NORMAL, 0b1011_0100),
-        (CEMIPriority.URGENT, 0b1011_1000),
-        (CEMIPriority.LOW, 0b1011_1100),
+        (CEMIPriority.SYSTEM, 0b0011_0000),
+        (CEMIPriority.NORMAL, 0b0011_0100),
+        (CEMIPriority.URGENT, 0b0011_1000),
+        (CEMIPriority.LOW, 0b0011_1100),
     ],
 )
 def test_priority_to_knx(priority: CEMIPriority, ctrl1: int) -> None:
     """Test priority encoding - 3/2/2 §2.2.2 Figure 28."""
-    raw = CEMIFlags(priority=priority).to_knx(
-        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=False
-    )
-    assert raw[0] == ctrl1
+    # the Frame Type bit is not set by `CEMIFlags.to_knx()`
+    assert CEMIFlags(priority=priority).to_knx() >> 8 == ctrl1
 
 
-def test_to_knx_derived_fields() -> None:
-    """Test Frame Type and Address Type are supplied by the frame, not by `flags`."""
-    flags = CEMIFlags()
-    assert flags.to_knx(
-        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True
-    ) == bytes((0xBC, 0xE0))
-    assert flags.to_knx(
-        frame_type=CEMIFrameType.EXTENDED, dst_is_group_address=True
-    ) == bytes((0x3C, 0xE0))
-    assert flags.to_knx(
-        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=False
-    ) == bytes((0xBC, 0x60))
+def test_to_knx_leaves_derived_bits_clear() -> None:
+    """Test Frame Type and Address Type are not set by `CEMIFlags.to_knx()`."""
+    raw = CEMIFlags().to_knx()
+    assert raw == control_field(0b0011_1100, 0b0110_0000)
+    assert CEMIFrameType.from_knx(raw) is CEMIFrameType.EXTENDED  # ie. bit not set
+    assert CEMIAddressType.from_knx(raw) is CEMIAddressType.INDIVIDUAL
+
+
+@pytest.mark.parametrize(
+    "frame_type,address_type,expected",
+    [
+        (CEMIFrameType.STANDARD, CEMIAddressType.GROUP, (0xBC, 0xE0)),
+        (CEMIFrameType.EXTENDED, CEMIAddressType.GROUP, (0x3C, 0xE0)),
+        (CEMIFrameType.STANDARD, CEMIAddressType.INDIVIDUAL, (0xBC, 0x60)),
+        (CEMIFrameType.EXTENDED, CEMIAddressType.INDIVIDUAL, (0x3C, 0x60)),
+    ],
+)
+def test_composition(
+    frame_type: CEMIFrameType,
+    address_type: CEMIAddressType,
+    expected: tuple[int, int],
+) -> None:
+    """Test the frame ORs the derived bits into the flags."""
+    raw = CEMIFlags().to_knx() | frame_type.to_knx() | address_type.to_knx()
+    assert raw == control_field(*expected)
 
 
 def test_to_knx_ignores_received_frame_type() -> None:
     """Test the Frame Type of a received frame is not used when serializing."""
-    flags = CEMIFlags.from_knx(bytes((0x3C, 0xE0)))
+    flags = CEMIFlags.from_knx(control_field(0x3C, 0xE0))
     assert flags.frame_type is CEMIFrameType.EXTENDED
-    assert flags.to_knx(
-        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True
-    ) == bytes((0xBC, 0xE0))
+    raw = (
+        flags.to_knx()
+        | CEMIFrameType.STANDARD.to_knx()
+        | CEMIAddressType.GROUP.to_knx()
+    )
+    assert raw == control_field(0xBC, 0xE0)
 
 
 def test_round_trip() -> None:
-    """Test parsing and serializing yields the same octets."""
+    """Test parsing and serializing yields the same control field."""
     for ctrl1 in (0xBC, 0xB0, 0x9C, 0xBF, 0x3C):
         for ctrl2 in (0xE0, 0x60, 0xF0, 0x00):
-            raw = bytes((ctrl1, ctrl2))
+            raw = control_field(ctrl1, ctrl2)
             flags = CEMIFlags.from_knx(raw)
             assert (
-                flags.to_knx(
-                    frame_type=flags.frame_type,
-                    dst_is_group_address=bool(ctrl2 & 0x80),
-                )
-                == raw
-            )
+                flags.to_knx()
+                | flags.frame_type.to_knx()
+                | CEMIAddressType.from_knx(raw).to_knx()
+            ) == raw
 
 
 @pytest.mark.parametrize("hop_count", [-1, 8, 255])
 def test_invalid_hop_count(hop_count: int) -> None:
     """Test hop count out of range."""
-    flags = CEMIFlags(hop_count=hop_count)
     with pytest.raises(ConversionError, match=r".*Hop count out of range.*"):
-        flags.to_knx(frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True)
+        CEMIFlags(hop_count=hop_count).to_knx()
 
 
 def test_str() -> None:
     """Test the compact string representation only lists flags that are set."""
     assert str(CEMIFlags()) == "LOW STANDARD hop_count=6"
     assert (
-        str(CEMIFlags.from_knx(bytes((0b1000_1011, 0b0111_0000))))
+        str(CEMIFlags.from_knx(control_field(0b1000_1011, 0b0111_0000)))
         == "URGENT STANDARD hop_count=7 repeat_on_error system_broadcast "
         "acknowledge_request confirm_error"
     )

--- a/test/cemi_tests/flags_test.py
+++ b/test/cemi_tests/flags_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from xknx.cemi import CEMIFlags, CEMIPriority
+from xknx.cemi import CEMIFlags, CEMIFrameFormat, CEMIFrameType, CEMIPriority
 from xknx.exceptions import ConversionError
 
 
@@ -16,9 +16,13 @@ from xknx.exceptions import ConversionError
             CEMIFlags(priority=CEMIPriority.LOW, hop_count=6),
         ),
         (
-            # Ctrl1 0x3C: extended frame - not evaluated when parsing
+            # Ctrl1 0x3C: extended frame - kept, but not evaluated
             bytes((0x3C, 0xE0)),
-            CEMIFlags(priority=CEMIPriority.LOW, hop_count=6),
+            CEMIFlags(
+                priority=CEMIPriority.LOW,
+                hop_count=6,
+                frame_type=CEMIFrameType.EXTENDED,
+            ),
         ),
         (
             # Ctrl1 0xB0: system priority; Ctrl2 0x60: individual address
@@ -46,6 +50,29 @@ def test_from_knx(raw: bytes, flags: CEMIFlags) -> None:
 
 
 @pytest.mark.parametrize(
+    "eff,frame_format",
+    [
+        (0b0000, CEMIFrameFormat.STANDARD),
+        # the whole 01xxb range is LTE-HEE; the 2 lsb are the LTE address type
+        (0b0100, CEMIFrameFormat.LTE_HEE),
+        (0b0101, CEMIFrameFormat.LTE_HEE),
+        (0b0110, CEMIFrameFormat.LTE_HEE),
+        (0b0111, CEMIFrameFormat.LTE_HEE),
+    ],
+)
+def test_frame_format_from_knx(eff: int, frame_format: CEMIFrameFormat) -> None:
+    """Test parsing of the Extended Frame Format field."""
+    assert CEMIFlags.from_knx(bytes((0xBC, 0xE0 | eff))).frame_format is frame_format
+
+
+@pytest.mark.parametrize("eff", [0b0001, 0b0010, 0b0011, 0b1000, 0b1100, 0b1111])
+def test_reserved_frame_format(eff: int) -> None:
+    """Test parsing of a reserved Extended Frame Format."""
+    with pytest.raises(ConversionError, match=r".*Reserved Extended Frame Format.*"):
+        CEMIFlags.from_knx(bytes((0xBC, 0xE0 | eff)))
+
+
+@pytest.mark.parametrize(
     "priority,ctrl1",
     [
         (CEMIPriority.SYSTEM, 0b1011_0000),
@@ -57,7 +84,7 @@ def test_from_knx(raw: bytes, flags: CEMIFlags) -> None:
 def test_priority_to_knx(priority: CEMIPriority, ctrl1: int) -> None:
     """Test priority encoding - 3/2/2 §2.2.2 Figure 28."""
     raw = CEMIFlags(priority=priority).to_knx(
-        frame_type_standard=True, dst_is_group_address=False
+        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=False
     )
     assert raw[0] == ctrl1
 
@@ -65,26 +92,35 @@ def test_priority_to_knx(priority: CEMIPriority, ctrl1: int) -> None:
 def test_to_knx_derived_fields() -> None:
     """Test Frame Type and Address Type are supplied by the frame, not by `flags`."""
     flags = CEMIFlags()
-    assert flags.to_knx(frame_type_standard=True, dst_is_group_address=True) == bytes(
-        (0xBC, 0xE0)
-    )
-    assert flags.to_knx(frame_type_standard=False, dst_is_group_address=True) == bytes(
-        (0x3C, 0xE0)
-    )
-    assert flags.to_knx(frame_type_standard=True, dst_is_group_address=False) == bytes(
-        (0xBC, 0x60)
-    )
+    assert flags.to_knx(
+        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True
+    ) == bytes((0xBC, 0xE0))
+    assert flags.to_knx(
+        frame_type=CEMIFrameType.EXTENDED, dst_is_group_address=True
+    ) == bytes((0x3C, 0xE0))
+    assert flags.to_knx(
+        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=False
+    ) == bytes((0xBC, 0x60))
+
+
+def test_to_knx_ignores_received_frame_type() -> None:
+    """Test the Frame Type of a received frame is not used when serializing."""
+    flags = CEMIFlags.from_knx(bytes((0x3C, 0xE0)))
+    assert flags.frame_type is CEMIFrameType.EXTENDED
+    assert flags.to_knx(
+        frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True
+    ) == bytes((0xBC, 0xE0))
 
 
 def test_round_trip() -> None:
     """Test parsing and serializing yields the same octets."""
-    for ctrl1 in (0xBC, 0xB0, 0x9C, 0xBF):
+    for ctrl1 in (0xBC, 0xB0, 0x9C, 0xBF, 0x3C):
         for ctrl2 in (0xE0, 0x60, 0xF0, 0x00):
             raw = bytes((ctrl1, ctrl2))
             flags = CEMIFlags.from_knx(raw)
             assert (
                 flags.to_knx(
-                    frame_type_standard=bool(ctrl1 & 0x80),
+                    frame_type=flags.frame_type,
                     dst_is_group_address=bool(ctrl2 & 0x80),
                 )
                 == raw
@@ -96,4 +132,14 @@ def test_invalid_hop_count(hop_count: int) -> None:
     """Test hop count out of range."""
     flags = CEMIFlags(hop_count=hop_count)
     with pytest.raises(ConversionError, match=r".*Hop count out of range.*"):
-        flags.to_knx(frame_type_standard=True, dst_is_group_address=True)
+        flags.to_knx(frame_type=CEMIFrameType.STANDARD, dst_is_group_address=True)
+
+
+def test_str() -> None:
+    """Test the compact string representation only lists flags that are set."""
+    assert str(CEMIFlags()) == "LOW STANDARD hop_count=6"
+    assert (
+        str(CEMIFlags.from_knx(bytes((0b1000_1011, 0b0111_0000))))
+        == "URGENT STANDARD hop_count=7 repeat_on_error system_broadcast "
+        "acknowledge_request confirm_error"
+    )

--- a/test/knxip_tests/routing_indication_test.py
+++ b/test/knxip_tests/routing_indication_test.py
@@ -44,7 +44,7 @@ class TestKNXIPRountingIndication:
             ),
         )
         assert isinstance(cemi.data, CEMILData)
-        cemi.data.hops = 5
+        cemi.data.flags.hop_count = 5
         routing_indication = RoutingIndication(raw_cemi=cemi.to_knx())
         knxipframe = KNXIPFrame.init_from_body(routing_indication)
 

--- a/test/secure_tests/data_secure_test.py
+++ b/test/secure_tests/data_secure_test.py
@@ -7,8 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
-from xknx.cemi.flags import FRAME_TYPE_STANDARD
+from xknx.cemi import CEMIFrame, CEMIFrameType, CEMILData, CEMIMessageCode
 from xknx.dpt import DPTArray
 from xknx.exceptions import DataSecureError
 from xknx.secure.data_secure import is_data_secure
@@ -483,7 +482,7 @@ class TestDataSecure:
         # 4 octet plain APDU + 12 octets Data Secure overhead doesn't fit in a
         # standard frame - it is serialized as L_Data_Extended frame
         assert outgoing_raw[6] == 16
-        assert not outgoing_raw[0] & FRAME_TYPE_STANDARD
+        assert CEMIFrameType.from_knx(outgoing_raw[0] << 8) is CEMIFrameType.EXTENDED
 
         # create new cemi to avoid mixed bytearray / byte parts
         incoming_cemi = CEMIFrame.from_knx(b"\x11\x00" + outgoing_raw)

--- a/test/secure_tests/data_secure_test.py
+++ b/test/secure_tests/data_secure_test.py
@@ -7,7 +7,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.cemi import CEMIFlags, CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
+from xknx.cemi.flags import FRAME_TYPE_STANDARD
 from xknx.dpt import DPTArray
 from xknx.exceptions import DataSecureError
 from xknx.secure.data_secure import is_data_secure
@@ -482,7 +483,7 @@ class TestDataSecure:
         # 4 octet plain APDU + 12 octets Data Secure overhead doesn't fit in a
         # standard frame - it is serialized as L_Data_Extended frame
         assert outgoing_raw[6] == 16
-        assert not outgoing_raw[0] & CEMIFlags.FRAME_TYPE_STANDARD >> 8
+        assert not outgoing_raw[0] & FRAME_TYPE_STANDARD
 
         # create new cemi to avoid mixed bytearray / byte parts
         incoming_cemi = CEMIFrame.from_knx(b"\x11\x00" + outgoing_raw)

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -735,7 +735,9 @@ class TestStringRepresentations:
         assert (
             str(cemi_frame)
             == '<CEMIFrame code="L_DATA_IND" info="CEMIInfo("")" data="CEMILData(src_addr="IndividualAddress("1.2.3")" '
-            'dst_addr="GroupAddress("1/2/5")" flags="1011110011100000" tpci="TDataGroup()" '
+            'dst_addr="GroupAddress("1/2/5")" flags="CEMIFlags(priority=LOW hop_count=6 '
+            "repeat_on_error=False system_broadcast=False acknowledge_request=False "
+            'confirm_error=False)" tpci="TDataGroup()" '
             'payload="<GroupValueWrite value="<DPTBinary value="7" />" />")" />'
         )
 

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -735,9 +735,8 @@ class TestStringRepresentations:
         assert (
             str(cemi_frame)
             == '<CEMIFrame code="L_DATA_IND" info="CEMIInfo("")" data="CEMILData(src_addr="IndividualAddress("1.2.3")" '
-            'dst_addr="GroupAddress("1/2/5")" flags="CEMIFlags(priority=LOW hop_count=6 '
-            "repeat_on_error=False system_broadcast=False acknowledge_request=False "
-            'confirm_error=False)" tpci="TDataGroup()" '
+            'dst_addr="GroupAddress("1/2/5")" flags="LOW STANDARD hop_count=6" '
+            'tpci="TDataGroup()" '
             'payload="<GroupValueWrite value="<DPTBinary value="7" />" />")" />'
         )
 

--- a/xknx/cemi/__init__.py
+++ b/xknx/cemi/__init__.py
@@ -12,4 +12,10 @@ from .cemi_frame import (
 )
 from .cemi_handler import CEMIHandler
 from .const import CEMIErrorCode, CEMIMessageCode
-from .flags import CEMIFlags, CEMIFrameFormat, CEMIFrameType, CEMIPriority
+from .flags import (
+    CEMIAddressType,
+    CEMIFlags,
+    CEMIFrameFormat,
+    CEMIFrameType,
+    CEMIPriority,
+)

--- a/xknx/cemi/__init__.py
+++ b/xknx/cemi/__init__.py
@@ -11,4 +11,5 @@ from .cemi_frame import (
     CEMIMPropWriteResponse,
 )
 from .cemi_handler import CEMIHandler
-from .const import CEMIErrorCode, CEMIFlags, CEMIMessageCode
+from .const import CEMIErrorCode, CEMIMessageCode
+from .flags import CEMIFlags, CEMIPriority

--- a/xknx/cemi/__init__.py
+++ b/xknx/cemi/__init__.py
@@ -12,4 +12,4 @@ from .cemi_frame import (
 )
 from .cemi_handler import CEMIHandler
 from .const import CEMIErrorCode, CEMIMessageCode
-from .flags import CEMIFlags, CEMIPriority
+from .flags import CEMIFlags, CEMIFrameFormat, CEMIFrameType, CEMIPriority

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -34,7 +34,7 @@ from .const import (
     CEMIMessageCode,
 )
 from .flags import (
-    DESTINATION_GROUP_ADDRESS,
+    CEMIAddressType,
     CEMIFlags,
     CEMIFrameFormat,
     CEMIFrameType,
@@ -123,9 +123,13 @@ class CEMILData(CEMIData):
         self.payload = payload
 
     @property
-    def dst_is_group_address(self) -> bool:
-        """Return True if the destination address is a group address."""
-        return isinstance(self.dst_addr, GroupAddress)
+    def address_type(self) -> CEMIAddressType:
+        """Return the Address Type of the destination address."""
+        return (
+            CEMIAddressType.GROUP
+            if isinstance(self.dst_addr, GroupAddress)
+            else CEMIAddressType.INDIVIDUAL
+        )
 
     def calculated_length(self) -> int:
         """Get length of KNX/IP body."""
@@ -195,15 +199,15 @@ class CEMILData(CEMIData):
         # frame shall not be used when a standard frame suffices - 3/2/2 §2.2.5.1.
         # Derived here instead of when the frame is created because the payload may
         # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
+        frame_type = (
+            CEMIFrameType.STANDARD
+            if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
+            else CEMIFrameType.EXTENDED
+        )
         return (
-            self.flags.to_knx(
-                frame_type=(
-                    CEMIFrameType.STANDARD
-                    if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
-                    else CEMIFrameType.EXTENDED
-                ),
-                dst_is_group_address=self.dst_is_group_address,
-            )
+            (
+                self.flags.to_knx() | frame_type.to_knx() | self.address_type.to_knx()
+            ).to_bytes(2, "big")
             + self.src_addr.to_knx()
             + self.dst_addr.to_knx()
             + npdu_len.to_bytes(1, "big")
@@ -221,8 +225,9 @@ class CEMILData(CEMIData):
         src_addr = IndividualAddress.from_knx(raw[2:4])
 
         # Control field 1 and Control field 2 - first 2 octets
+        _control_field = int.from_bytes(raw[0:2], "big")
         try:
-            flags = CEMIFlags.from_knx(raw[0:2])
+            flags = CEMIFlags.from_knx(_control_field)
         except ConversionError as err:
             raise UnsupportedCEMIMessage(
                 f"{err} from {src_addr} in CEMI: {raw.hex()}"
@@ -240,7 +245,9 @@ class CEMILData(CEMIData):
                 f"from {src_addr} in CEMI: {raw.hex()}"
             )
 
-        _dst_is_group_address = bool(raw[1] & DESTINATION_GROUP_ADDRESS)
+        _dst_is_group_address = (
+            CEMIAddressType.from_knx(_control_field) is CEMIAddressType.GROUP
+        )
         dst_addr: GroupAddress | IndividualAddress = (
             GroupAddress.from_knx(raw[4:6])
             if _dst_is_group_address

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -35,8 +35,9 @@ from .const import (
 )
 from .flags import (
     DESTINATION_GROUP_ADDRESS,
-    EXTENDED_FRAME_FORMAT_MASK,
     CEMIFlags,
+    CEMIFrameFormat,
+    CEMIFrameType,
     CEMIPriority,
 )
 
@@ -196,7 +197,11 @@ class CEMILData(CEMIData):
         # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
         return (
             self.flags.to_knx(
-                frame_type_standard=npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH,
+                frame_type=(
+                    CEMIFrameType.STANDARD
+                    if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
+                    else CEMIFrameType.EXTENDED
+                ),
                 dst_is_group_address=self.dst_is_group_address,
             )
             + self.src_addr.to_knx()
@@ -213,20 +218,25 @@ class CEMILData(CEMIData):
                 f"CEMI too small. Length: {len(raw)}; CEMI: {raw.hex()}"
             )
 
-        # Control field 1 and Control field 2 - first 2 octets
-        flags = CEMIFlags.from_knx(raw[0:2])
-
         src_addr = IndividualAddress.from_knx(raw[2:4])
 
-        # The Extended Frame Format defines how the address fields are to be
-        # interpreted - 3/2/2 §2.2.5.3. Only 0000b (standard and long frames) is
-        # supported; 01xxb are LTE-HEE zone addressed frames, the rest is reserved.
-        # The Frame Type flag itself is deliberately not validated against the NPDU
-        # length: "any receiver shall be tolerant towards the use of the Frame
-        # Format" - 3/6/3 §4.1.5.2.3.
-        if _eff := raw[1] & EXTENDED_FRAME_FORMAT_MASK:
+        # Control field 1 and Control field 2 - first 2 octets
+        try:
+            flags = CEMIFlags.from_knx(raw[0:2])
+        except ConversionError as err:
             raise UnsupportedCEMIMessage(
-                f"Extended Frame Format not supported: {_eff:#06b} "
+                f"{err} from {src_addr} in CEMI: {raw.hex()}"
+            ) from err
+
+        # The Extended Frame Format defines how the address fields are to be
+        # interpreted - 3/2/2 §2.2.5.3. Only STANDARD (standard and long frames) is
+        # supported; LTE-HEE frames are zone addressed. The Frame Type is kept as
+        # received but deliberately not validated against the NPDU length: "any
+        # receiver shall be tolerant towards the use of the Frame Format"
+        # - 3/6/3 §4.1.5.2.3.
+        if flags.frame_format is not CEMIFrameFormat.STANDARD:
+            raise UnsupportedCEMIMessage(
+                f"Extended Frame Format not supported: {flags.frame_format.name} "
                 f"from {src_addr} in CEMI: {raw.hex()}"
             )
 
@@ -310,7 +320,7 @@ class CEMILData(CEMIData):
             "CEMILData("
             f'src_addr="{self.src_addr.__repr__()}" '
             f'dst_addr="{self.dst_addr.__repr__()}" '
-            f'flags="{self.flags!r}" '
+            f'flags="{self.flags}" '
             f'tpci="{self.tpci}" '
             f'payload="{self.payload}")'
         )

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -31,8 +31,13 @@ from .const import (
     MAX_NPDU_LENGTH,
     STANDARD_FRAME_MAX_NPDU_LENGTH,
     CEMIErrorCode,
-    CEMIFlags,
     CEMIMessageCode,
+)
+from .flags import (
+    DESTINATION_GROUP_ADDRESS,
+    EXTENDED_FRAME_FORMAT_MASK,
+    CEMIFlags,
+    CEMIPriority,
 )
 
 
@@ -103,31 +108,23 @@ class CEMILData(CEMIData):
     def __init__(
         self,
         *,
-        flags: int,
+        flags: CEMIFlags | None = None,
         src_addr: IndividualAddress,
         dst_addr: GroupAddress | IndividualAddress,
         tpci: TPCI,
         payload: APCI | None,
     ) -> None:
         """Initialize CEMILData object."""
-        self.flags = flags
+        self.flags = flags if flags is not None else CEMIFlags()
         self.src_addr = src_addr
         self.dst_addr = dst_addr
         self.tpci = tpci
         self.payload = payload
 
     @property
-    def hops(self) -> int:
-        """Return hops."""
-        return (self.flags & 0x0070) >> 4
-
-    @hops.setter
-    def hops(self, val: int) -> None:
-        """Set hops."""
-        # Resetting hops
-        self.flags &= 0xFFFF ^ 0x0070
-        # Setting new hops
-        self.flags |= val << 4
+    def dst_is_group_address(self) -> bool:
+        """Return True if the destination address is a group address."""
+        return isinstance(self.dst_addr, GroupAddress)
 
     def calculated_length(self) -> int:
         """Get length of KNX/IP body."""
@@ -143,30 +140,19 @@ class CEMILData(CEMIData):
         src_addr: IndividualAddress | None = None,
     ) -> CEMILData:
         """Return CEMILData from a Telegram."""
-        flags = (
-            # default; the Frame Type is derived from the NPDU length in `to_knx()`
-            CEMIFlags.FRAME_TYPE_STANDARD
-            | CEMIFlags.DO_NOT_REPEAT
-            | CEMIFlags.BROADCAST
-            | CEMIFlags.NO_ACK_REQUESTED
-            | CEMIFlags.CONFIRM_NO_ERROR
-            | CEMIFlags.HOP_COUNT_1ST
-        )
         if isinstance(telegram.destination_address, GroupAddress):
-            flags |= CEMIFlags.DESTINATION_GROUP_ADDRESS
-            if isinstance(telegram.tpci, TDataBroadcast):
-                flags |= CEMIFlags.PRIORITY_SYSTEM
-            else:
-                flags |= CEMIFlags.PRIORITY_LOW
-        elif isinstance(telegram.destination_address, IndividualAddress):
-            flags |= (
-                CEMIFlags.DESTINATION_INDIVIDUAL_ADDRESS | CEMIFlags.PRIORITY_SYSTEM
+            priority = (
+                CEMIPriority.SYSTEM
+                if isinstance(telegram.tpci, TDataBroadcast)
+                else CEMIPriority.LOW
             )
+        elif isinstance(telegram.destination_address, IndividualAddress):
+            priority = CEMIPriority.SYSTEM
         else:
             raise TypeError()
 
         return CEMILData(
-            flags=flags,
+            flags=CEMIFlags(priority=priority),
             src_addr=src_addr or telegram.source_address,
             dst_addr=telegram.destination_address,
             tpci=telegram.tpci,
@@ -208,14 +194,11 @@ class CEMILData(CEMIData):
         # frame shall not be used when a standard frame suffices - 3/2/2 §2.2.5.1.
         # Derived here instead of when the frame is created because the payload may
         # be replaced afterwards - eg. wrapped in a SecureAPDU by Data Secure.
-        flags = (
-            self.flags | CEMIFlags.FRAME_TYPE_STANDARD
-            if npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH
-            else self.flags & ~CEMIFlags.FRAME_TYPE_STANDARD
-        )
-
         return (
-            flags.to_bytes(2, "big")
+            self.flags.to_knx(
+                frame_type_standard=npdu_len <= STANDARD_FRAME_MAX_NPDU_LENGTH,
+                dst_is_group_address=self.dst_is_group_address,
+            )
             + self.src_addr.to_knx()
             + self.dst_addr.to_knx()
             + npdu_len.to_bytes(1, "big")
@@ -231,7 +214,7 @@ class CEMILData(CEMIData):
             )
 
         # Control field 1 and Control field 2 - first 2 octets
-        flags = int.from_bytes(raw[0:2], "big")
+        flags = CEMIFlags.from_knx(raw[0:2])
 
         src_addr = IndividualAddress.from_knx(raw[2:4])
 
@@ -241,13 +224,13 @@ class CEMILData(CEMIData):
         # The Frame Type flag itself is deliberately not validated against the NPDU
         # length: "any receiver shall be tolerant towards the use of the Frame
         # Format" - 3/6/3 §4.1.5.2.3.
-        if _eff := flags & CEMIFlags.EXTENDED_FRAME_FORMAT_MASK:
+        if _eff := raw[1] & EXTENDED_FRAME_FORMAT_MASK:
             raise UnsupportedCEMIMessage(
                 f"Extended Frame Format not supported: {_eff:#06b} "
                 f"from {src_addr} in CEMI: {raw.hex()}"
             )
 
-        _dst_is_group_address = bool(flags & CEMIFlags.DESTINATION_GROUP_ADDRESS)
+        _dst_is_group_address = bool(raw[1] & DESTINATION_GROUP_ADDRESS)
         dst_addr: GroupAddress | IndividualAddress = (
             GroupAddress.from_knx(raw[4:6])
             if _dst_is_group_address
@@ -327,7 +310,7 @@ class CEMILData(CEMIData):
             "CEMILData("
             f'src_addr="{self.src_addr.__repr__()}" '
             f'dst_addr="{self.dst_addr.__repr__()}" '
-            f'flags="{self.flags:16b}" '
+            f'flags="{self.flags!r}" '
             f'tpci="{self.tpci}" '
             f'payload="{self.payload}")'
         )

--- a/xknx/cemi/const.py
+++ b/xknx/cemi/const.py
@@ -47,57 +47,6 @@ class CEMIMessageCode(Enum):
     M_RESET_IND = 0xF0  # Reset confirmation
 
 
-class CEMIFlags:
-    """Enum class for CEMI Flags."""
-
-    # Bit 1/7 - Frame Type (FT); see 3/6/3 EMI_IMI §4.1.4.3.2
-    # Derived from the NPDU length when serializing - see `CEMILData.to_knx`.
-    FRAME_TYPE_EXTENDED = 0x0000
-    FRAME_TYPE_STANDARD = 0x8000
-
-    # Bit 1/6 - Reserved
-
-    # Bit 1/5
-    # Repeat in case of an error
-    REPEAT = 0x0000
-    DO_NOT_REPEAT = 0x2000
-
-    # Bit 1/4
-    SYSTEM_BROADCAST = 0x0000
-    BROADCAST = 0x1000
-
-    # Bit 1/3+2
-    PRIORITY_SYSTEM = 0x0000
-    PRIORITY_NORMAL = 0x0400
-    PRIORITY_URGENT = 0x0800
-    PRIORITY_LOW = 0x0C00
-
-    # Bit 1/1
-    NO_ACK_REQUESTED = 0x0000
-    ACK_REQUESTED = 0x0200
-
-    # Bit 1/0
-    CONFIRM_NO_ERROR = 0x0000
-    CONFIRM_ERROR = 0x0100
-
-    # Bit 0/7
-    DESTINATION_INDIVIDUAL_ADDRESS = 0x0000
-    DESTINATION_GROUP_ADDRESS = 0x0080
-
-    # Bit 0/6+5+4
-    HOP_COUNT_NO = 0x0070
-    HOP_COUNT_1ST = 0x0060
-
-    # Bit 0/3+2+1+0 - Extended Frame Format (EFF); see 3/6/3 EMI_IMI §4.1.4.3.2
-    # and 3/2/2 Communication Medium TP1 §2.2.5.3.
-    # 0000b is used for L_Data_Standard frames as well as for long
-    # L_Data_Extended frames; 01xxb denotes LTE-HEE (zone addressed) frames.
-    # All other values are reserved.
-    STANDARD_FRAME_FORMAT = 0x0000
-    LTE_FRAME_FORMAT = 0x0004
-    EXTENDED_FRAME_FORMAT_MASK = 0x000F
-
-
 class CEMIErrorCode(IntEnum):
     """Enum class for CEMI Error Codes."""
 

--- a/xknx/cemi/flags.py
+++ b/xknx/cemi/flags.py
@@ -10,8 +10,9 @@ The two control field octets Ctrl1 and Ctrl2 are specified in
 
 Not every field is independent state: the Frame Type (FT) follows from the NPDU
 length and the Address Type (AT) from the destination address, so both are
-derived when serializing - see `CEMILData`. The Extended Frame Format (EFF) is
-always 0 for the frame types XKNX supports.
+derived when serializing - see `CEMILData`. The received Frame Type is still kept
+for inspection; the Address Type can be read from the type of the destination
+address.
 """
 
 from __future__ import annotations
@@ -35,10 +36,6 @@ DESTINATION_GROUP_ADDRESS = 0b10000000
 HOP_COUNT_MASK = 0b01110000
 HOP_COUNT_OFFSET = 4
 EXTENDED_FRAME_FORMAT_MASK = 0b00001111
-# 0000b is used for L_Data_Standard frames as well as for long L_Data_Extended
-# frames; 01xxb denotes LTE-HEE (zone addressed) frames. The rest is reserved.
-STANDARD_FRAME_FORMAT = 0b0000
-LTE_FRAME_FORMAT = 0b0100
 
 MAX_HOP_COUNT = 7
 
@@ -52,13 +49,47 @@ class CEMIPriority(IntEnum):
     LOW = 0b11
 
 
+class CEMIFrameType(IntEnum):
+    """
+    Frame Type of a cEMI L_Data frame. See 3/6/3 §4.1.4.3.2.
+
+    An L_Data_Standard frame carries at most 15 octets after the TPCI octet;
+    longer APDUs require an L_Data_Extended frame - 3/2/2 §2.2.4 and §2.2.5.1.
+    """
+
+    EXTENDED = 0
+    STANDARD = 1
+
+
+class CEMIFrameFormat(IntEnum):
+    """
+    Extended Frame Format (EFF) of a cEMI L_Data frame. See 3/2/2 §2.2.5.3.
+
+    `STANDARD` is used for L_Data_Standard frames as well as for long
+    L_Data_Extended frames. `LTE_HEE` covers 01xxb - the two least significant
+    bits hold the LTE extended address type. All other values are reserved.
+    """
+
+    STANDARD = 0b0000
+    LTE_HEE = 0b0100
+
+    @classmethod
+    def _missing_(cls, value: object) -> CEMIFrameFormat | None:
+        """Resolve the whole 01xxb range to LTE_HEE; reserved values fail."""
+        if isinstance(value, int) and value & 0b1100 == cls.LTE_HEE:
+            return cls.LTE_HEE
+        return None
+
+
 @dataclass(slots=True)
 class CEMIFlags:
     """
     Control fields of a cEMI L_Data frame.
 
-    Holds only the fields that are independent state. Frame Type, Address Type and
-    Extended Frame Format are not stored - they follow from the frame itself.
+    `frame_type` and `frame_format` are informational: they hold what was received
+    and are ignored when serializing. The Frame Type of an outgoing frame follows
+    from its NPDU length and is passed to `to_knx()` by the frame; the Address Type
+    is not held at all - it can be read from the type of the destination address.
 
     `confirm_error` is only meaningful in an L_Data.con frame.
     """
@@ -70,19 +101,23 @@ class CEMIFlags:
     acknowledge_request: bool = False
     confirm_error: bool = False
     hop_count: int = 6
+    # as received; not used when serializing
+    frame_type: CEMIFrameType = CEMIFrameType.STANDARD
+    frame_format: CEMIFrameFormat = CEMIFrameFormat.STANDARD
 
-    def to_knx(self, *, frame_type_standard: bool, dst_is_group_address: bool) -> bytes:
+    def to_knx(self, *, frame_type: CEMIFrameType, dst_is_group_address: bool) -> bytes:
         """
         Serialize to Ctrl1 and Ctrl2.
 
-        Frame Type and Address Type are not held by this object; they are passed in
-        by the frame that knows its NPDU length and destination address.
+        The Frame Type is passed in by the frame that knows its NPDU length; the
+        Address Type by the frame that knows its destination address. `self.frame_type`
+        holds the Frame Type of a received frame and is not used here.
         """
         if not 0 <= self.hop_count <= MAX_HOP_COUNT:
             raise ConversionError(f"Hop count out of range: {self.hop_count}")
 
         ctrl1 = (
-            (FRAME_TYPE_STANDARD if frame_type_standard else 0)
+            (FRAME_TYPE_STANDARD if frame_type is CEMIFrameType.STANDARD else 0)
             | (0 if self.repeat_on_error else DO_NOT_REPEAT)
             | (0 if self.system_broadcast else BROADCAST)
             | (self.priority << PRIORITY_OFFSET)
@@ -92,7 +127,7 @@ class CEMIFlags:
         ctrl2 = (
             (DESTINATION_GROUP_ADDRESS if dst_is_group_address else 0)
             | (self.hop_count << HOP_COUNT_OFFSET)
-            | STANDARD_FRAME_FORMAT
+            | CEMIFrameFormat.STANDARD
         )
         return bytes((ctrl1, ctrl2))
 
@@ -101,10 +136,19 @@ class CEMIFlags:
         """
         Parse Ctrl1 and Ctrl2.
 
-        The Frame Type is deliberately not evaluated: "any receiver shall be
-        tolerant towards the use of the Frame Format" - 3/6/3 §4.1.5.2.3.
+        Raise `ConversionError` for a reserved Extended Frame Format. The Frame Type
+        is kept but not evaluated: "any receiver shall be tolerant towards the use of
+        the Frame Format" - 3/6/3 §4.1.5.2.3.
         """
         ctrl1, ctrl2 = raw[0], raw[1]
+        _eff = ctrl2 & EXTENDED_FRAME_FORMAT_MASK
+        try:
+            frame_format = CEMIFrameFormat(_eff)
+        except ValueError:
+            raise ConversionError(
+                f"Reserved Extended Frame Format: {_eff:#06b}"
+            ) from None
+
         return cls(
             priority=CEMIPriority((ctrl1 & PRIORITY_MASK) >> PRIORITY_OFFSET),
             repeat_on_error=not ctrl1 & DO_NOT_REPEAT,
@@ -112,15 +156,27 @@ class CEMIFlags:
             acknowledge_request=bool(ctrl1 & ACK_REQUESTED),
             confirm_error=bool(ctrl1 & CONFIRM_ERROR),
             hop_count=(ctrl2 & HOP_COUNT_MASK) >> HOP_COUNT_OFFSET,
+            frame_type=CEMIFrameType(ctrl1 >> 7),
+            frame_format=frame_format,
         )
 
-    def __repr__(self) -> str:
-        """Return object as readable string."""
-        return (
-            f"CEMIFlags(priority={self.priority.name} "
-            f"hop_count={self.hop_count} "
-            f"repeat_on_error={self.repeat_on_error} "
-            f"system_broadcast={self.system_broadcast} "
-            f"acknowledge_request={self.acknowledge_request} "
-            f"confirm_error={self.confirm_error})"
+    def __str__(self) -> str:
+        """Return object as compact readable string."""
+        _set_flags = [
+            name
+            for name, value in (
+                ("repeat_on_error", self.repeat_on_error),
+                ("system_broadcast", self.system_broadcast),
+                ("acknowledge_request", self.acknowledge_request),
+                ("confirm_error", self.confirm_error),
+            )
+            if value
+        ]
+        return " ".join(
+            (
+                self.priority.name,
+                self.frame_type.name,
+                f"hop_count={self.hop_count}",
+                *_set_flags,
+            )
         )

--- a/xknx/cemi/flags.py
+++ b/xknx/cemi/flags.py
@@ -117,10 +117,12 @@ class CEMIFlags:
     """
     Control fields of a cEMI L_Data frame.
 
-    `frame_type` and `frame_format` are informational: they hold what was received
-    and are ignored when serializing. The Frame Type of an outgoing frame follows
-    from its NPDU length and is passed to `to_knx()` by the frame; the Address Type
-    is not held at all - it can be read from the type of the destination address.
+    `frame_type` is informational: it holds what was received and is ignored when
+    serializing, as the Frame Type of an outgoing frame follows from its NPDU length
+    and is passed to `to_knx()` by the frame. The Address Type is not held at all -
+    it can be read from the type of the destination address. The Extended Frame
+    Format does not follow from anything else, so `frame_format` is serialized as
+    held; it is `STANDARD` for every frame xknx currently supports.
 
     `confirm_error` is only meaningful in an L_Data.con frame.
     """
@@ -142,7 +144,9 @@ class CEMIFlags:
 
         The Frame Type and Address Type bits are left clear; the frame ORs them in
         from `CEMIFrameType.to_knx()` and `CEMIAddressType.to_knx()`. `self.frame_type`
-        holds the Frame Type of a received frame and is not used here.
+        holds the Frame Type of a received frame and is not used here. The Extended
+        Frame Format is serialized - Data Secure protects it, so the value on the
+        wire and the one fed to the MAC have to come from the same place.
         """
         if not 0 <= self.hop_count <= MAX_HOP_COUNT:
             raise ConversionError(f"Hop count out of range: {self.hop_count}")
@@ -154,7 +158,7 @@ class CEMIFlags:
             | (ACK_REQUESTED if self.acknowledge_request else 0)
             | (CONFIRM_ERROR if self.confirm_error else 0)
             | (self.hop_count << HOP_COUNT_OFFSET)
-            | CEMIFrameFormat.STANDARD
+            | self.frame_format
         )
 
     @classmethod

--- a/xknx/cemi/flags.py
+++ b/xknx/cemi/flags.py
@@ -1,0 +1,126 @@
+"""
+Control fields of a cEMI L_Data frame.
+
+The two control field octets Ctrl1 and Ctrl2 are specified in
+3/6/3 EMI_IMI §4.1.4.3.2 and 3/2/2 Communication Medium TP1 §2.2.2 / §2.2.5.3.
+
+    Ctrl1                            Ctrl2
+    7  6  5  4  3  2  1  0           7  6  5  4  3  2  1  0
+    FT  r  R SB  P  P  A  C          AT  H  H  H  E  E  E  E
+
+Not every field is independent state: the Frame Type (FT) follows from the NPDU
+length and the Address Type (AT) from the destination address, so both are
+derived when serializing - see `CEMILData`. The Extended Frame Format (EFF) is
+always 0 for the frame types XKNX supports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+from xknx.exceptions import ConversionError
+
+# Ctrl1
+FRAME_TYPE_STANDARD = 0b10000000
+DO_NOT_REPEAT = 0b00100000
+BROADCAST = 0b00010000
+PRIORITY_MASK = 0b00001100
+PRIORITY_OFFSET = 2
+ACK_REQUESTED = 0b00000010
+CONFIRM_ERROR = 0b00000001
+
+# Ctrl2
+DESTINATION_GROUP_ADDRESS = 0b10000000
+HOP_COUNT_MASK = 0b01110000
+HOP_COUNT_OFFSET = 4
+EXTENDED_FRAME_FORMAT_MASK = 0b00001111
+# 0000b is used for L_Data_Standard frames as well as for long L_Data_Extended
+# frames; 01xxb denotes LTE-HEE (zone addressed) frames. The rest is reserved.
+STANDARD_FRAME_FORMAT = 0b0000
+LTE_FRAME_FORMAT = 0b0100
+
+MAX_HOP_COUNT = 7
+
+
+class CEMIPriority(IntEnum):
+    """Priority of a cEMI L_Data frame. See 3/2/2 §2.2.2 Figure 28."""
+
+    SYSTEM = 0b00
+    NORMAL = 0b01
+    URGENT = 0b10
+    LOW = 0b11
+
+
+@dataclass(slots=True)
+class CEMIFlags:
+    """
+    Control fields of a cEMI L_Data frame.
+
+    Holds only the fields that are independent state. Frame Type, Address Type and
+    Extended Frame Format are not stored - they follow from the frame itself.
+
+    `confirm_error` is only meaningful in an L_Data.con frame.
+    """
+
+    priority: CEMIPriority = CEMIPriority.LOW
+    # `repeat_on_error` and `system_broadcast` are inverted on the wire
+    repeat_on_error: bool = False
+    system_broadcast: bool = False
+    acknowledge_request: bool = False
+    confirm_error: bool = False
+    hop_count: int = 6
+
+    def to_knx(self, *, frame_type_standard: bool, dst_is_group_address: bool) -> bytes:
+        """
+        Serialize to Ctrl1 and Ctrl2.
+
+        Frame Type and Address Type are not held by this object; they are passed in
+        by the frame that knows its NPDU length and destination address.
+        """
+        if not 0 <= self.hop_count <= MAX_HOP_COUNT:
+            raise ConversionError(f"Hop count out of range: {self.hop_count}")
+
+        ctrl1 = (
+            (FRAME_TYPE_STANDARD if frame_type_standard else 0)
+            | (0 if self.repeat_on_error else DO_NOT_REPEAT)
+            | (0 if self.system_broadcast else BROADCAST)
+            | (self.priority << PRIORITY_OFFSET)
+            | (ACK_REQUESTED if self.acknowledge_request else 0)
+            | (CONFIRM_ERROR if self.confirm_error else 0)
+        )
+        ctrl2 = (
+            (DESTINATION_GROUP_ADDRESS if dst_is_group_address else 0)
+            | (self.hop_count << HOP_COUNT_OFFSET)
+            | STANDARD_FRAME_FORMAT
+        )
+        return bytes((ctrl1, ctrl2))
+
+    @classmethod
+    def from_knx(cls, raw: bytes) -> CEMIFlags:
+        """
+        Parse Ctrl1 and Ctrl2.
+
+        The Frame Type is deliberately not evaluated: "any receiver shall be
+        tolerant towards the use of the Frame Format" - 3/6/3 §4.1.5.2.3.
+        """
+        ctrl1, ctrl2 = raw[0], raw[1]
+        return cls(
+            priority=CEMIPriority((ctrl1 & PRIORITY_MASK) >> PRIORITY_OFFSET),
+            repeat_on_error=not ctrl1 & DO_NOT_REPEAT,
+            system_broadcast=not ctrl1 & BROADCAST,
+            acknowledge_request=bool(ctrl1 & ACK_REQUESTED),
+            confirm_error=bool(ctrl1 & CONFIRM_ERROR),
+            hop_count=(ctrl2 & HOP_COUNT_MASK) >> HOP_COUNT_OFFSET,
+        )
+
+    def __repr__(self) -> str:
+        """Return object as readable string."""
+        return (
+            f"CEMIFlags(priority={self.priority.name} "
+            f"hop_count={self.hop_count} "
+            f"repeat_on_error={self.repeat_on_error} "
+            f"system_broadcast={self.system_broadcast} "
+            f"acknowledge_request={self.acknowledge_request} "
+            f"confirm_error={self.confirm_error})"
+        )

--- a/xknx/cemi/flags.py
+++ b/xknx/cemi/flags.py
@@ -22,20 +22,21 @@ from enum import IntEnum
 
 from xknx.exceptions import ConversionError
 
+# Ctrl1 and Ctrl2 are handled as one 16 bit value: Ctrl1 << 8 | Ctrl2.
+# The Frame Type and Address Type bits are not listed here - `CEMIFrameType` and
+# `CEMIAddressType` place their own bit.
 # Ctrl1
-FRAME_TYPE_STANDARD = 0b10000000
-DO_NOT_REPEAT = 0b00100000
-BROADCAST = 0b00010000
-PRIORITY_MASK = 0b00001100
-PRIORITY_OFFSET = 2
-ACK_REQUESTED = 0b00000010
-CONFIRM_ERROR = 0b00000001
+DO_NOT_REPEAT = 0b00100000_00000000
+BROADCAST = 0b00010000_00000000
+PRIORITY_MASK = 0b00001100_00000000
+PRIORITY_OFFSET = 10
+ACK_REQUESTED = 0b00000010_00000000
+CONFIRM_ERROR = 0b00000001_00000000
 
 # Ctrl2
-DESTINATION_GROUP_ADDRESS = 0b10000000
-HOP_COUNT_MASK = 0b01110000
+HOP_COUNT_MASK = 0b00000000_01110000
 HOP_COUNT_OFFSET = 4
-EXTENDED_FRAME_FORMAT_MASK = 0b00001111
+EXTENDED_FRAME_FORMAT_MASK = 0b00000000_00001111
 
 MAX_HOP_COUNT = 7
 
@@ -59,6 +60,36 @@ class CEMIFrameType(IntEnum):
 
     EXTENDED = 0
     STANDARD = 1
+
+    def to_knx(self) -> int:
+        """Serialize to the Frame Type bit of the control field - Ctrl1 b7."""
+        return self << 15
+
+    @classmethod
+    def from_knx(cls, raw: int) -> CEMIFrameType:
+        """Parse the Frame Type bit from the control field."""
+        return cls(raw >> 15 & 0b1)
+
+
+class CEMIAddressType(IntEnum):
+    """
+    Destination Address Type of a cEMI L_Data frame. See 3/6/3 §4.1.4.3.2.
+
+    Follows from the type of the destination address, so it is not held by
+    `CEMIFlags` - see `CEMILData.address_type`.
+    """
+
+    INDIVIDUAL = 0
+    GROUP = 1
+
+    def to_knx(self) -> int:
+        """Serialize to the Address Type bit of the control field - Ctrl2 b7."""
+        return self << 7
+
+    @classmethod
+    def from_knx(cls, raw: int) -> CEMIAddressType:
+        """Parse the Address Type bit from the control field."""
+        return cls(raw >> 7 & 0b1)
 
 
 class CEMIFrameFormat(IntEnum):
@@ -105,43 +136,37 @@ class CEMIFlags:
     frame_type: CEMIFrameType = CEMIFrameType.STANDARD
     frame_format: CEMIFrameFormat = CEMIFrameFormat.STANDARD
 
-    def to_knx(self, *, frame_type: CEMIFrameType, dst_is_group_address: bool) -> bytes:
+    def to_knx(self) -> int:
         """
-        Serialize to Ctrl1 and Ctrl2.
+        Serialize the control field bits held by this object.
 
-        The Frame Type is passed in by the frame that knows its NPDU length; the
-        Address Type by the frame that knows its destination address. `self.frame_type`
+        The Frame Type and Address Type bits are left clear; the frame ORs them in
+        from `CEMIFrameType.to_knx()` and `CEMIAddressType.to_knx()`. `self.frame_type`
         holds the Frame Type of a received frame and is not used here.
         """
         if not 0 <= self.hop_count <= MAX_HOP_COUNT:
             raise ConversionError(f"Hop count out of range: {self.hop_count}")
 
-        ctrl1 = (
-            (FRAME_TYPE_STANDARD if frame_type is CEMIFrameType.STANDARD else 0)
-            | (0 if self.repeat_on_error else DO_NOT_REPEAT)
+        return (
+            (0 if self.repeat_on_error else DO_NOT_REPEAT)
             | (0 if self.system_broadcast else BROADCAST)
             | (self.priority << PRIORITY_OFFSET)
             | (ACK_REQUESTED if self.acknowledge_request else 0)
             | (CONFIRM_ERROR if self.confirm_error else 0)
-        )
-        ctrl2 = (
-            (DESTINATION_GROUP_ADDRESS if dst_is_group_address else 0)
             | (self.hop_count << HOP_COUNT_OFFSET)
             | CEMIFrameFormat.STANDARD
         )
-        return bytes((ctrl1, ctrl2))
 
     @classmethod
-    def from_knx(cls, raw: bytes) -> CEMIFlags:
+    def from_knx(cls, raw: int) -> CEMIFlags:
         """
-        Parse Ctrl1 and Ctrl2.
+        Parse the control field.
 
         Raise `ConversionError` for a reserved Extended Frame Format. The Frame Type
         is kept but not evaluated: "any receiver shall be tolerant towards the use of
         the Frame Format" - 3/6/3 §4.1.5.2.3.
         """
-        ctrl1, ctrl2 = raw[0], raw[1]
-        _eff = ctrl2 & EXTENDED_FRAME_FORMAT_MASK
+        _eff = raw & EXTENDED_FRAME_FORMAT_MASK
         try:
             frame_format = CEMIFrameFormat(_eff)
         except ValueError:
@@ -150,13 +175,13 @@ class CEMIFlags:
             ) from None
 
         return cls(
-            priority=CEMIPriority((ctrl1 & PRIORITY_MASK) >> PRIORITY_OFFSET),
-            repeat_on_error=not ctrl1 & DO_NOT_REPEAT,
-            system_broadcast=not ctrl1 & BROADCAST,
-            acknowledge_request=bool(ctrl1 & ACK_REQUESTED),
-            confirm_error=bool(ctrl1 & CONFIRM_ERROR),
-            hop_count=(ctrl2 & HOP_COUNT_MASK) >> HOP_COUNT_OFFSET,
-            frame_type=CEMIFrameType(ctrl1 >> 7),
+            priority=CEMIPriority((raw & PRIORITY_MASK) >> PRIORITY_OFFSET),
+            repeat_on_error=not raw & DO_NOT_REPEAT,
+            system_broadcast=not raw & BROADCAST,
+            acknowledge_request=bool(raw & ACK_REQUESTED),
+            confirm_error=bool(raw & CONFIRM_ERROR),
+            hop_count=(raw & HOP_COUNT_MASK) >> HOP_COUNT_OFFSET,
+            frame_type=CEMIFrameType.from_knx(raw),
             frame_format=frame_format,
         )
 

--- a/xknx/secure/data_secure.py
+++ b/xknx/secure/data_secure.py
@@ -212,6 +212,7 @@ class DataSecure:
                 scf=s_apdu.scf,
                 address_fields_raw=_address_fields_raw,
                 address_type=cemi_data.address_type,
+                frame_format=cemi_data.flags.frame_format,
                 tpci=cemi_data.tpci,
             )
         decrypted_payload = APCI.from_knx(plain_apdu_raw)
@@ -260,6 +261,7 @@ class DataSecure:
             address_fields_raw=cemi_data.src_addr.to_knx()
             + cemi_data.dst_addr.to_knx(),
             address_type=cemi_data.address_type,
+            frame_format=cemi_data.flags.frame_format,
             tpci=cemi_data.tpci,
         )
         secure_cemi_data = copy(cemi_data)

--- a/xknx/secure/data_secure.py
+++ b/xknx/secure/data_secure.py
@@ -211,7 +211,7 @@ class DataSecure:
                 key=key,
                 scf=s_apdu.scf,
                 address_fields_raw=_address_fields_raw,
-                dst_is_group_address=cemi_data.dst_is_group_address,
+                address_type=cemi_data.address_type,
                 tpci=cemi_data.tpci,
             )
         decrypted_payload = APCI.from_knx(plain_apdu_raw)
@@ -259,7 +259,7 @@ class DataSecure:
             sequence_number=self.get_sequence_number(),
             address_fields_raw=cemi_data.src_addr.to_knx()
             + cemi_data.dst_addr.to_knx(),
-            dst_is_group_address=cemi_data.dst_is_group_address,
+            address_type=cemi_data.address_type,
             tpci=cemi_data.tpci,
         )
         secure_cemi_data = copy(cemi_data)

--- a/xknx/secure/data_secure.py
+++ b/xknx/secure/data_secure.py
@@ -211,7 +211,7 @@ class DataSecure:
                 key=key,
                 scf=s_apdu.scf,
                 address_fields_raw=_address_fields_raw,
-                frame_flags=cemi_data.flags,
+                dst_is_group_address=cemi_data.dst_is_group_address,
                 tpci=cemi_data.tpci,
             )
         decrypted_payload = APCI.from_knx(plain_apdu_raw)
@@ -259,7 +259,7 @@ class DataSecure:
             sequence_number=self.get_sequence_number(),
             address_fields_raw=cemi_data.src_addr.to_knx()
             + cemi_data.dst_addr.to_knx(),
-            frame_flags=cemi_data.flags,
+            dst_is_group_address=cemi_data.dst_is_group_address,
             tpci=cemi_data.tpci,
         )
         secure_cemi_data = copy(cemi_data)

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -16,14 +16,16 @@ from .security_primitives import (
 # Secure APCI is 0x03F1 - in block_0 it is used split into 2 octets
 _APCI_SEC_HIGH = 0x03
 _APCI_SEC_LOW = 0xF1
-# only Address Type (IA / GA) and Extended Frame format are used
-B0_AT_FIELD_FLAGS_MASK = 0b10001111
+# Of the cEMI control fields only the Address Type (IA / GA) and the Extended Frame
+# Format are used; both live in Ctrl2. Ctrl1 - and with it the Frame Type - is not
+# covered by the MAC. The Extended Frame Format is always 0 for supported frames.
+_B0_ADDRESS_TYPE_GROUP = 0b10000000
 
 
 def block_0(
     sequence_number: bytes,
     address_fields_raw: bytes,
-    frame_flags: int,
+    dst_is_group_address: bool,
     tpci_int: int,
     payload_length: int,
 ) -> bytes:
@@ -34,7 +36,7 @@ def block_0(
         + bytes(
             (
                 0,
-                frame_flags & B0_AT_FIELD_FLAGS_MASK,
+                _B0_ADDRESS_TYPE_GROUP if dst_is_group_address else 0,
                 (tpci_int << 2) + _APCI_SEC_HIGH,
                 _APCI_SEC_LOW,
                 0,
@@ -147,7 +149,7 @@ class SecureData:
         scf: SecurityControlField,
         sequence_number: int,
         address_fields_raw: bytes,
-        frame_flags: int,
+        dst_is_group_address: bool,
         tpci: TPCI,
     ) -> SecureData:
         """Serialize to KNX raw data."""
@@ -160,7 +162,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    frame_flags=frame_flags,
+                    dst_is_group_address=dst_is_group_address,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),
@@ -174,7 +176,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    frame_flags=frame_flags,
+                    dst_is_group_address=dst_is_group_address,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(apdu),
                 ),
@@ -219,7 +221,7 @@ class SecureData:
         key: bytes,
         scf: SecurityControlField,
         address_fields_raw: bytes,
-        frame_flags: int,
+        dst_is_group_address: bool,
         tpci: TPCI,
     ) -> bytes:
         """
@@ -245,7 +247,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    frame_flags=frame_flags,
+                    dst_is_group_address=dst_is_group_address,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(dec_payload),
                 ),
@@ -261,7 +263,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    frame_flags=frame_flags,
+                    dst_is_group_address=dst_is_group_address,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import IntEnum
 
+from xknx.cemi.flags import CEMIAddressType
 from xknx.exceptions import DataSecureError
 from xknx.telegram.tpci import TPCI
 
@@ -18,14 +19,14 @@ _APCI_SEC_HIGH = 0x03
 _APCI_SEC_LOW = 0xF1
 # Of the cEMI control fields only the Address Type (IA / GA) and the Extended Frame
 # Format are used; both live in Ctrl2. Ctrl1 - and with it the Frame Type - is not
-# covered by the MAC. The Extended Frame Format is always 0 for supported frames.
-_B0_ADDRESS_TYPE_GROUP = 0b10000000
+# covered by the MAC. The Extended Frame Format is always 0 for supported frames,
+# so `CEMIAddressType.to_knx()` is the whole octet.
 
 
 def block_0(
     sequence_number: bytes,
     address_fields_raw: bytes,
-    dst_is_group_address: bool,
+    address_type: CEMIAddressType,
     tpci_int: int,
     payload_length: int,
 ) -> bytes:
@@ -36,7 +37,7 @@ def block_0(
         + bytes(
             (
                 0,
-                _B0_ADDRESS_TYPE_GROUP if dst_is_group_address else 0,
+                address_type.to_knx(),
                 (tpci_int << 2) + _APCI_SEC_HIGH,
                 _APCI_SEC_LOW,
                 0,
@@ -149,7 +150,7 @@ class SecureData:
         scf: SecurityControlField,
         sequence_number: int,
         address_fields_raw: bytes,
-        dst_is_group_address: bool,
+        address_type: CEMIAddressType,
         tpci: TPCI,
     ) -> SecureData:
         """Serialize to KNX raw data."""
@@ -162,7 +163,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    dst_is_group_address=dst_is_group_address,
+                    address_type=address_type,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),
@@ -176,7 +177,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    dst_is_group_address=dst_is_group_address,
+                    address_type=address_type,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(apdu),
                 ),
@@ -221,7 +222,7 @@ class SecureData:
         key: bytes,
         scf: SecurityControlField,
         address_fields_raw: bytes,
-        dst_is_group_address: bool,
+        address_type: CEMIAddressType,
         tpci: TPCI,
     ) -> bytes:
         """
@@ -247,7 +248,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    dst_is_group_address=dst_is_group_address,
+                    address_type=address_type,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(dec_payload),
                 ),
@@ -263,7 +264,7 @@ class SecureData:
                 block_0=block_0(
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
-                    dst_is_group_address=dst_is_group_address,
+                    address_type=address_type,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from enum import IntEnum
 
-from xknx.cemi.flags import CEMIAddressType
+from xknx.cemi.flags import CEMIAddressType, CEMIFrameFormat
 from xknx.exceptions import DataSecureError
 from xknx.telegram.tpci import TPCI
 
@@ -17,27 +17,29 @@ from .security_primitives import (
 # Secure APCI is 0x03F1 - in block_0 it is used split into 2 octets
 _APCI_SEC_HIGH = 0x03
 _APCI_SEC_LOW = 0xF1
-# Of the cEMI control fields only the Address Type (IA / GA) and the Extended Frame
-# Format are used; both live in Ctrl2. Ctrl1 - and with it the Frame Type - is not
-# covered by the MAC. The Extended Frame Format is always 0 for supported frames,
-# so `CEMIAddressType.to_knx()` is the whole octet.
 
 
 def block_0(
     sequence_number: bytes,
     address_fields_raw: bytes,
     address_type: CEMIAddressType,
+    frame_format: CEMIFrameFormat,
     tpci_int: int,
     payload_length: int,
 ) -> bytes:
     """Return Block 0 for KNX Data Secure."""
+    # Of the two control field octets only Ctrl2 is protected, and only as
+    # `A000EEEEb` - A the Address Type, EEEEb the Extended Frame Format if
+    # L_Data_Extended frames are used and 0000b otherwise. Priority, repeat flag,
+    # hop count and the Frame Type stay unprotected and may change on the way -
+    # KNX v02.01.01 - Application Layer 03.03.07 - §5.1.3.2 Figure 100 and NOTE 16.
     return (
         sequence_number
         + address_fields_raw
         + bytes(
             (
                 0,
-                address_type.to_knx(),
+                address_type.to_knx() | frame_format,
                 (tpci_int << 2) + _APCI_SEC_HIGH,
                 _APCI_SEC_LOW,
                 0,
@@ -151,6 +153,7 @@ class SecureData:
         sequence_number: int,
         address_fields_raw: bytes,
         address_type: CEMIAddressType,
+        frame_format: CEMIFrameFormat,
         tpci: TPCI,
     ) -> SecureData:
         """Serialize to KNX raw data."""
@@ -164,6 +167,7 @@ class SecureData:
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
                     address_type=address_type,
+                    frame_format=frame_format,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),
@@ -178,6 +182,7 @@ class SecureData:
                     sequence_number=sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
                     address_type=address_type,
+                    frame_format=frame_format,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(apdu),
                 ),
@@ -223,6 +228,7 @@ class SecureData:
         scf: SecurityControlField,
         address_fields_raw: bytes,
         address_type: CEMIAddressType,
+        frame_format: CEMIFrameFormat,
         tpci: TPCI,
     ) -> bytes:
         """
@@ -249,6 +255,7 @@ class SecureData:
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
                     address_type=address_type,
+                    frame_format=frame_format,
                     tpci_int=tpci.to_knx(),
                     payload_length=len(dec_payload),
                 ),
@@ -265,6 +272,7 @@ class SecureData:
                     sequence_number=self.sequence_number_bytes,
                     address_fields_raw=address_fields_raw,
                     address_type=address_type,
+                    frame_format=frame_format,
                     tpci_int=tpci.to_knx(),
                     payload_length=0,
                 ),


### PR DESCRIPTION
## Description

Follow-up to #1882, targeted at the next major release. `CEMILData.flags` was a bare 16 bit `int` and `CEMIFlags` a bag of bit constants, so callers had to know the layout of Ctrl1 and Ctrl2 to read or set anything, and `hops` needed a hand written mask/shift property.

`CEMIFlags` is now a slotted dataclass holding the control field values that are actually independent state:

```python
@dataclass(slots=True)
class CEMIFlags:
    priority: CEMIPriority = CEMIPriority.LOW
    # `repeat_on_error` and `system_broadcast` are inverted on the wire
    repeat_on_error: bool = False
    system_broadcast: bool = False
    acknowledge_request: bool = False
    confirm_error: bool = False
    hop_count: int = 6
    # as received; not used when serializing
    frame_type: CEMIFrameType = CEMIFrameType.STANDARD
    frame_format: CEMIFrameFormat = CEMIFrameFormat.STANDARD
```

`enum.Flag` was considered and does not fit: priority is a 2 bit value and the hop count a 3 bit counter, neither of which are flags. A plain slotted dataclass gives free `__eq__`, keyword construction and mutability for the hop count, which is what a router would need.

### Each part serializes itself

The three fields that are not plain flags get their own type and place their own bits, instead of being masked in and out by hand:

| field | type | where it comes from |
|---|---|---|
| Frame Type (Ctrl1 b7) | `CEMIFrameType` | derived when serializing: NPDU length - `<= 15` is a standard frame |
| Address Type (Ctrl2 b7) | `CEMIAddressType` | derived when serializing: `CEMILData.address_type`, ie. the type of the destination address |
| Extended Frame Format (Ctrl2 b3..0) | `CEMIFrameFormat` | held by `CEMIFlags`; `STANDARD` for every frame xknx supports |

`CEMIFlags.to_knx()` leaves the two derived bits clear and the frame ORs them in from the values only it knows:

```python
self.flags.to_knx() | frame_type.to_knx() | self.address_type.to_knx()
```

This means `flags` can no longer disagree with what is put on the wire - the class of bug that made #1868 possible - and there is no stale Frame Type left to go wrong when Data Secure replaces the payload of a frame it copied.

Frame Type and Extended Frame Format are still *parsed* into the dataclass, but they are not the same kind of thing and are not treated the same:

- `frame_type` is informational. It holds what was received, for inspection, and is ignored when serializing, since the Frame Type of an outgoing frame follows from its NPDU length.
- `frame_format` is real state - it does not follow from anything else - so it is serialized as held. Data Secure protects the Extended Frame Format, so the value on the wire and the one fed to the MAC have to come from the same place; a constant in both spots would only be kept in sync by a comment. It is `STANDARD` throughout today: LTE-HEE frames are rejected while parsing and cannot be constructed.

### On the `int | None` idea

Storing raw incoming flags in a private attribute was considered and rejected. Parsing straight into the dataclass loses nothing but the reserved Ctrl1 b6 - the Frame Type is kept, and everything else round-trips, including for a received frame. Letting a stored raw value take precedence when serializing would reintroduce exactly the stale-flags problem, since a `copy()`d frame with a swapped payload would emit the old Frame Type. If you want byte-exact fidelity for debugging, the raw octets of a received frame are already available in `CEMIHandler.handle_raw_cemi` - keeping a second, partly authoritative copy on the object is the part that does not pay for itself.

Happy to add it as a debug-only field if you disagree - it is a small addition on top of this.

### Also in this change

- `CEMILData.hops` is replaced by `flags.hop_count`, validated to `0..7` when serializing instead of silently corrupting Ctrl2. `CEMILData.address_type` is added.
- The raw bit masks move to `xknx.cemi.flags` as module level constants. Ctrl1 and Ctrl2 stay one 16 bit value (`Ctrl1 << 8 | Ctrl2`), so `CEMIFlags.to_knx()` returns an `int` and `from_knx()` takes one; the bits that have a type of their own are not among the constants.
- `block_0()`, `SecureData.init_from_plain_apdu()` and `SecureData.get_plain_apdu()` take `address_type: CEMIAddressType` and `frame_format: CEMIFrameFormat` instead of `frame_flags: int`. Only those two fields of Ctrl2 ever survived `B0_AT_FIELD_FLAGS_MASK`, so the mask is gone and the B0 octet is spelled out as the `A000EEEEb` of KNX v02.01.01 - Application Layer 03.03.07 - §5.1.3.2 Figure 100. The CCM input is unchanged.
- `CEMILData(flags=...)` is optional and defaults to `CEMIFlags()`.
- `CEMIFlags` has a compact `__str__` used in `CEMILData.__repr__` - eg. `LOW STANDARD hop_count=6`, listing only the boolean flags that are set.

### Verification

The Data Secure byte vectors are the strongest check that nothing moved: the AN158 v07 Annex A example and the real-device frame still verify, and the secured outgoing frames are byte-identical to what `main` produces, including the extended-frame vector from #1882:

```
3ce0500104001103f11000254ae1cb67cd98e577b519be47bb
```

New `test/cemi_tests/flags_test.py` covers parsing, the priority encoding from 3/2/2 Figure 28, the Extended Frame Format including its reserved values, the composition of the derived bits, a Ctrl1/Ctrl2 round trip and hop count validation. Full suite passes (3875); `test/integration_tests/routing_multicast_test.py` fails on my machine for lack of multicast routing, identically on `main`.

Rebased onto `main` after the 3.20.0 release - the code is byte-identical to the previously reviewed version, only the changelog entries moved into the new `# Unreleased changes` section.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
