### PR TITLE
Fix S-A-Service encoding of S-A_Sync_Req in the SCF

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Bugfixes
+
+- Fix the encoding of `SecurityALService.S_A_SYNC_REQ`: the S-A-Service field of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001` (AN158 v07 Figure 12 and Table 2; the SCF examples of Figure 15 and 16 use `0x9A` / `0x9B`). Incoming Data Secure sync requests were rejected with `CouldNotParseCEMI` "APDU invalid" instead of being parsed and then ignored as an unsupported S-AL service.
+
 # 3.18.0 Protocol Droid 2026-08-02
 
 ### Bugfixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ nav_order: 2
 
 ### Bugfixes
 
-- Fix the encoding of `SecurityALService.S_A_SYNC_REQ`: the S-A-Service field of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001` (AN158 v07 Figure 12 and Table 2; the SCF examples of Figure 15 and 16 use `0x9A` / `0x9B`). Incoming Data Secure sync requests were rejected with `CouldNotParseCEMI` "APDU invalid" instead of being parsed and then ignored as an unsupported S-AL service.
+- Fix the encoding of `SecurityALService.S_A_SYNC_REQ`: the S-A-Service field of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001` - KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5. Incoming Data Secure sync requests were rejected with `CouldNotParseCEMI` "APDU invalid" instead of being parsed and then ignored as an unsupported S-AL service.
 
 # 3.18.0 Protocol Droid 2026-08-02
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -5582,7 +5582,8 @@ class TestSecureAPDU:
         """Test the from_knx method for an S-A_Sync_Req-PDU."""
         # Real frame from 1.0.252 to 0/0/0. SCF 0x92 -> tool access, CCM with
         # confidentiality, S-A_Sync_Req. Its ASDU holds the 6 octet KNX serial
-        # number and the 6 octet challenge - AN158 v07 Figure 15.
+        # number and the 6 octet challenge - KNX v02.01.01 - Application Layer
+        # 03.03.07 - §5.3.2 Figure 109.
         raw = bytes.fromhex("03f192003f1414e8e5000a46492919b3498640a7655948919e")
         payload = APCI.from_knx(raw)
 

--- a/test/telegram_tests/apci_test.py
+++ b/test/telegram_tests/apci_test.py
@@ -5578,6 +5578,30 @@ class TestSecureAPDU:
         assert payload.secured_data.secured_apdu == b"\xaa\xbb"
         assert payload.secured_data.message_authentication_code == b"\x11\x22\x33\x44"
 
+    def test_from_knx_sync_request(self) -> None:
+        """Test the from_knx method for an S-A_Sync_Req-PDU."""
+        # Real frame from 1.0.252 to 0/0/0. SCF 0x92 -> tool access, CCM with
+        # confidentiality, S-A_Sync_Req. Its ASDU holds the 6 octet KNX serial
+        # number and the 6 octet challenge - AN158 v07 Figure 15.
+        raw = bytes.fromhex("03f192003f1414e8e5000a46492919b3498640a7655948919e")
+        payload = APCI.from_knx(raw)
+
+        assert isinstance(payload, SecureAPDU)
+        assert payload.scf.tool_access is True
+        assert payload.scf.algorithm == SecurityAlgorithmIdentifier.CCM_ENCRYPTION
+        assert payload.scf.system_broadcast is False
+        assert payload.scf.service == SecurityALService.S_A_SYNC_REQ
+        assert payload.secured_data.sequence_number_bytes == bytes.fromhex(
+            "003f1414e8e5"
+        )
+        assert payload.secured_data.secured_apdu == bytes.fromhex(
+            "000a46492919b3498640a765"
+        )
+        assert payload.secured_data.message_authentication_code == bytes.fromhex(
+            "5948919e"
+        )
+        assert payload.to_knx() == raw
+
     def test_from_knx_wrong_length(self) -> None:
         """Test from_knx raises ConversionError for a too-short APDU."""
         with pytest.raises(ConversionError, match=r".*Invalid length.*"):

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -62,8 +62,11 @@ class SecurityAlgorithmIdentifier(IntEnum):
 class SecurityALService(IntEnum):
     """Enum representing the used security application layer service."""
 
+    # AN158 v07 Figure 12 and Table 2; 0b001 is not a defined service.
+    # The SCF examples of Figure 15 (S-A_Sync_Req 0x9A) and Figure 16
+    # (S-A_Sync_Res 0x9B) confirm the encoding.
     S_A_DATA = 0b000
-    S_A_SYNC_REQ = 0b001
+    S_A_SYNC_REQ = 0b010
     S_A_SYNC_RES = 0b011
 
 

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -62,8 +62,9 @@ class SecurityAlgorithmIdentifier(IntEnum):
 class SecurityALService(IntEnum):
     """Enum representing the used security application layer service."""
 
-    # AN158 v07 Figure 12 and Table 2; 0b001 is not a defined service.
-    # The SCF examples of Figure 15 (S-A_Sync_Req 0x9A) and Figure 16
+    # KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5; 0b001 is not
+    # a defined service. The SCF is specified in §5.2.1.2 Figure 106; its
+    # example values in §5.3.2 Figure 109 (S-A_Sync_Req 0x9A) and Figure 110
     # (S-A_Sync_Res 0x9B) confirm the encoding.
     S_A_DATA = 0b000
     S_A_SYNC_REQ = 0b010

--- a/xknx/secure/data_secure_asdu.py
+++ b/xknx/secure/data_secure_asdu.py
@@ -62,10 +62,7 @@ class SecurityAlgorithmIdentifier(IntEnum):
 class SecurityALService(IntEnum):
     """Enum representing the used security application layer service."""
 
-    # KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5; 0b001 is not
-    # a defined service. The SCF is specified in §5.2.1.2 Figure 106; its
-    # example values in §5.3.2 Figure 109 (S-A_Sync_Req 0x9A) and Figure 110
-    # (S-A_Sync_Res 0x9B) confirm the encoding.
+    # KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5
     S_A_DATA = 0b000
     S_A_SYNC_REQ = 0b010
     S_A_SYNC_RES = 0b011


### PR DESCRIPTION
### Description

The S-A-Service field (`b2..b0`) of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001`. `SecurityALService.S_A_SYNC_REQ` has had the wrong value since Data Secure was added in #1167; `0b001` is not a defined service at all.

