### PR TITLE
Streamline MCP raw payload type

### DIFF
--- a/test/mcp_tests/tools_test.py
+++ b/test/mcp_tests/tools_test.py
@@ -220,7 +220,7 @@ async def test_encode_dpt_payload() -> None:
     switch_result = await encode_dpt_payload(
         EncodeDptPayloadInput(value=True, value_type="1.001")
     )
-    assert switch_result.payload == [1]
+    assert switch_result.payload == 1
     assert switch_result.value_type == "1.001"
 
 

--- a/xknx/mcp/tools.py
+++ b/xknx/mcp/tools.py
@@ -229,7 +229,7 @@ async def encode_dpt_payload(request: EncodeDptPayloadInput) -> EncodeDptPayload
     transcoder = DPTBase.get_dpt(request.value_type)
     encoded = transcoder.to_knx(request.value)
     payload = (
-        list(encoded.value) if isinstance(encoded, DPTArray) else [int(encoded.value)]
+        list(encoded.value) if isinstance(encoded, DPTArray) else int(encoded.value)
     )
     return EncodeDptPayloadResult(payload=payload, value_type=request.value_type)
 

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -154,7 +154,7 @@ class EncodeDptPayloadInput:
 class EncodeDptPayloadResult:
     """Result of :func:`~xknx.mcp.tools.encode_dpt_payload`."""
 
-    payload: list[int]
+    payload: list[int] | int
     value_type: str
 
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

As the decoded payload type uses `list[int] | int` to distinguish between `DPTBinary` and `DPTArray`

```py
@dataclass(frozen=True, slots=True)
class DecodeDptPayloadInput:
    """Input for :func:`~xknx.mcp.tools.decode_dpt_payload`."""

    payload: Annotated[
        list[int] | int,
        "Raw payload representation to decode (list of byte integers, or a single integer for 6-bit DPTs like DPT 1/2/3).",
    ]
    value_type: Annotated[
        str,
        'DPT number ("9.001") or value-type name ("temperature") to decode with.',
    ]
```
so should `EncodeDptPayloadResult` yield results of the same type.


Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)