### PR TITLE
Partly revert #1891

### DIFF
--- a/test/mcp_tests/tools_test.py
+++ b/test/mcp_tests/tools_test.py
@@ -46,7 +46,7 @@ async def test_list_dpts_text_filter() -> None:
 
 
 def test_jsonify_shapes() -> None:
-    """_jsonify passes JSON natives through, flattens tuples and handles DPT objects."""
+    """_jsonify passes JSON natives through, flattens tuples and stringifies the rest."""
 
     class _Mode(Enum):
         AUTO = "auto"
@@ -94,22 +94,23 @@ async def test_describe_dpt_semantics() -> None:
     assert switch.dpt is not None
     assert switch.dpt.payload_type == "binary"
     assert switch.dpt.payload_length == 1
-    assert switch.options == ["off", "on"]
-    assert switch.fields is None
+    assert switch.dpt.options == ["off", "on"]
+    assert switch.dpt.schema is None
 
     controlled = await describe_dpt("2.001")  # complex
     assert controlled.dpt is not None
     assert controlled.dpt.payload_type == "binary"
     assert controlled.dpt.payload_length == 2
-    assert controlled.fields is not None
-    assert {f["name"] for f in controlled.fields} == {"control", "value"}
+    assert controlled.dpt.options is None
+    assert controlled.dpt.schema is not None
+    assert {f["name"] for f in controlled.dpt.schema} == {"control", "value"}
 
-    string = await describe_dpt(
-        "16.000"
-    )  # string: payload_length is max length in bytes
+    string = await describe_dpt("16.000")  # string: payload_length is the max length
     assert string.dpt is not None
     assert string.dpt.payload_type == "array"
     assert string.dpt.payload_length == 14
+    assert controlled.dpt.options is None
+    assert controlled.dpt.schema is not None
 
 
 async def test_describe_dpt_unknown() -> None:

--- a/xknx/mcp/tools.py
+++ b/xknx/mcp/tools.py
@@ -82,6 +82,16 @@ def _summarize_dpt(dpt: type[DPTBase]) -> DptSummary:
         resolution=resolution,
         payload_type="binary" if dpt.payload_type is DPTBinary else "array",
         payload_length=dpt.payload_length,
+        options=(
+            [member.name.lower() for member in dpt.get_valid_values()]
+            if issubclass(dpt, DPTEnum)
+            else None
+        ),
+        schema=(
+            [dict(field) for field in dpt.get_dict_schema()]
+            if issubclass(dpt, DPTComplex)
+            else None
+        ),
     )
 
 
@@ -103,7 +113,7 @@ async def list_dpts(filters: DptFilter | None = None) -> DptListResult:
         if (filters.main is None or dpt.dpt_main_number == filters.main)
         and (needle is None or needle in _dpt_haystack(dpt))
     ]
-    matches.sort(key=lambda dpt: (dpt.dpt_main_number, dpt.dpt_sub_number or -1))
+    matches.sort(key=lambda dpt: (dpt.dpt_main_number or 0, dpt.dpt_sub_number or -1))
 
     window, limit_reached = _paginate(matches, filters.limit, filters.offset)
     return DptListResult(
@@ -121,22 +131,7 @@ async def describe_dpt(dpt: str) -> DptDetail:
         transcoder = DPTBase.get_dpt(dpt)
     except ValueError:
         return DptDetail(found=False, dpt=None)
-    options = (
-        [member.name.lower() for member in transcoder.get_valid_values()]
-        if issubclass(transcoder, DPTEnum)
-        else None
-    )
-    fields = (
-        [dict(field) for field in transcoder.get_dict_schema()]
-        if issubclass(transcoder, DPTComplex)
-        else None
-    )
-    return DptDetail(
-        found=True,
-        dpt=_summarize_dpt(transcoder),
-        options=options,
-        fields=fields,
-    )
+    return DptDetail(found=True, dpt=_summarize_dpt(transcoder))
 
 
 async def get_connection_status(xknx: XKNX) -> ConnectionStatusResult:

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -45,7 +45,12 @@ class DptSummary:
     resolution: float | None
     # "array" for DPTArray (payload_length in bytes) or "binary" for DPTBinary (payload_length in bits)
     payload_type: str
-    payload_length: int
+    # DPTArray byte / DPTBinary bit length; e.g. string max length
+    payload_length: int | None
+    # enum DPTs: lower-cased value names, as in a complex DPT's enum-field schema
+    options: list[str] | None
+    # for complex DPTs: the field schema of the dict form
+    schema: list[dict[str, Any]] | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,15 +71,11 @@ class DptDetail:
     Result of :func:`~xknx.mcp.tools.describe_dpt`.
 
     ``found`` is ``False`` when the identifier resolves to no transcoder, in
-    which case all other fields are ``None``.
+    which case ``dpt`` is ``None``.
     """
 
     found: bool
     dpt: DptSummary | None
-    # enum DPTs: lower-cased value names
-    options: list[str] | None = None
-    # for complex DPTs: the field list of the dict form
-    fields: list[dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
keep options and schema in DptSummary

In my previous review I have mistaken DptSummary for a TypedDict, but it's a dataclass 😬. We can't omit keys in a dataclass ... so I guess this was misleading. Correcting it here. Sorry about that.

<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)