### PR TITLE
Disable ruff ASYNC109 rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ lint.ignore = [
   "D212",
   "E501",     # line too long
   "SIM102",   # collapsible-if
-  "SIM105",   #suppressible-exception
+  "SIM105",   # suppressible-exception
 ]
 extend-exclude = ["script"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,13 +137,14 @@ lint.select = [
   "W",     # pydocstyle warning
 ]
 lint.ignore = [
-  "ANN401", # any-type - mypy should handle this where necessary
+  "ANN401",   # any-type - mypy should handle this where necessary
+  "ASYNC109", # async-function-with-timeout - timeout is part of the public API
   "D202",
   "D203",
   "D212",
-  "E501",   # line too long
-  "SIM102", # collapsible-if
-  "SIM105", #suppressible-exception
+  "E501",     # line too long
+  "SIM102",   # collapsible-if
+  "SIM105",   #suppressible-exception
 ]
 extend-exclude = ["script"]
 

--- a/xknx/management/management.py
+++ b/xknx/management/management.py
@@ -165,7 +165,7 @@ class BroadcastContext:
 
     async def receive(
         self,
-        timeout: float | None = 3,  # noqa: ASYNC109 - part of the public API
+        timeout: float | None = 3,
     ) -> AsyncGenerator[Telegram, None]:
         """Receive telegrams from the broadcast context."""
         try:

--- a/xknx/management/procedures/network/nm_individual_address_read.py
+++ b/xknx/management/procedures/network/nm_individual_address_read.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("xknx.management.procedures")
 
 async def nm_individual_address_read(
     xknx: XKNX,
-    timeout: float | None = 3,  # noqa: ASYNC109 - part of the public API
+    timeout: float | None = 3,
     raise_if_multiple: bool = False,
 ) -> list[IndividualAddress]:
     """

--- a/xknx/management/procedures/network/nm_individual_address_serial_number_read.py
+++ b/xknx/management/procedures/network/nm_individual_address_serial_number_read.py
@@ -17,7 +17,7 @@ logger = logging.getLogger("xknx.management.procedures")
 async def nm_individual_address_serial_number_read(
     xknx: XKNX,
     serial: bytes,
-    timeout: float = 3,  # noqa: ASYNC109 - part of the public API
+    timeout: float = 3,
 ) -> IndividualAddress | None:
     """Read individual address from device with specified serial number."""
     # initialize queue or event handler gathering broadcasts


### PR DESCRIPTION
`ASYNC109` (async function with a `timeout` parameter) flags the management procedures' `timeout` arguments, which are part of the public API and won't be replaced by `asyncio.timeout()` context managers by callers.

Every occurrence carried a per-line `# noqa: ASYNC109`, so ignore the rule globally and drop the hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)