### PR TITLE
mcp: describe input fields via dataclass field metadata instead of Annotated

### DIFF
--- a/test/mcp_tests/types_test.py
+++ b/test/mcp_tests/types_test.py
@@ -1,0 +1,35 @@
+"""Tests for the xknx MCP input/output dataclasses."""
+
+from dataclasses import Field, fields
+
+import pytest
+
+from xknx.mcp import (
+    DecodeDptPayloadInput,
+    DptFilter,
+    EncodeDptPayloadInput,
+    GroupAddressInput,
+    GroupValueReadInput,
+    GroupValueWriteInput,
+)
+
+
+@pytest.mark.parametrize(
+    "input_type",
+    [
+        DecodeDptPayloadInput,
+        DptFilter,
+        EncodeDptPayloadInput,
+        GroupAddressInput,
+        GroupValueReadInput,
+        GroupValueWriteInput,
+    ],
+)
+def test_input_fields_carry_a_description(input_type: type) -> None:
+    """Every input field is described, so a consumer can build its tool schema."""
+    field: Field  # type: ignore[type-arg]
+    for field in fields(input_type):
+        description = field.metadata.get("description")
+        assert isinstance(description, str) and description, (
+            f"{input_type.__name__}.{field.name} has no description metadata"
+        )

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -6,16 +6,20 @@ arguments and serialise outputs with :func:`dataclasses.asdict` without custom
 encoders. DPTs are rendered as ``"main"`` or ``"main.sub"`` strings and
 timestamps as ISO-8601.
 
-Input fields carry their human-readable description as :data:`typing.Annotated`
-metadata (a plain string). This keeps the library free of any schema/validation
-dependency while letting a consumer surface per-parameter descriptions in its
-tool schema via ``typing.get_type_hints(..., include_extras=True)``.
+Input fields carry their human-readable description in the dataclass field
+metadata - ``field(metadata={"description": ...})``. This keeps the library free
+of any schema/validation dependency while letting a consumer surface
+per-parameter descriptions in its tool schema: Pydantic applies the metadata of
+a stdlib dataclass field as its ``Field()`` arguments, so an MCP SDK deriving
+tool schemas through Pydantic picks the descriptions up without any glue code.
+Consumers that build their schema by hand read them from
+``dataclasses.fields(cls)`` without resolving type hints.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Annotated, Any
+from dataclasses import dataclass, field
+from typing import Any
 
 # JSON-native value carried on the bus (decoded via a DPT transcoder, or raw).
 GroupValue = bool | int | float | str | list[Any] | dict[str, Any] | None
@@ -25,12 +29,24 @@ GroupValue = bool | int | float | str | list[Any] | dict[str, Any] | None
 class DptFilter:
     """Filters for :func:`~xknx.mcp.tools.list_dpts`."""
 
