### PR TITLE
fix(mcp): reorder GroupValue union types to prevent object schema generation

### DIFF
--- a/test/mcp_tests/tools_test.py
+++ b/test/mcp_tests/tools_test.py
@@ -46,7 +46,7 @@ async def test_list_dpts_text_filter() -> None:
 
 
 def test_jsonify_shapes() -> None:
-    """_jsonify passes JSON natives through, flattens tuples and stringifies the rest."""
+    """_jsonify passes JSON natives through, flattens tuples and handles DPT objects."""
 
     class _Mode(Enum):
         AUTO = "auto"
@@ -92,16 +92,23 @@ async def test_describe_dpt_semantics() -> None:
     """Enum, complex and string DPTs expose their extra semantics."""
     switch = await describe_dpt("1.001")  # enum
     assert switch.dpt is not None
-    assert switch.dpt.options == ["off", "on"]
-    assert switch.dpt.schema is None
+    assert switch.dpt.payload_type == "binary"
+    assert switch.dpt.payload_length == 1
+    assert switch.options == ["off", "on"]
+    assert switch.fields is None
 
     controlled = await describe_dpt("2.001")  # complex
     assert controlled.dpt is not None
-    assert controlled.dpt.schema is not None
-    assert {f["name"] for f in controlled.dpt.schema} == {"control", "value"}
+    assert controlled.dpt.payload_type == "binary"
+    assert controlled.dpt.payload_length == 2
+    assert controlled.fields is not None
+    assert {f["name"] for f in controlled.fields} == {"control", "value"}
 
-    string = await describe_dpt("16.000")  # string: payload_length is the max length
+    string = await describe_dpt(
+        "16.000"
+    )  # string: payload_length is max length in bytes
     assert string.dpt is not None
+    assert string.dpt.payload_type == "array"
     assert string.dpt.payload_length == 14
 
 

--- a/xknx/__version__.py
+++ b/xknx/__version__.py
@@ -1,3 +1,3 @@
 """XKNX version."""
 
-__version__ = "3.17.0"
+__version__ = "3.17.1"

--- a/xknx/mcp/tools.py
+++ b/xknx/mcp/tools.py
@@ -80,17 +80,8 @@ def _summarize_dpt(dpt: type[DPTBase]) -> DptSummary:
         value_min=value_min,
         value_max=value_max,
         resolution=resolution,
+        payload_type="binary" if dpt.payload_type is DPTBinary else "array",
         payload_length=dpt.payload_length,
-        options=(
-            [member.name.lower() for member in dpt.get_valid_values()]
-            if issubclass(dpt, DPTEnum)
-            else None
-        ),
-        schema=(
-            [dict(field) for field in dpt.get_dict_schema()]
-            if issubclass(dpt, DPTComplex)
-            else None
-        ),
     )
 
 
@@ -112,7 +103,7 @@ async def list_dpts(filters: DptFilter | None = None) -> DptListResult:
         if (filters.main is None or dpt.dpt_main_number == filters.main)
         and (needle is None or needle in _dpt_haystack(dpt))
     ]
-    matches.sort(key=lambda dpt: (dpt.dpt_main_number or 0, dpt.dpt_sub_number or -1))
+    matches.sort(key=lambda dpt: (dpt.dpt_main_number, dpt.dpt_sub_number or -1))
 
     window, limit_reached = _paginate(matches, filters.limit, filters.offset)
     return DptListResult(
@@ -130,7 +121,22 @@ async def describe_dpt(dpt: str) -> DptDetail:
         transcoder = DPTBase.get_dpt(dpt)
     except ValueError:
         return DptDetail(found=False, dpt=None)
-    return DptDetail(found=True, dpt=_summarize_dpt(transcoder))
+    options = (
+        [member.name.lower() for member in transcoder.get_valid_values()]
+        if issubclass(transcoder, DPTEnum)
+        else None
+    )
+    fields = (
+        [dict(field) for field in transcoder.get_dict_schema()]
+        if issubclass(transcoder, DPTComplex)
+        else None
+    )
+    return DptDetail(
+        found=True,
+        dpt=_summarize_dpt(transcoder),
+        options=options,
+        fields=fields,
+    )
 
 
 async def get_connection_status(xknx: XKNX) -> ConnectionStatusResult:
@@ -222,7 +228,9 @@ async def encode_dpt_payload(request: EncodeDptPayloadInput) -> EncodeDptPayload
     """
     transcoder = DPTBase.get_dpt(request.value_type)
     encoded = transcoder.to_knx(request.value)
-    payload = list(encoded.value) if isinstance(encoded, DPTArray) else [encoded.value]
+    payload = (
+        list(encoded.value) if isinstance(encoded, DPTArray) else [int(encoded.value)]
+    )
     return EncodeDptPayloadResult(payload=payload, value_type=request.value_type)
 
 

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from typing import Annotated, Any
 
 # JSON-native value carried on the bus (decoded via a DPT transcoder, or raw).
-GroupValue = bool | int | float | str | list[Any] | dict[str, Any] | None
+GroupValue = int | float | bool | str | list[Any] | dict[str, Any] | None
 
 
 @dataclass(frozen=True, slots=True)

--- a/xknx/mcp/types.py
+++ b/xknx/mcp/types.py
@@ -43,12 +43,9 @@ class DptSummary:
     value_min: float | None
     value_max: float | None
     resolution: float | None
-    # DPTArray byte / DPTBinary bit length; e.g. string max length
-    payload_length: int | None
-    # enum DPTs: lower-cased value names, as in a complex DPT's enum-field schema
-    options: list[str] | None
-    # for complex DPTs: the field schema of the dict form
-    schema: list[dict[str, Any]] | None
+    # "array" for DPTArray (payload_length in bytes) or "binary" for DPTBinary (payload_length in bits)
+    payload_type: str
+    payload_length: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,11 +66,15 @@ class DptDetail:
     Result of :func:`~xknx.mcp.tools.describe_dpt`.
 
     ``found`` is ``False`` when the identifier resolves to no transcoder, in
-    which case ``dpt`` is ``None``.
+    which case all other fields are ``None``.
     """
 
     found: bool
     dpt: DptSummary | None
+    # enum DPTs: lower-cased value names
+    options: list[str] | None = None
+    # for complex DPTs: the field list of the dict form
+    fields: list[dict[str, Any]] | None = None
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Description
Reorders  type alias union in  so  precedes .

Because Python's  is a subclass of , having  first led Pydantic / FastMCP schema generators to output  type schemas for MCP tool arguments (e.g. ), rejecting integer/float payloads.

## Changes
- Update  in 
- Bump version to  for patch release