Sources - all in `KNX v02.01.01 - Application Layer 03.03.07`:

- **§5.1.1 Table 5** (Security Application Layer PDUs): `000` S-A_Data-PDU, `010` S-A_Sync_Req-PDU, `011` S-A_Sync_Res-PDU. The same table marks the sync PDUs as mandatory on T_Data_Broadcast, T_Data_SystemBroadcast, T_Data_Individual and T_Data_Connected, and not allowed on T_Data_Group / T_Data_Tag_Group.
- **§5.2.1.2 Figure 106** (Security Control Field) gives the bit layout: `b7` Tool Access, `b6..b4` SAI, `b3` SBC, `b2..b0` S-AL service.
- The worked SCF examples confirm it: **§5.3.2 Figure 109** uses `9Ah` for an S-A_Sync_Req ("SCF with Tool Key and SBC set"), **Figure 110** uses `9Bh` for the S-A_Sync_Res.

Calimero agrees - `SecureApplicationLayer.java`: `SecureDataPdu = 0`, `SecureSyncRequest = 2`, `SecureSyncResponse = 3`.

### Impact

An incoming sync request could not be parsed and was rejected while decoding the APDU, so it surfaced as a `CouldNotParseCEMI` warning about a malformed frame - reported from a Home Assistant log:

```
WARNING (MainThread) [xknx.cemi] CEMI Frame failed to parse: <CouldNotParseCEMI description="APDU invalid from 1.0.252 to 0/0/0 with TPCI TDataBroadcast() in CEMI: 30e010fc00001803f192003f1414e8e5000a46492919b3498640a7655948919e" />
```

That frame is well formed: SCF `0x92` = tool access, CCM with confidentiality, SBC=0, S-A_Sync_Req. Its ASDU matches Figure 109 exactly - 6 octets plaintext SeqNr, 12 encrypted octets (6 octet KNX serial number + 6 octet challenge), 4 octet MAC. Broadcast is a legitimate destination for a sync request per Table 5, and Calimero sends them that way too.

With the fix the frame parses, and `DataSecure._received_secure_cemi` discards it as an unsupported S-AL service at debug level, as intended - xknx implements no sync handling. Nothing else in xknx reads `S_A_SYNC_REQ`; the enum members exist only so a received SCF can be decoded, which is why this stayed unnoticed.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

### Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)