### PR TITLE
Discard unencrypted frames on KNX IP Secure transports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ if they aren't already established elsewhere in the codebase.
 | v01.06.02 | Core | 03.08.02 |
 | v01.07.03 | Device Management | 03.08.03 |
 | v01.07.01 | Tunnelling | 03.08.04 |
+| v01.01.02 | KNX IP Secure | 03.08.09 |
 
 Note that Management Procedures and Application Layer are two different
 documents, cited side by side in places, that carry *different* versions

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ nav_order: 2
 
 # Changelog
 
+# Unreleased changes
+
+### Connection
+
+- KNX IP Secure transports discard unencrypted frames instead of passing them to their callbacks. A secure session accepts a plain frame only for the handshake - `SessionRequest` outgoing, `SessionResponse` incoming - and raises `IPSecureError` when anything else is sent before the session is initialized. Secure routing keeps forwarding plain discovery and self description frames (`SearchRequest`, `SearchResponse`, `DescriptionRequest` and `DescriptionResponse`, extended variants included) since these services are never secured and share the multicast endpoint, but now drops every other plain frame - previously only `RoutingIndication` was dropped, so a plain `RoutingBusy` from any sender could still throttle outgoing telegrams. Frames that may not be encapsulated at all - a nested `SecureWrapper` and the Remote Configuration and Diagnosis service family - are discarded when received inside a `SecureWrapper`.
+
 # 3.20.0 DeviceManagement and Expose init 2026-08-16
 
 ### Devices

--- a/test/io_tests/secure_group_test.py
+++ b/test/io_tests/secure_group_test.py
@@ -6,10 +6,21 @@ from unittest.mock import Mock, patch
 import pytest
 
 from xknx.cemi import CEMIFrame, CEMILData, CEMIMessageCode
-from xknx.exceptions import IPSecureError
+from xknx.exceptions import IPSecureError, KNXSecureValidationError
 from xknx.io.const import DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT, XKNX_SERIAL_NUMBER
 from xknx.io.ip_secure import SecureGroup, SecureSequenceTimer
-from xknx.knxip import HPAI, KNXIPFrame, RoutingIndication, SecureWrapper, TimerNotify
+from xknx.knxip import (
+    HPAI,
+    DescriptionRequest,
+    DescriptionResponse,
+    KNXIPFrame,
+    RoutingBusy,
+    RoutingIndication,
+    RoutingLostMessage,
+    SecureWrapper,
+    SessionRequest,
+    TimerNotify,
+)
 from xknx.telegram import GroupAddress, Telegram, apci
 
 from ..conftest import EventLoopClockAdvancer
@@ -525,7 +536,7 @@ class TestSecureGroup:
         mock_super_send: Mock,
         mock_super_connect: Mock,
     ) -> None:
-        """Test class for KNXnet/IP secure routing."""
+        """Test that only unsecured discovery services are handled unencrypted."""
         frame_received_mock = Mock()
         secure_group = SecureGroup(
             local_addr=self.mock_addr,
@@ -534,18 +545,72 @@ class TestSecureGroup:
             latency_ms=1000,
         )
         secure_group.register_callback(frame_received_mock)
+
+        def receive(raw: bytes) -> bool:
+            """Return True if the plain frame was passed on to the callbacks."""
+            frame_received_mock.reset_mock()
+            secure_group.data_received_callback(raw, ("192.168.1.2", 3671))
+            return frame_received_mock.called
+
+        # the routing service family shall only be received in a SecureWrapper
         plain_routing_indication = bytes.fromhex("0610 0530 0010 2900b06010fa10ff0080")
