### PR TITLE
Add Scene.learn() and move Scene to DPT 18.001

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -26,10 +26,15 @@ nav_order: 2
 - Remove device lookup by name or index from `xknx.devices`. `xknx.devices["NameOfDevice"]` and `xknx.devices[0]` are gone - device names are never checked for uniqueness, so the lookup could return any one of several devices sharing a name. Keep a reference to the device object instead, or iterate `xknx.devices` to find it. `device in xknx.devices` takes the `Device` object now instead of its name.
 - `Devices.async_add()` and `Devices.async_remove()` raise `ValueError` when the device object is already registered, or not registered at all. Adding a device twice had it receive every telegram twice and fire its callbacks twice; removing an unregistered one cancelled its tasks and unregistered its state updater before failing.
 - Remove `Device.__eq__()` - same reasoning as `RemoteValue.__eq__()` above: it compared `__dict__` attributes and was a leftover of the YAML config handling removed in 1.0. Devices compare by identity now, which also makes `Device` hashable again, so devices can be used in sets and as dict keys. The same applies to `Light.red`, `.green`, `.blue` and `.white`.
+- `Scene.scene_value` is a `RemoteValueSceneControl` (DPT 18.001) instead of a `RemoteValueSceneNumber` (DPT 17.001), so its value carries the learn bit next to the scene number. Telegrams on the wire are unchanged: DPT 18.001 encodes an activation to the same octet DPT 17.001 does, and decodes one back the same way. The device callback is called for received learn telegrams of the devices `scene_number` now, not only for activations - the new `Scene.learn_requested` tells both apart.
 
 ### Connection
 
 - KNX IP Secure transports discard unencrypted frames instead of passing them to their callbacks. A secure session accepts a plain frame only for the handshake - `SessionRequest` outgoing, `SessionResponse` incoming - and raises `IPSecureError` when anything else is sent before the session is initialized. Secure routing keeps forwarding plain discovery and self description frames (`SearchRequest`, `SearchResponse`, `DescriptionRequest` and `DescriptionResponse`, extended variants included) since these services are never secured and share the multicast endpoint, but now drops every other plain frame - previously only `RoutingIndication` was dropped, so a plain `RoutingBusy` from any sender could still throttle outgoing telegrams. Frames that may not be encapsulated at all - a nested `SecureWrapper` and the Remote Configuration and Diagnosis service family - are discarded when received inside a `SecureWrapper`.
+
+### Devices
+
+- Scene: add `learn()` to send a telegram with the learn bit set, telling actuators to store their current state as this scene. Received learn telegrams are decoded instead of logging a "Can not process" warning, so a Scene can serve as scene actuator: restore its state from the device callback when `learn_requested` is `False`, store it when it is `True`.
 
 ### Internals
 

--- a/examples/example_scene.py
+++ b/examples/example_scene.py
@@ -1,4 +1,4 @@
-"""Example for switching a light on and off."""
+"""Example for activating a scene and for reacting to scenes called on the bus."""
 
 import asyncio
 
@@ -6,13 +6,33 @@ from xknx import XKNX
 from xknx.devices import Scene
 
 
+def scene_updated_cb(scene: Scene) -> None:
+    """Handle a telegram for the scene number of this device."""
+    if scene.learn_requested:
+        # a learn telegram tells actuators to store their current state
+        print(f"Storing current state as scene {scene.scene_number}")
+    else:
+        print(f"Restoring state of scene {scene.scene_number}")
+
+
 async def main() -> None:
-    """Connect to KNX/IP bus and run scene."""
+    """Connect to KNX/IP bus, call a scene and listen for scenes called by others."""
     async with XKNX() as xknx:
-        scene = Scene(xknx, name="Romantic", group_address="7/0/9", scene_number=23)
+        scene = Scene(
+            xknx,
+            name="Romantic",
+            group_address="7/0/9",
+            scene_number=23,
+            device_updated_cb=scene_updated_cb,
+        )
         xknx.devices.async_add(scene)
 
+        # `scene.learn()` would ask the actuators to store their current state
+        # as this scene instead of restoring it
         await scene.run()