-    main: Annotated[int | None, "Restrict to this DPT main number, e.g. 9."] = None
-    text: Annotated[
-        str | None, "Case-insensitive match on the DPT number, value type and unit."
-    ] = None
-    limit: Annotated[int, "Maximum number of results to return."] = 200
-    offset: Annotated[int, "Number of results to skip, for pagination."] = 0
+    main: int | None = field(
+        default=None,
+        metadata={"description": "Restrict to this DPT main number, e.g. 9."},
+    )
+    text: str | None = field(
+        default=None,
+        metadata={
+            "description": "Case-insensitive match on the DPT number, value type and unit."
+        },
+    )
+    limit: int = field(
+        default=200,
+        metadata={"description": "Maximum number of results to return."},
+    )
+    offset: int = field(
+        default=0,
+        metadata={"description": "Number of results to skip, for pagination."},
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,12 +108,18 @@ class ConnectionStatusResult:
 class GroupValueReadInput:
     """Input for :func:`~xknx.mcp.tools.read_group_value`."""
 
-    group_address: Annotated[str, 'Destination group address, e.g. "1/2/3".']
-    value_type: Annotated[
-        str | None,
-        'DPT number ("9.001") or value-type name ("temperature"); omit to return '
-        "the raw payload value.",
-    ] = None
+    group_address: str = field(
+        metadata={"description": 'Destination group address, e.g. "1/2/3".'}
+    )
+    value_type: str | None = field(
+        default=None,
+        metadata={
+            "description": (
+                'DPT number ("9.001") or value-type name ("temperature"); omit to '
+                "return the raw payload value."
+            )
+        },
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -114,20 +136,30 @@ class GroupValueReadResult:
 class GroupAddressInput:
     """Input naming a single group address (e.g. for a GroupValueRead)."""
 
-    group_address: Annotated[str, 'Group address to act on, e.g. "1/2/3".']
+    group_address: str = field(
+        metadata={"description": 'Group address to act on, e.g. "1/2/3".'}
+    )
 
 
 @dataclass(frozen=True, slots=True)
 class GroupValueWriteInput:
     """Input for :func:`~xknx.mcp.tools.send_group_value_write`."""
 
-    group_address: Annotated[str, 'Destination group address, e.g. "1/2/3".']
-    value: Annotated[GroupValue, "Value to write; encoded with value_type when given."]
-    value_type: Annotated[
-        str | None,
-        'DPT number ("9.001") or value-type name ("temperature"). Without it, an '
-        "int is sent as a 6-bit payload and a list of ints as a byte array.",
-    ] = None
+    group_address: str = field(
+        metadata={"description": 'Destination group address, e.g. "1/2/3".'}
+    )
+    value: GroupValue = field(
+        metadata={"description": "Value to write; encoded with value_type when given."}
+    )
+    value_type: str | None = field(
+        default=None,
+        metadata={
+            "description": (
+                'DPT number ("9.001") or value-type name ("temperature"). Without it, '
+                "an int is sent as a 6-bit payload and a list of ints as a byte array."
+            )
+        },
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -143,11 +175,14 @@ class SendResult:
 class EncodeDptPayloadInput:
     """Input for :func:`~xknx.mcp.tools.encode_dpt_payload`."""
 
-    value: Annotated[GroupValue, "Value to encode (Python native type)."]
-    value_type: Annotated[
-        str,
-        'DPT number ("9.001") or value-type name ("temperature") to encode with.',
-    ]
+    value: GroupValue = field(
+        metadata={"description": "Value to encode (Python native type)."}
+    )
+    value_type: str = field(
+        metadata={
+            "description": 'DPT number ("9.001") or value-type name ("temperature") to encode with.'
+        }
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,14 +197,19 @@ class EncodeDptPayloadResult:
 class DecodeDptPayloadInput:
     """Input for :func:`~xknx.mcp.tools.decode_dpt_payload`."""
 
-    payload: Annotated[
-        list[int] | int,
-        "Raw payload representation to decode (list of byte integers, or a single integer for 6-bit DPTs like DPT 1/2/3).",
-    ]
-    value_type: Annotated[
-        str,
-        'DPT number ("9.001") or value-type name ("temperature") to decode with.',
-    ]
+    payload: list[int] | int = field(
+        metadata={
+            "description": (
+                "Raw payload representation to decode (list of byte integers, or a "
+                "single integer for 6-bit DPTs like DPT 1/2/3)."
+            )
+        }
+    )
+    value_type: str = field(
+        metadata={
+            "description": 'DPT number ("9.001") or value-type name ("temperature") to decode with.'
+        }
+    )
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Summary

Moves the per-field descriptions of the `xknx.mcp` **input** dataclasses from `Annotated[T, "..."]` to `field(metadata={"description": "..."})`. Output dataclasses are untouched.

## Why

Both forms are stdlib-only and keep the package free of any schema/validation dependency, as intended. The difference is what a consumer gets for free.

The MCP SDKs build a tool's input schema from the function's type hints, through Pydantic — from the [Python SDK's tools documentation](https://py.sdk.modelcontextprotocol.io/servers/tools/):

> From those type hints the SDK generates a JSON Schema and sends it to the client during `tools/list`

> If you've used FastAPI or Pydantic, you already know all of this. It's the same `Field`, the same `Annotated`, the same validation.

And Pydantic applies the metadata of a **stdlib** dataclass field as that field's `Field()` arguments — see ["You can use both the Pydantic's `Field()` and the stdlib's `field()` functions"](https://pydantic.dev/docs/validation/latest/concepts/dataclasses/) with its `metadata={'title': ..., 'description': ...}` example. A bare string inside `Annotated`, by contrast, is metadata Pydantic does not recognise and silently ignores.

So today's descriptions never reach the wire unless every consumer writes its own extraction loop. Same tool defined both ways against the official SDK (`mcp` 2.0.0), reading back `tool.input_schema`:

```
with_annotated -> {"group_address": {"title": "Group Address", "type": "string"}}
with_metadata  -> {"group_address": {"description": "Destination group address, e.g. \"1/2/3\".",
                                     "title": "Group Address", "type": "string"}}
```

After this change, registering the real `send_group_value_write` with the SDK yields:

```json
"GroupValueWriteInput": {
  "description": "Input for :func:`~xknx.mcp.tools.send_group_value_write`.",
  "properties": {
    "group_address": {
      "description": "Destination group address, e.g. \"1/2/3\".",
      "title": "Group Address", "type": "string"
    },
    "value_type": {
      "anyOf": [{"type": "string"}, {"type": "null"}],
      "default": null,
      "description": "DPT number (\"9.001\") or value-type name (\"temperature\"). Without it, an int is sent as a 6-bit payload and a list of ints as a byte array.",
      "title": "Value Type"
    }
  },
  "required": ["group_address", "value"]
}
```

Zero glue code in the consumer. This is not new or version-fragile behaviour — I verified identical results on Pydantic 2.5.3, 2.9.2, 2.11.7 and 2.13.4. The mapping is not limited to `description`:

| declared | resulting JSON schema |
|---|---|
| `metadata={"description": "d"}` | `"description": "d"` |
| `metadata={"title": "T", "examples": ["x"]}` | `"title": "T", "examples": ["x"]` |
| `metadata={"ge": 1}` | `"minimum": 1` |
| `metadata={"foo": "bar"}` | ignored, no error |
| `Annotated[str, "d"]` | dropped |
| `Annotated[str, Doc("d")]` (PEP 727) | dropped |
| `Annotated[str, Field(description="d")]` | `"description": "d"` — but needs a Pydantic import |

`Annotated[..., Field(...)]` is the only other form that works, and it would put a Pydantic dependency in `xknx`, which is exactly what this package avoids. Adding constraints (`ge` on `offset`, etc.) is now possible without one — deliberately not done here to keep this change about descriptions only.

Consumers that build their schema by hand — Home Assistant's `mcp_server` derives its tool schemas from voluptuous via `voluptuous_openapi`, so it needs a mapping loop either way — benefit as well: `dataclasses.fields(cls)` exposes the metadata directly, with no `get_type_hints(..., include_extras=True)` call. That also removes a fragile coupling: the current approach obliges every consumer to keep every annotation in `xknx.mcp.types` resolvable at runtime from a module they do not own, so adding a single `TYPE_CHECKING`-only import here would break their extraction with a `NameError`.

## Trade-offs

- Noisier declarations: each documented field needs a `field(...)` call and its default moves inside it.
- The description leaves the type annotation, so it no longer shows on IDE hover of the type. It stays visible in the source and via `dataclasses.fields()`.
- `metadata` is `Mapping[str, Any]`, so a typo in the key is silent — the same weakness the bare-string `Annotated` form had. The new `types_test.py` guards the `description` key for every input field.

## Testing

`ruff`, `ruff format`, `mypy`, `pylint`, `codespell` and `pytest test/mcp_tests` (22 passed) all clean. No changelog entry: `xknx.mcp` is still under *Unreleased*, so this is not a breaking change for any release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
