### PR TITLE
Notify on every received Cover position telegram

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ nav_order: 2
 
 - Fix the encoding of `SecurityALService.S_A_SYNC_REQ`: the S-A-Service field of the Security Control Field encodes an S-A_Sync_Req-PDU as `0b010`, not `0b001` - KNX v02.01.01 - Application Layer 03.03.07 - §5.1.1 Table 5. Incoming Data Secure sync requests were rejected with `CouldNotParseCEMI` "APDU invalid" instead of being parsed and then ignored as an unsupported S-AL service.
 
+### Devices
+
+- Cover: run device callbacks for every received current position telegram, even when the position doesn't change. Previously a GroupValueResponse or GroupValueWrite confirming the position a consumer already assumed - eg. one restored from a previous run - was swallowed, so the consumer never learned that its position is now confirmed by the bus. The periodic update task is still only started when the position actually changed.
+
 ### Protocol
 
 - Parse `M_PropInfo.ind` cEMI frames into a `CEMIMPropReadResponse` - its payload has the same layout as `M_PropRead.con`. A KNXnet/IP server sends these to announce a property changing on its own, e.g. the KNXnet/IP parameter object's device state when the KNX bus fails; they previously raised `UnsupportedCEMIMessage` and were counted as incoming errors. Serializing already worked.

--- a/test/devices_tests/cover_test.py
+++ b/test/devices_tests/cover_test.py
@@ -837,6 +837,9 @@ class TestCover:
             # call position with same value again to make sure `always_callback` is set for target position
             ("1/2/4", DPTArray(42), "position"),
             ("1/2/5", DPTArray(42), "position state"),
+            # call position state with same value again - confirming the current
+            # position is new information even when the position didn't change
+            ("1/2/5", DPTArray(42), "position state"),
             ("1/2/6", DPTArray(42), "angle"),
             ("1/2/7", DPTArray(51), "angle state"),
         ]:

--- a/xknx/devices/cover.py
+++ b/xknx/devices/cover.py
@@ -305,11 +305,15 @@ class Cover(Device):
             self.travelcalculator.update_position(new_position)
         else:
             self.travelcalculator.set_position(new_position)
-        if position_before_update != self.travelcalculator.current_position():
-            if position_before_update is not None:  # None on first move
-                # restarts when already running
-                self.xknx.task_registry.start_task(self._periodic_update_task)
-            self.after_update()
+        if (
+            position_before_update != self.travelcalculator.current_position()
+            and position_before_update is not None  # None on first move
+        ):
+            # restarts when already running
+            self.xknx.task_registry.start_task(self._periodic_update_task)
+        # a telegram confirming an unchanged position is new information too - it
+        # tells a consumer that the position isn't just an assumption anymore
+        self.after_update()
 
     async def set_angle(self, angle: int) -> None:
         """Move cover to designated angle."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

`Cover._current_position_from_rv` only ran device callbacks when the received position differed from the travelcalculators current position. A `GroupValueResponse` or `GroupValueWrite` confirming a position a consumer already assumed - eg. one restored from a previous run - was therefore swallowed, so the consumer never learned that its position is confirmed by the bus now.

Found in Home Assistant: a KNX cover restores its last position on startup and reports `assumed_state` until the bus confirms it. When the initial read response carried exactly the restored position, no callback ran, so the entity state was never written and kept `assumed_state: true` indefinitely - even though `position_current.value` was set by then.

`position_current` is processed with `always_callback=True`, so notifying for every position telegram is what the RemoteValue already intends; the change-filter in the device callback contradicted that. The periodic update task is still only started when the position actually changed.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)