+
+        # listen for scene telegrams from the bus
+        await asyncio.sleep(10)
 
 
 asyncio.run(main())

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -27,7 +27,7 @@
 |[Switch light](./example_light_switch.py)|Example for switching a light on and off|
 |[Sensor](./example_sensor.py)|Example for Sensor device|
 |[Switch](./example_switch.py)|Example for Switch device|
-|[Scene](./example_scene.py)|Example for calling a scene|
+|[Scene](./example_scene.py)|Example for calling a scene and reacting to scenes called or learned on the bus|
 |[Weather](./example_weather.py)|Example for reading a Weather devices data|
 
 ## Low-level

--- a/test/devices_tests/scene_test.py
+++ b/test/devices_tests/scene_test.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from xknx import XKNX
 from xknx.devices import Scene
 from xknx.dpt import DPTArray
@@ -38,6 +40,21 @@ class TestScene:
         )
 
     #
+    # TEST LEARN SCENE
+    #
+    async def test_learn(self) -> None:
+        """Test storing a scene."""
+        xknx = XKNX()
+        scene = Scene(xknx, "TestScene", group_address="1/2/1", scene_number=23)
+        await scene.learn()
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/1"),
+            payload=GroupValueWrite(DPTArray(0x96)),
+        )
+
+    #
     # TEST has_group_address
     #
     def test_has_group_address(self) -> None:
@@ -47,7 +64,7 @@ class TestScene:
         assert scene.has_group_address(GroupAddress("1/2/1"))
         assert not scene.has_group_address(GroupAddress("2/2/2"))
 
-    async def test_process_callback(self) -> None:
+    async def test_process_callback(self, caplog: pytest.LogCaptureFixture) -> None:
         """Test process / reading telegrams from telegram queue. Test if callback is called."""
 
         xknx = XKNX()
@@ -76,3 +93,39 @@ class TestScene:
             )
         )
         after_update_callback.assert_not_called()
+
+        assert not scene.learn_requested
+
+        after_update_callback.reset_mock()
+        scene.process(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x80,))),  # same scene number, learn
+            )
+        )
+        # a request to store the scene calls the callback too - `learn_requested`
+        # tells it apart from an activation
+        after_update_callback.assert_called_with(scene)
+        assert scene.learn_requested
+        assert not caplog.records
+
+        after_update_callback.reset_mock()
+        scene.process(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x81,))),  # different scene number
+            )
+        )
+        # another scene neither calls the callback nor changes `learn_requested`
+        after_update_callback.assert_not_called()
+        assert scene.learn_requested
+
+        after_update_callback.reset_mock()
+        scene.process(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTArray((0x00,))),  # same number, activate
+            )
+        )
+        after_update_callback.assert_called_with(scene)
+        assert not scene.learn_requested

