### PR TITLE
Don't swallow the cause of CEMI and APDU parse errors

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - Fix the encoding of `SecurityALService.S_A_SYNC_REQ`: the S-A-Service field of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001` - KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5. Incoming Data Secure sync requests were rejected with `CouldNotParseCEMI` "APDU invalid" instead of being parsed and then ignored as an unsupported S-AL service.
 
+### Internals
+
+- Keep the underlying error message when a CEMI or APDU parse error is re-raised as a more generic exception so it no longer hides what was actually wrong with the frame.
+
 # 3.18.0 Protocol Droid 2026-08-02
 
 ### Bugfixes

--- a/test/cemi_tests/cemi_frame_test.py
+++ b/test/cemi_tests/cemi_frame_test.py
@@ -149,6 +149,28 @@ def test_truncated_secure_apdu() -> None:
         CEMIFrame.from_knx(raw)
 
 
+def test_invalid_secure_apdu_keeps_cause_in_message() -> None:
+    """
+    Test the CEMI parse error repeats the underlying APDU error message.
+
+    L_Data.ind carrying an A_SecureData APDU (APCI 0x3F1) whose SCF names the
+    reserved S-A-Service 0b100. `CouldNotParseCEMI` is logged as a plain string,
+    so the message must carry the cause; without it the log only says "APDU
+    invalid" and the actual defect of the frame is lost.
+    """
+    raw = bytes.fromhex(
+        "290030e010fc00001803f194003f1414e8e5000a46492919b3498640a7655948919e"
+    )
+    with pytest.raises(CouldNotParseCEMI) as err_info:
+        CEMIFrame.from_knx(raw)
+
+    message = str(err_info.value)
+    assert "APDU invalid" in message
+    assert "Error parsing APCI 0b1111110001" in message  # APCI layer
+    assert "4 is not a valid SecurityALService" in message  # root cause
+    assert "from 1.0.252 to 0/0/0" in message  # CEMI layer context
+
+
 def test_invalid_apdu_len() -> None:
     """Test for invalid apdu len."""
     with pytest.raises(CouldNotParseCEMI, match=r".*APDU LEN should be .*"):

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -153,6 +153,19 @@ class TestAPCI:
         with pytest.raises(ConversionError):
             APCI.from_knx(raw)
 
+    def test_from_knx_keeps_cause_in_message(self) -> None:
+        """Test the wrapping ConversionError repeats the original error message."""
+        # A_SecureData (0x3F1) with SCF 0x94 -> reserved S-A-Service 0b100. The
+        # enum lookup failure is the only hint about what is wrong with the frame,
+        # so it must survive the wrapping - `raise ... from err` alone only shows
+        # up in a traceback, not in the message loggers print.
+        raw = bytes.fromhex("03f194003f1414e8e5000a46492919b3498640a7655948919e")
+        with pytest.raises(
+            ConversionError, match=r".*4 is not a valid SecurityALService.*"
+        ) as err_info:
+            APCI.from_knx(raw)
+        assert isinstance(err_info.value.__cause__, ValueError)
+
 
 class TestGroupValueRead:
     """Test class for GroupValueRead objects."""

--- a/xknx/cemi/cemi_frame.py
+++ b/xknx/cemi/cemi_frame.py
@@ -275,7 +275,7 @@ class CEMILData(CEMIData):
             )
         except ConversionError as err:
             raise UnsupportedCEMIMessage(
-                f"TPCI not supported: {_tpdu[0]:#10b} "
+                f"TPCI not supported: {err.description} - {_tpdu[0]:#10b} "
                 f"from {src_addr} in CEMI: {raw.hex()}"
             ) from err
 
@@ -298,15 +298,17 @@ class CEMILData(CEMIData):
         except UnsupportedAPCIService as err:
             # Recognized but not implemented (or reserved) APCI service - benign,
             # to be ignored per KNX spec 03_03_07 §2.2. Logged at info level.
+            # The cause names the offending service - keep it in the message.
             raise UnsupportedCEMIMessage(
-                f"APDU not supported from {src_addr} to {dst_addr} "
+                f"APDU not supported: {err.description} - from {src_addr} to {dst_addr} "
                 f"with TPCI {tpci} in CEMI: {raw.hex()}"
             ) from err
         except ConversionError as err:
             # Malformed/truncated APDU of a recognized service - a genuine parse
-            # error worth surfacing at warning level.
+            # error worth surfacing at warning level. Only the cause tells what
+            # was actually wrong with the APDU, so it is part of the message.
             raise CouldNotParseCEMI(
-                f"APDU invalid from {src_addr} to {dst_addr} "
+                f"APDU invalid: {err.description} - from {src_addr} to {dst_addr} "
                 f"with TPCI {tpci} in CEMI: {raw.hex()}"
             ) from err
 

--- a/xknx/telegram/apci.py
+++ b/xknx/telegram/apci.py
@@ -439,8 +439,11 @@ class APCI(ABC):
                 if apci == APCIExtendedService.APCI_SEC.value:
                     return SecureAPDU.from_knx(raw)
         except (IndexError, struct.error, ValueError) as err:
+            # Include the original exception in the message - these are raised deep
+            # inside the service parsers (slicing, `struct.unpack`, enum lookups) and
+            # carry the only hint about what exactly was wrong with the payload.
             raise ConversionError(
-                f"Error parsing APCI {apci:#012b} from raw data: {raw.hex()}"
+                f"Error parsing APCI {apci:#012b} from raw data: {raw.hex()}: {err!r}"
             ) from err
 
         raise UnsupportedAPCIService(f"Class not implemented for APCI {apci:#012b}.")


### PR DESCRIPTION
### Description

`CouldNotParseCEMI` and `UnsupportedCEMIMessage` are logged with `%s`, so the exception chain established by `raise ... from err` never reaches the log - only the outermost, most generic message does. Reported from a Home Assistant log:

```
WARNING (MainThread) [xknx.cemi] CEMI Frame failed to parse: <CouldNotParseCEMI description="APDU invalid from 1.0.252 to 0/0/0 with TPCI TDataBroadcast() in CEMI: 30e010fc00001803f192003f1414e8e5000a46492919b3498640a7655948919e" />
```

Two layers each dropped their cause, so acting on a report like this means re-parsing the hex by hand in a REPL.

- `APCI.from_knx` now repeats the `IndexError` / `struct.error` / `ValueError` it wraps in its `ConversionError` message. These are raised deep inside the service parsers (slicing, `struct.unpack`, enum lookups) and carry the only hint about what exactly was wrong with the payload.
- `CEMILData.from_knx` includes the description of the wrapped `ConversionError` / `UnsupportedAPCIService` / TPCI error. The "APDU not supported" case gains the most - it used to drop the name of the offending service entirely, even though that is the whole point of the message.

The same frame now logs as

```
<CouldNotParseCEMI description="APDU invalid: Error parsing APCI 0b1111110001 from raw data: 03f192003f1414e8e5000a46492919b3498640a7655948919e: ValueError('2 is not a valid SecurityALService') - from 1.0.252 to 0/0/0 with TPCI TDataBroadcast() in CEMI: 30e010fc00001803f192003f1414e8e5000a46492919b3498640a7655948919e" />
```

The APDU hex appears twice - once on its own, once as part of the cEMI frame. `APCI.from_knx` is also used standalone, so it keeps its own context.

Note that the frame from that report is *not* actually invalid - it is a Data Secure S-A_Sync_Req with a mis-decoded S-A-Service. That is fixed separately in `fix-data-secure-scf-sync-req`; the tests here use SCF `0x94` (S-A-Service `0b100`, reserved) instead, so the two changes are independent.

### Checklist

- [x] Tests added/updated
- [x] `docs/changelog.md` updated