### PR TITLE
Add ExposeSensor.initialize_value()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### Devices
+
+- Add `ExposeSensor.initialize_value()` to set a value without sending it to the KNX bus, eg. one restored from a previous run. Unlike assigning `sensor_value.value` directly, it also initializes the payload used for periodic sending and `skip_unchanged`. `None` clears the value.
+
 ### Features
 
 - Add `DeviceManagement` to acknowledge `DeviceConfigurationRequest` frames received over a device management connection. A KNXnet/IP server sends requests of its own over such a connection - a `M_PropRead.con` answering a read, or a `M_PropInfo.ind` announcing a property it changed by itself - and repeats each of them until it is acknowledged, then closes the connection. Sending those acknowledgements had no counterpart to `DeviceConfiguration`, which covers the other direction. Sequence counters are handled as they are for tunnelling; the connection itself stays with the caller.

--- a/test/devices_tests/expose_sensor_test.py
+++ b/test/devices_tests/expose_sensor_test.py
@@ -114,6 +114,55 @@ class TestExposeSensor:
             payload=GroupValueWrite(DPTArray((0x0C, 0x1A))),
         )
 
+    async def test_initialize_value(self) -> None:
+        """Test initialize_value doesn't send, but is answered and compared against."""
+        xknx = XKNX()
+        expose_sensor = ExposeSensor(
+            xknx, "TestSensor", group_address="1/2/3", value_type="percent"
+        )
+        expose_sensor.initialize_value(75)
+        assert xknx.telegrams.qsize() == 0
+        assert expose_sensor.resolve_state() == 75
+
+        # answers a GroupValueRead with the initialized value
+        expose_sensor.process(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueRead(),
+            )
+        )
+        assert xknx.telegrams.get_nowait() == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueResponse(DPTArray((0xBF,))),
+        )
+
+        # skip_unchanged compares against the initialized value
+        await expose_sensor.set(75, skip_unchanged=True)
+        assert xknx.telegrams.qsize() == 0
+        await expose_sensor.set(50, skip_unchanged=True)
+        assert xknx.telegrams.get_nowait() == Telegram(
+            destination_address=GroupAddress("1/2/3"),
+            payload=GroupValueWrite(DPTArray((0x80,))),
+        )
+
+    async def test_initialize_value_none(self) -> None:
+        """Test initialize_value with None clears the value again."""
+        xknx = XKNX()
+        expose_sensor = ExposeSensor(
+            xknx, "TestSensor", group_address="1/2/3", value_type="percent"
+        )
+        expose_sensor.initialize_value(75)
+        expose_sensor.initialize_value(None)
+        assert expose_sensor.resolve_state() is None
+
+        expose_sensor.process(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueRead(),
+            )
+        )
+        assert xknx.telegrams.qsize() == 0
+
     #
     # TEST PROCESS (GROUP READ)
     #
@@ -590,5 +639,40 @@ class TestExposeSensor:
         )
         await time_travel(10)
         xknx.cemi_handler.send_telegram.assert_not_called()
+
+        await xknx.stop()
+
+    async def test_periodic_send_local_value(
+        self,
+        xknx_no_interface: XKNX,
+        time_travel: EventLoopClockAdvancer,
+    ) -> None:
+        """Test a value set locally is sent periodically."""
+        xknx = xknx_no_interface
+        xknx.connection_manager.connection_state_changed(XknxConnectionState.CONNECTED)
+        xknx.cemi_handler = AsyncMock()
+        expose_sensor = ExposeSensor(
+            xknx,
+            "TestSensor",
+            group_address="1/2/3",
+            value_type="switch",
+            periodic_send=10,
+        )
+        xknx.devices.async_add(expose_sensor)
+        await xknx.start()
+
+        # initializing the value sends nothing by itself
+        expose_sensor.initialize_value(True)
+        await time_travel(0)
+        xknx.cemi_handler.send_telegram.assert_not_called()
+
+        # but it is picked up by the periodic send
+        await time_travel(10)
+        xknx.cemi_handler.send_telegram.assert_called_once_with(
+            Telegram(
+                destination_address=GroupAddress("1/2/3"),
+                payload=GroupValueWrite(DPTBinary(True)),
+            )
+        )
 
         await xknx.stop()

--- a/xknx/devices/expose_sensor.py
+++ b/xknx/devices/expose_sensor.py
@@ -168,6 +168,20 @@ class ExposeSensor(Device):
             self.xknx.task_registry.start_task(self._cooldown_task)
         self.sensor_value.send_raw(payload)
 
+    def initialize_value(self, value: Any) -> None:
+        """
+        Set new value without sending it to the KNX bus.
+
+        The value is treated as if it had been sent: it answers GroupValueRead
+        telegrams, is used by periodic sending and is compared against by
+        `skip_unchanged` in `set()`. `None` clears it again.
+        Raises ConversionError on invalid value.
+        """
+        self.sensor_value.value = value
+        # equal to `last_payload` means nothing is pending, so a running
+        # cooldown task will cancel itself instead of sending this value
+        self._payload_after_cooldown = self.sensor_value.last_payload
+
     async def _cooldown_send(self) -> None:
         """Send value after cooldown if it differs from last processed value."""
         if self.sensor_value.last_payload == self._payload_after_cooldown:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Adds `ExposeSensor.initialize_value()` - set an exposed value without sending it to the KNX bus, for initializing an exposure from a state the consumer already knows, eg. one restored from a previous run.

Consumers can already do this by assigning `sensor_value.value` directly, but that leaves `_payload_after_cooldown` untouched. That is the payload periodic sending and `skip_unchanged` work off:

```python
async def _periodic_send_impl(self) -> None:
    if self._payload_after_cooldown is not None:
        ...
```

so an exposure initialized that way never sends periodically, and always sends its first `set()` even when the value has not changed. A `GroupValueRead` is also answered through `sensor_value.respond()` rather than the cooldown branch of `process_group_read()`, so the read response does not restart the cooldown timer as intended.

`initialize_value()` sets both, so the initialized value is treated as if it had been sent - it answers reads, is picked up by periodic sending, and is compared against by `skip_unchanged`. Passing `None` clears it again.

Setting `sensor_value.value` first is what keeps this safe while a cooldown is in flight: `_cooldown_send()` bails when `last_payload` equals `_payload_after_cooldown`, and after the assignment they are equal by construction, so a running cooldown task cancels itself instead of sending the value that was just initialized.

Found while reviewing home-assistant/core#178793, which changes the KNX integration to initialize an exposure from a restored entity state during startup instead of writing it to the bus. That integration currently assigns `sensor_value.value` directly in `_init_expose_state()`, and the PR extends that path to restored states - which would silently disable `periodic_send` across a Home Assistant restart. It will use this method once released.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)