--- a/test/remote_value_tests/remote_value_scene_control_test.py
+++ b/test/remote_value_tests/remote_value_scene_control_test.py
@@ -1,0 +1,108 @@
+"""Unit test for RemoteValueSceneControl objects."""
+
+import pytest
+
+from xknx import XKNX
+from xknx.dpt import DPTArray, DPTBinary, SceneControl
+from xknx.exceptions import ConversionError
+from xknx.remote_value import RemoteValueSceneControl
+from xknx.telegram import GroupAddress, Telegram
+from xknx.telegram.apci import GroupValueWrite
+
+
+class TestRemoteValueSceneControl:
+    """Test class for RemoteValueSceneControl objects."""
+
+    @pytest.mark.parametrize(
+        ("value", "raw"),
+        [
+            (SceneControl(11), 0x0A),
+            (SceneControl(11, learn=True), 0x8A),
+            (SceneControl(1), 0x00),
+            (SceneControl(64, learn=True), 0xBF),
+        ],
+    )
+    def test_to_knx(self, value: SceneControl, raw: int) -> None:
+        """Test to_knx function with normal operation."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(xknx)
+        assert remote_value.to_knx(value) == DPTArray((raw,))
+
+    @pytest.mark.parametrize(
+        ("raw", "value"),
+        [
+            (0x0A, SceneControl(11)),
+            (0x8A, SceneControl(11, learn=True)),
+            (0x00, SceneControl(1)),
+            (0xBF, SceneControl(64, learn=True)),
+        ],
+    )
+    def test_from_knx(self, raw: int, value: SceneControl) -> None:
+        """Test from_knx function with normal operation."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(xknx)
+        assert remote_value.from_knx(DPTArray((raw,))) == value
+
+    def test_to_knx_error(self) -> None:
+        """Test to_knx function with wrong parametern."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(xknx)
+        with pytest.raises(ConversionError):
+            remote_value.to_knx(SceneControl(100))
+        with pytest.raises(ConversionError):
+            remote_value.to_knx({"scene_number": 11, "learn": "yes"})
+
+    def test_set(self) -> None:
+        """Test setting value."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(
+            xknx, group_address=GroupAddress("1/2/3")
+        )
+        remote_value.set(SceneControl(11))
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x0A,))),
+        )
+        remote_value.set(SceneControl(11, learn=True))
+        assert xknx.telegrams.qsize() == 1
+        telegram = xknx.telegrams.get_nowait()
+        assert telegram == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x8A,))),
+        )
+
+    def test_process(self) -> None:
+        """Test process telegram."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(
+            xknx, group_address=GroupAddress("1/2/3")
+        )
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x8A,))),
+        )
+        remote_value.process(telegram)
+        assert remote_value.value == SceneControl(11, learn=True)
+
+    def test_to_process_error(self) -> None:
+        """Test process erroneous telegram."""
+        xknx = XKNX()
+        remote_value = RemoteValueSceneControl(
+            xknx, group_address=GroupAddress("1/2/3")
+        )
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTBinary(1)),
+        )
+        assert remote_value.process(telegram) is False
+
+        telegram = Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x64, 0x65))),
+        )
+        assert remote_value.process(telegram) is False
+
+        assert remote_value.value is None

--- a/xknx/devices/scene.py
+++ b/xknx/devices/scene.py
@@ -6,7 +6,8 @@ from collections.abc import Iterator
 import logging
 from typing import TYPE_CHECKING
 
-from xknx.remote_value import GroupAddressesType, RemoteValueSceneNumber
+from xknx.dpt import SceneControl
+from xknx.remote_value import GroupAddressesType, RemoteValueSceneControl
 
 from .device import Device, DeviceCallbackType
 
@@ -31,32 +32,46 @@ class Scene(Device):
         """Initialize Sceneclass."""
         super().__init__(xknx, name, device_updated_cb)
 
-        # TODO: state_updater: disable for scene number per default?
-        self.scene_value = RemoteValueSceneNumber(
+        self.scene_value = RemoteValueSceneControl(
             xknx,
             group_address=group_address,
             device_name=self.name,
-            feature_name="Scene number",
-            after_update_cb=self._scene_activation_from_rv,
+            feature_name="Scene control",
+            after_update_cb=self._scene_control_from_rv,
         )
         self.scene_number = int(scene_number)
+        self._learn_requested = False
 
-    def _iter_remote_values(self) -> Iterator[RemoteValueSceneNumber]:
+    def _iter_remote_values(self) -> Iterator[RemoteValueSceneControl]:
         """Iterate the devices RemoteValue classes."""
         yield self.scene_value
 
+    @property
+    def learn_requested(self) -> bool:
+        """Return if the last telegram for this scene requested storing it."""
+        return self._learn_requested
+
     async def run(self) -> None:
         """Activate scene."""
-        self.scene_value.set(self.scene_number)
+        self.scene_value.set(SceneControl(self.scene_number, learn=False))
+
+    async def learn(self) -> None:
+        """Let actuators store their current state as this scene."""
+        self.scene_value.set(SceneControl(self.scene_number, learn=True))
 
     def process_group_write(self, telegram: GroupValueTelegram) -> None:
         """Process incoming and outgoing GROUP WRITE telegram."""
         self.scene_value.process(telegram, always_callback=True)
 
-    def _scene_activation_from_rv(self, called_scene_number: int) -> None:
-        """Check the scene number from RemoteValue (Callback)."""
-        if called_scene_number == self.scene_number:
-            self.after_update()
+    def _scene_control_from_rv(self, scene_control: SceneControl) -> None:
+        """Check the scene control from RemoteValue (Callback)."""
+        # scene_value holds every scene number seen on the group address, so
+        # callbacks are only called - and `learn_requested` is only updated -
+        # for telegrams of this devices scene number
+        if scene_control.scene_number != self.scene_number:
+            return
+        self._learn_requested = scene_control.learn
+        self.after_update()
 
     def __str__(self) -> str:
         """Return object as readable string."""

--- a/xknx/remote_value/__init__.py
+++ b/xknx/remote_value/__init__.py
@@ -15,6 +15,7 @@ from .remote_value_datetime import RemoteValueDate, RemoteValueDateTime, RemoteV
 from .remote_value_dpt_value_1_ucount import RemoteValueDptValue1Ucount
 from .remote_value_raw import RemoteValueRaw
 from .remote_value_scaling import RemoteValueScaling
+from .remote_value_scene_control import RemoteValueSceneControl
 from .remote_value_scene_number import RemoteValueSceneNumber
 from .remote_value_sensor import (
     RemoteValueNumeric,
@@ -44,6 +45,7 @@ __all__ = [
     "RemoteValueOperationMode",
     "RemoteValueRaw",
     "RemoteValueScaling",
+    "RemoteValueSceneControl",
     "RemoteValueSceneNumber",
     "RemoteValueSensor",
     "RemoteValueSetpointShift",

--- a/xknx/remote_value/remote_value_scene_control.py
+++ b/xknx/remote_value/remote_value_scene_control.py
@@ -1,0 +1,18 @@
+"""
+Module for managing a scene control remote value.
+
+DPT 18.001.
+"""
+
+from __future__ import annotations
+
+from xknx.dpt import DPTSceneControl, SceneControl
+
+from .remote_value import RemoteValue
+
+
+class RemoteValueSceneControl(RemoteValue[SceneControl]):
+    """Abstraction for remote value of KNX DPT 18.001 (DPT_SceneControl)."""
+
+    __slots__ = ()
+    dpt_class = DPTSceneControl


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

`Scene.scene_value` was a `RemoteValueSceneNumber` (DPT 17.001), which cannot represent the learn bit. Two consequences:

- storing a scene was not possible from the device, and
- a learn telegram received from the bus was rejected with a `Can not process` warning, since decoding it as a scene number lands outside 1-64:

```
WARNING xknx.log Can not process <Telegram … DPTArray value="[0x97]" /> for TestScene - Scene number:
  <ConversionError description="Could not parse DPTSceneNumber (17.001)" payload=DPTArray((0x97)) value=152/>
```

DPT 18.001 is a superset of 17.001 on the wire: an activation encodes to the same octet and decodes back the same way. So `scene_value` can carry `SceneControl` without changing any telegram xknx sends today - `test_run` keeps its unchanged `DPTArray(0x16)` assertion to pin that down.

On top of that:

- **`Scene.learn()`** sends a telegram with the learn bit set, telling actuators to store their current state as this scene.
- Received learn telegrams now decode instead of warning, and do **not** fire the device callback - storing a scene is not an activation.
- New `RemoteValueSceneControl` (DPT 18.001), following `RemoteValueColorXYY` as the existing `DPTComplex`-backed remote value.
- `RemoteValueSceneNumber` is unchanged and still exported, for plain DPT 17.001 group addresses.

This is a breaking change for anyone reading `scene.scene_value.value`, which is now a `SceneControl` rather than an `int` - see the changelog entry.

Motivation: Home Assistant is adding a `knx.save_scene` entity action. It currently has to hand-build the DPT 18.001 payload and push it through `scene_value.send_raw()`, which works but triggers the warning above on every save, because xknx runs outgoing telegrams through its devices too. With this PR the integration is just `await self._device.learn()`.

Not documented under `docs/` beyond the changelog - there is no Scene page there. `examples/example_scene.py` is deliberately left alone; calling `learn()` in an example would overwrite a real scene for anyone running it against their bus.

Fixes #857

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)