-        secure_group.data_received_callback(
-            plain_routing_indication, ("192.168.1.2", 3671)
+        assert not receive(plain_routing_indication)
+        assert not receive(KNXIPFrame.init_from_body(RoutingBusy()).to_knx())
+        assert not receive(KNXIPFrame.init_from_body(RoutingLostMessage()).to_knx())
+        # session services belong to unicast connections
+        assert not receive(
+            KNXIPFrame.init_from_body(
+                SessionRequest(ecdh_client_public_key=bytes(32))
+            ).to_knx()
         )
-        frame_received_mock.assert_not_called()
+        # discovery and self description are never secured; the multicast listener
+        # socket receives unicast frames addressed to us on macOS and Windows
         plain_search_response = bytes.fromhex(
             "0610020c006608010a0100280e57360102001000000000082d40834de000170c"
             "000ab3274a3247697261204b4e582f49502d526f757465720000000000000000"
             "000000000e02020203020402050207010901140700dc10f1fffe10f2ffff10f3"
             "ffff10f4ffff"
         )
-        secure_group.data_received_callback(
-            plain_search_response, ("192.168.1.2", 3671)
+        assert receive(plain_search_response)
+        assert receive(
+            KNXIPFrame.init_from_body(
+                DescriptionRequest(control_endpoint=HPAI())
+            ).to_knx()
         )
-        frame_received_mock.assert_called_once()
+        assert receive(KNXIPFrame.init_from_body(DescriptionResponse()).to_knx())
+
+    async def test_nested_secure_wrapper(
+        self,
+        mock_super_send: Mock,
+        mock_super_connect: Mock,
+    ) -> None:
+        """Test that a SecureWrapper inside a SecureWrapper is discarded."""
+        frame_received_mock = Mock()
+        secure_group = SecureGroup(
+            local_addr=self.mock_addr,
+            remote_addr=(DEFAULT_MCAST_GRP, DEFAULT_MCAST_PORT),
+            backbone_key=self.mock_backbone_key,
+            latency_ms=1000,
+        )
+        secure_group.register_callback(frame_received_mock)
+        secure_group.secure_timer.timer_authenticated = True
+
+        raw_test_cemi = CEMIFrame(
+            code=CEMIMessageCode.L_DATA_IND,
+            data=CEMILData.init_from_telegram(
+                Telegram(
+                    destination_address=GroupAddress("1/2/3"),
+                    payload=apci.GroupValueRead(),
+                )
+            ),
+        ).to_knx()
+        inner = secure_group.encrypt_frame(
+            KNXIPFrame.init_from_body(RoutingIndication(raw_cemi=raw_test_cemi))
+        )
+        nested = secure_group.encrypt_frame(inner)
+
+        with pytest.raises(KNXSecureValidationError):
+            secure_group.decrypt_frame(nested)
+        # discarded by handle_knxipframe instead of raising
+        secure_group.data_received_callback(nested.to_knx(), ("192.168.1.2", 3671))
+        frame_received_mock.assert_not_called()

--- a/test/io_tests/secure_session_test.py
+++ b/test/io_tests/secure_session_test.py
@@ -6,17 +6,19 @@ from unittest.mock import Mock, patch
 from cryptography.hazmat.primitives.asymmetric.x25519 import X25519PrivateKey
 import pytest
 
-from xknx.exceptions import CommunicationError, CouldNotParseKNXIP
+from xknx.exceptions import CommunicationError, CouldNotParseKNXIP, IPSecureError
 from xknx.io.const import SESSION_KEEPALIVE_RATE
 from xknx.io.ip_secure import SecureSession
 from xknx.knxip import (
     HPAI,
+    DisconnectRequest,
     KNXIPFrame,
     SecureWrapper,
     SessionAuthenticate,
     SessionRequest,
     SessionResponse,
     SessionStatus,
+    TunnellingRequest,
 )
 from xknx.knxip.knxip_enum import SecureSessionStatusCode
 
@@ -178,13 +180,14 @@ class TestSecureSession:
         assert self.session.initialized is True
         assert not self.session._keepalive_task.done()
 
-        # handle incoming SessionStatus (unencrypted for sake of simplicity)
+        # handle incoming SessionStatus - SessionStatus is only valid encrypted
         session_status_close_frame = KNXIPFrame.init_from_body(
             SessionStatus(status=SecureSessionStatusCode.STATUS_CLOSE)
         )
         with patch.object(self.session, "transport") as mock_transport:
             self.session.handle_knxipframe(
-                session_status_close_frame, HPAI(*self.mock_addr)
+                self.session.encrypt_frame(session_status_close_frame),
+                HPAI(*self.mock_addr),
             )
             mock_transport.close.assert_called_once()
 
@@ -442,3 +445,55 @@ class TestSecureSession:
         with pytest.raises(CommunicationError):
             await time_travel(10)
             await connect_task
+
+    def test_receive_plain_frames(self) -> None:
+        """Test that only a SessionResponse is handled unencrypted."""
+        frame_received_mock = Mock()
+        self.session.register_callback(frame_received_mock)
+        session_response_frame = KNXIPFrame.init_from_body(
+            SessionResponse(
+                secure_session_id=1,
+                ecdh_server_public_key=self.mock_server_public_key,
+                message_authentication_code=bytes(16),
+            )
+        )
+        tunnelling_request_frame = KNXIPFrame.init_from_body(
+            TunnellingRequest(raw_cemi=bytes.fromhex("2900b06010fa10ff0080"))
+        )
+        disconnect_request_frame = KNXIPFrame.init_from_body(DisconnectRequest())
+
+        def receive(knxipframe: KNXIPFrame) -> bool:
+            """Return True if the plain frame was passed on to the callbacks."""
+            frame_received_mock.reset_mock()
+            self.session.handle_knxipframe(knxipframe, HPAI(*self.mock_addr))
+            return frame_received_mock.called
+
+        # the SessionResponse of the handshake is the only plain frame received
+        assert not self.session.initialized
+        assert receive(session_response_frame)
+        assert not receive(tunnelling_request_frame)
+        assert not receive(disconnect_request_frame)
+        # nothing is accepted in plain once the session is established
+        self.session.initialized = True
+        assert not receive(session_response_frame)
+        assert not receive(tunnelling_request_frame)
+        assert not receive(disconnect_request_frame)
+
+    @patch("xknx.io.transport.tcp_transport.TCPTransport.send")
+    def test_send_plain_frames(self, mock_super_send: Mock) -> None:
+        """Test that only a SessionRequest is sent unencrypted."""
+        session_request_frame = KNXIPFrame.init_from_body(
+            SessionRequest(ecdh_client_public_key=self.mock_public_key)
+        )
+        assert not self.session.initialized
+        self.session.send(session_request_frame)
+        mock_super_send.assert_called_once_with(session_request_frame, None)
+
+        mock_super_send.reset_mock()
+        with pytest.raises(IPSecureError):
+            self.session.send(
+                KNXIPFrame.init_from_body(
+                    SessionStatus(status=SecureSessionStatusCode.STATUS_KEEPALIVE)
+                )
+            )
+        mock_super_send.assert_not_called()

--- a/xknx/io/ip_secure.py
+++ b/xknx/io/ip_secure.py
@@ -24,8 +24,8 @@ from xknx.knxip import (
     HPAI,
     KNXIPFrame,
     KNXIPServiceType,
-    RoutingIndication,
     SecureWrapper,
+    SessionRequest,
     SessionResponse,
     SessionStatus,
     TimerNotify,
@@ -55,6 +55,32 @@ COUNTER_0_HANDSHAKE = (  # used in SessionResponse and SessionAuthenticate
     b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\x00"
 )
 MESSAGE_TAG_TUNNELLING = bytes.fromhex("00 00")  # use 0x00 0x00 for tunneling
+
+# Discovery and self description are never secured
+# KNX v01.01.02 - KNX IP Secure 03.08.09 - §2.6.2 and §2.2.1.4.2
+# The routing multicast endpoint is by default the discovery endpoint, and the multicast
+# listener socket binds INADDR_ANY:3671 on macOS and Windows, so unicast requests addressed
+# to us arrive there too. These are the only plain frames a SecureGroup forwards.
+PLAIN_MULTICAST_SERVICES: Final = (
+    KNXIPServiceType.SEARCH_REQUEST,
+    KNXIPServiceType.SEARCH_REQUEST_EXTENDED,
+    KNXIPServiceType.SEARCH_RESPONSE,
+    KNXIPServiceType.SEARCH_RESPONSE_EXTENDED,
+    KNXIPServiceType.DESCRIPTION_REQUEST,
+    KNXIPServiceType.DESCRIPTION_RESPONSE,
+)
+# Services that shall not travel inside a SecureWrapper either.
+FORBIDDEN_WRAPPED_SERVICES: Final = (
+    # secure wrappers and sessions may not be nested
+    # KNX v01.01.02 - KNX IP Secure 03.08.09 - §2.2.1.2.2.2 and §2.2.3.5.1
+    KNXIPServiceType.SECURE_WRAPPER,
+    # Remote Configuration and Diagnosis is not supported in Security Mode
+    # KNX v01.01.02 - KNX IP Secure 03.08.09 - §2.2.1.4.7
+    KNXIPServiceType.REMOTE_DIAG_REQUEST,
+    KNXIPServiceType.REMOTE_DIAG_RESPONSE,
+    KNXIPServiceType.REMOTE_CONFIG_REQUEST,
+    KNXIPServiceType.REMOTE_RESET_REQUEST,
+)
 
 
 class _IPSecureTransportLayer(ABC):
@@ -112,6 +138,10 @@ class _IPSecureTransportLayer(ABC):
             )
 
         knxipframe, _ = KNXIPFrame.from_knx(dec_frame)
+        if knxipframe.header.service_type_ident in FORBIDDEN_WRAPPED_SERVICES:
+            raise KNXSecureValidationError(
+                f"Service type not allowed in SecureWrapper: {knxipframe}"
+            )
         return knxipframe
 
     def encrypt_frame(self, plain_frame: KNXIPFrame) -> KNXIPFrame:
@@ -325,7 +355,6 @@ class SecureSession(TCPTransport, _IPSecureTransportLayer):
 
     def handle_knxipframe(self, knxipframe: KNXIPFrame, source: HPAI) -> None:
         """Handle KNXIP Frame and call all callbacks matching the service type ident."""
-        # TODO: disallow unencrypted frames with exceptions for discovery etc. eg. DescriptionResponse
         if isinstance(knxipframe.body, SecureWrapper):
             if not self.initialized:
                 raise CouldNotParseKNXIP(
@@ -354,6 +383,14 @@ class SecureSession(TCPTransport, _IPSecureTransportLayer):
                 return
             self._sequence_number_received = new_sequence_number
             knx_logger.debug("Decrypted frame: %s", knxipframe)
+        elif self.initialized or not isinstance(knxipframe.body, SessionResponse):
+            # SessionResponse is the only frame received in plain - and only until
+            # the session is initialized. Everything else shall be ignored.
+            # KNX v01.01.02 - KNX IP Secure 03.08.09 - §2.4.1
+            ip_secure_logger.warning(
+                "Discarding received unencrypted frame: %s", knxipframe
+            )
+            return
         super().handle_knxipframe(knxipframe, source)
 
     async def _session_keepalive(self) -> None:
@@ -373,8 +410,10 @@ class SecureSession(TCPTransport, _IPSecureTransportLayer):
             # keepalive timer is started with first and reset with every other
             # SecureWrapper frame (including wrapped keepalive frames themselves)
             self.start_keepalive_task()
-        # TODO: disallow sending unencrypted frames over non-initialized session with
-        # exceptions for discovery and SessionRequest
+        elif not isinstance(knxipframe.body, SessionRequest):
+            raise IPSecureError(
+                f"Only SessionRequest may be sent unencrypted over a secure session: {knxipframe}"
+            )
         super().send(knxipframe, addr)
 
     def get_sequence_information(self) -> bytes:
@@ -454,12 +493,6 @@ class SecureGroup(UDPTransport, _IPSecureTransportLayer):
 
     def handle_knxipframe(self, knxipframe: KNXIPFrame, source: HPAI) -> None:
         """Handle KNXIP Frame and call all callbacks matching the service type ident."""
-        if isinstance(knxipframe.body, RoutingIndication):
-            ip_secure_logger.info(
-                "Discarding received unencrypted RoutingIndication: %s",
-                knxipframe,
-            )
-            return
         if isinstance(knxipframe.body, TimerNotify):
             self.secure_timer.handle_timer_notify(knxipframe.body)
             return
@@ -490,15 +523,19 @@ class SecureGroup(UDPTransport, _IPSecureTransportLayer):
                 )
                 return
             knx_logger.debug("Decrypted frame: %s", knxipframe)
-        # handle decrypted frames and plain frames (e.g. SearchRequest for discovery)
+        elif knxipframe.header.service_type_ident not in PLAIN_MULTICAST_SERVICES:
+            ip_secure_logger.info(
+                "Discarding received unencrypted frame: %s",
+                knxipframe,
+            )
+            return
+        # handle decrypted frames and plain discovery frames (e.g. SearchRequest)
         super().handle_knxipframe(knxipframe, source)
 
     def send(self, knxipframe: KNXIPFrame, addr: tuple[str, int] | None = None) -> None:
         """Send KNXIPFrame to socket. `addr` is ignored on TCP."""
         knx_logger.debug("Encrypting frame: %s", knxipframe)
         knxipframe = self.encrypt_frame(plain_frame=knxipframe)
-        # TODO: disallow sending unencrypted frames over non-initialized session with
-        # exceptions for discovery and SessionRequest
         super().send(knxipframe, addr)
 
     def get_sequence_information(self) -> bytes:
@@ -514,7 +551,7 @@ class SecureSequenceTimer:
     """
     Class for holding and synchronizing the timer for secure sequence information.
 
-    According to AN159 v06 KNXnet-IP Secure AS §2.2.2.3 Timer synchronizing
+    According to KNX v01.01.02 - KNX IP Secure 03.08.09 - §2.2.2.3 Timer synchronizing
     """
 
     __slots__ = (

--- a/xknx/io/ip_secure.py
+++ b/xknx/io/ip_secure.py
@@ -522,15 +522,18 @@ class SecureGroup(UDPTransport, _IPSecureTransportLayer):
                     secure_wrapper,
                 )
                 return
+            # handle decrypted frames
             knx_logger.debug("Decrypted frame: %s", knxipframe)
-        elif knxipframe.header.service_type_ident not in PLAIN_MULTICAST_SERVICES:
-            ip_secure_logger.info(
-                "Discarding received unencrypted frame: %s",
-                knxipframe,
-            )
+            super().handle_knxipframe(knxipframe, source)
             return
-        # handle decrypted frames and plain discovery frames (e.g. SearchRequest)
-        super().handle_knxipframe(knxipframe, source)
+        if knxipframe.header.service_type_ident in PLAIN_MULTICAST_SERVICES:
+            # handle plain discovery frames (e.g. SearchRequest)
+            super().handle_knxipframe(knxipframe, source)
+            return
+        ip_secure_logger.info(
+            "Discarding received unencrypted frame: %s",
+            knxipframe,
+        )
 
     def send(self, knxipframe: KNXIPFrame, addr: tuple[str, int] | None = None) -> None:
         """Send KNXIPFrame to socket. `addr` is ignored on TCP."""


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Resolves the three `# TODO: disallow unencrypted frames ...` comments in `xknx/io/ip_secure.py`.

`SecureSession.handle_knxipframe()` passed **every** non-`SecureWrapper` frame straight to the callbacks. Since `RequestResponse` and `_Tunnel` register their callbacks on the transport, an on-path attacker on the TCP connection could inject a plain `TunnellingRequest` (telegram injection), a plain `DisconnectRequest` (forced disconnect) or a plain `ConnectResponse`, and it was acted on unauthenticated. `SecureGroup` dropped plain `RoutingIndication` but still forwarded plain `RoutingBusy` into `Routing._flow_control.handle_routing_busy()`, so any sender on the multicast group could throttle or stall our transmissions.

### What the spec allows in plain

All references: `KNX v01.01.02 - KNX IP Secure 03.08.09`.

**Secure session** — exactly two frames, and only before the session is initialized:

- §2.2.3.6.1 / §2.2.3.7 — `SessionRequest` out, `SessionResponse` in.
- §2.2.3.5.2.3 — the session state machine knows only two wire events: *Received SESSION_REQUEST* and *Received valid SECURE_WRAPPER*.
- §2.4.1 — "For all connections created within a secure session, the server shall accept only SECURE_WRAPPER frames […] and plain frames shall be ignored."

The old TODO mentioned "exceptions for discovery etc. eg. DescriptionResponse", but that turns out **not** to be an exception for *plain* frames: §2.2.1.4.2 exempts discovery from *authorization*, not from encryption, and §2.4.1 puts connectionless services like `DESCRIPTION_REQUEST` "within the context of the session" — still wrapped. That matches what xknx already does: `_Tunnel.request_description()` runs over the established session, and pre-connection discovery uses its own plain `UDPTransport`.

**Secure routing** — `TimerNotify` (carries its own MAC, §2.2.2.4.3) plus discovery and self description, which are never secured (§2.6.2, §2.2.1.4.2) and share the endpoint: the routing multicast group is by default the discovery group, and `create_multicast_sock()` binds the listener to `INADDR_ANY:3671` on macOS and Windows, so unicast `DescriptionRequest`s addressed to us arrive there too. Everything else plain is discarded — which now also covers the rest of the routing service family (§2.2.1.4.5 speaks of the *service family*, not just `Routing.ind`), `TimerNotify` on a session, and `SESSION_*` on the multicast group.

**Never encapsulated at all** — rejected after decryption, in `decrypt_frame()` so both transports share the rule:

- a nested `SecureWrapper` (§2.2.1.2.2.2, §2.2.3.5.1);
- the Remote Configuration and Diagnosis family, which §2.2.1.4.7 forbids outright in Security Mode and which `03.08.07` transmits by multicast — straight onto the `SecureGroup` socket. Those four service types have no body class yet, so the guard is what keeps the rule true once they get one.

### Summary of behaviour changes

| | Before | After |
|---|---|---|
| `SecureSession.handle_knxipframe` | every plain frame dispatched | only pre-init `SessionResponse`; rest discarded with a warning |
| `SecureSession.send` | anything sent plain pre-init | raises `IPSecureError` for anything but `SessionRequest` |
| `SecureGroup.handle_knxipframe` | only plain `RoutingIndication` dropped | allow-list of `SEARCH_*` + `DESCRIPTION_*`; rest discarded |
| `decrypt_frame` | any decrypted body accepted | rejects nested `SecureWrapper` and the Remote Config/Diagnosis family |
| `SecureGroup.send` | stale TODO | removed — it always encrypts |

### Notes for the reviewer

- `test_lifecycle` fed a plain `SessionStatus(STATUS_CLOSE)` marked *"unencrypted for sake of simplicity"*. §2.2.3.9 says that frame "shall only be sent wrapped in a SECURE_WRAPPER frame", so the test now wraps it via `encrypt_frame()` — the shortcut had been exercising a path the spec forbids.
- Sending raises rather than dropping: reaching that branch can only be an internal bug, never remote input, matching the `IPSecureError` already raised on sequence-number overflow. `IPSecureError` is a `CommunicationError`, which `RequestResponse.start()` already handles.
- Receiving discards rather than raises, per §2.4.1 "shall be ignored" — a raise would escape `TCPTransport.data_received_callback()`, which only guards `KNXIPFrame.from_knx()`.
- `AGENTS.md` gains the confirmed `KNX IP Secure | 03.08.09 | v01.01.02` row (taken from the document's own title page), and the one `AN159 v06`-style citation in `ip_secure.py` is converted to the documented format.

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)
