### PR TITLE
Parse M_PropInfo.ind cEMI frames

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Features
+
+- Parse `M_PropInfo.ind` cEMI frames. A KNXnet/IP server uses them to announce a property changing on its own, for example the KNXnet/IP parameter object's device state when the KNX bus fails, and `CEMIFrame.from_knx()` raised `UnsupportedCEMIMessage` for them. The payload is the same as `M_PropRead.con`, so it is parsed into a `CEMIMPropReadResponse`. Serializing already worked.
+
 # 3.18.0 Protocol Droid 2026-08-02
 
 ### Bugfixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,9 +8,9 @@ nav_order: 2
 
 # Unreleased changes
 
-### Features
+### Protocol
 
-- Parse `M_PropInfo.ind` cEMI frames. A KNXnet/IP server uses them to announce a property changing on its own, for example the KNXnet/IP parameter object's device state when the KNX bus fails, and `CEMIFrame.from_knx()` raised `UnsupportedCEMIMessage` for them. The payload is the same as `M_PropRead.con`, so it is parsed into a `CEMIMPropReadResponse`. Serializing already worked.
+- Parse `M_PropInfo.ind` cEMI frames into a `CEMIMPropReadResponse` - its payload has the same layout as `M_PropRead.con`. A KNXnet/IP server sends these to announce a property changing on its own, e.g. the KNXnet/IP parameter object's device state when the KNX bus fails; they previously raised `UnsupportedCEMIMessage` and were counted as incoming errors. Serializing already worked.
 
 # 3.18.0 Protocol Droid 2026-08-02
 

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -482,8 +482,8 @@ def test_valid_prop_info_ind() -> None:
     assert frame.to_knx() == raw
 
 
-def test_valid_error_prop_info_ind() -> None:
-    """Test for valid frame parsing."""
+def test_prop_info_ind_with_error_code() -> None:
+    """Test lenient parsing of an off-spec error payload in M_PropInfo.ind."""
     raw = get_prop(0xF7, 0x000B, 1, 69, 0, 1, [0x07])
     frame = CEMIFrame.from_knx(raw)
     assert frame.code == CEMIMessageCode.M_PROP_INFO_IND

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -459,6 +459,40 @@ def test_valid_error_read_con() -> None:
     assert frame.to_knx() == raw
 
 
+def test_valid_prop_info_ind() -> None:
+    """Test for valid frame parsing."""
+    raw = get_prop(0xF7, 0x000B, 1, 69, 1, 1, [0x01])
+    frame = CEMIFrame.from_knx(raw)
+    assert frame.code == CEMIMessageCode.M_PROP_INFO_IND
+    assert isinstance(frame.data, CEMIMPropReadResponse)
+    assert (
+        frame.data.property_info.object_type
+        == ResourceObjectType.OBJECT_KNXNETIP_PARAMETER
+    )
+    assert frame.data.property_info.object_instance == 1
+    assert (
+        frame.data.property_info.property_id
+        == ResourceKNXNETIPPropertyId.PID_KNXNETIP_DEVICE_STATE
+    )
+    assert frame.data.property_info.number_of_elements == 1
+    assert frame.data.property_info.start_index == 1
+    assert frame.data.error_code is None
+    assert frame.data.data == bytes([0x01])
+    assert frame.calculated_length() == 8
+    assert frame.to_knx() == raw
+
+
+def test_valid_error_prop_info_ind() -> None:
+    """Test for valid frame parsing."""
+    raw = get_prop(0xF7, 0x000B, 1, 69, 0, 1, [0x07])
+    frame = CEMIFrame.from_knx(raw)
+    assert frame.code == CEMIMessageCode.M_PROP_INFO_IND
+    assert isinstance(frame.data, CEMIMPropReadResponse)
+    assert frame.data.property_info.number_of_elements == 0
+    assert frame.data.error_code == CEMIErrorCode.CEMI_ERROR_VOID_DP
+    assert frame.to_knx() == raw
+
+
 def test_valid_write_req() -> None:
     """Test for valid frame parsing."""
     raw = get_prop(0xF6, 0x000B, 1, 52, 1, 1, [0x12, 0x03])

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -682,6 +682,10 @@ class CEMIFrame:
             return CEMIFrame(code=code, data=CEMIMPropWriteRequest.from_knx(raw[1:]))
         if code == CEMIMessageCode.M_PROP_WRITE_CON:
             return CEMIFrame(code=code, data=CEMIMPropWriteResponse.from_knx(raw[1:]))
+        if code == CEMIMessageCode.M_PROP_INFO_IND:
+            # Same payload as M_PropRead.con: the property, then either its
+            # value or, with number of elements zero, an error code.
+            return CEMIFrame(code=code, data=CEMIMPropReadResponse.from_knx(raw[1:]))
 
         raise UnsupportedCEMIMessage(
             f"Could not handle CEMIMessageCode: {code} / {raw[0]} in CEMI: {raw.hex()}"

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -683,8 +683,9 @@ class CEMIFrame:
         if code == CEMIMessageCode.M_PROP_WRITE_CON:
             return CEMIFrame(code=code, data=CEMIMPropWriteResponse.from_knx(raw[1:]))
         if code == CEMIMessageCode.M_PROP_INFO_IND:
-            # Same payload as M_PropRead.con: the property, then either its
-            # value or, with number of elements zero, an error code.
+            # Same payload as M_PropRead.con. The spec defines only the positive
+            # form (number of elements > 0, see 3/6/3 EMI_IMI §4.1.7.3.6); a
+            # number of elements == 0 error payload is parsed leniently as well.
             return CEMIFrame(code=code, data=CEMIMPropReadResponse.from_knx(raw[1:]))
 
         raise UnsupportedCEMIMessage(


### PR DESCRIPTION
## Description
A KNXnet/IP server sends M_PropInfo.ind to announce a property changing on its own, such as the device state of the KNXnet/IP parameter object when the KNX bus fails. The message code was already known and already excluded from carrying additional info, and serializing a frame with it worked, but from_knx() rejected it with UnsupportedCEMIMessage.

Its payload is the same as M_PropRead.con: the property, then either its value or, when the number of elements is zero, an error code. Parse it into a CEMIMPropReadResponse.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)