### PR TITLE
Remove device lookup by name or number

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,8 @@ nav_order: 2
   rv_1.my_own_attribute = 1  # before: works; now: AttributeError
   ```
 - Remove device lookup by name or index from `xknx.devices`. `xknx.devices["NameOfDevice"]` and `xknx.devices[0]` are gone - device names are never checked for uniqueness, so the lookup could return any one of several devices sharing a name. Keep a reference to the device object instead, or iterate `xknx.devices` to find it. `device in xknx.devices` takes the `Device` object now instead of its name.
-- `Devices.async_add()` and `Devices.async_remove()` raise `ValueError` when the device object is already registered, or not registered at all. Adding a device twice had it receive every telegram twice and fire its callbacks twice; removing an unregistered one cancelled its tasks and unregistered its state updater before failing. Registered devices are identified by object identity now - `Device.__eq__()` compares attributes, so two distinct devices of equal state no longer shadow each other in `device in xknx.devices` or `async_remove()`.
+- `Devices.async_add()` and `Devices.async_remove()` raise `ValueError` when the device object is already registered, or not registered at all. Adding a device twice had it receive every telegram twice and fire its callbacks twice; removing an unregistered one cancelled its tasks and unregistered its state updater before failing.
+- Remove `Device.__eq__()` - same reasoning as `RemoteValue.__eq__()` above: it compared `__dict__` attributes and was a leftover of the YAML config handling removed in 1.0. Devices compare by identity now, which also makes `Device` hashable again, so devices can be used in sets and as dict keys. The same applies to `Light.red`, `.green`, `.blue` and `.white`.
 
 ### Connection
 
@@ -38,10 +39,6 @@ nav_order: 2
 - `DescriptionQuery` and `SearchExtendedQuery` derive from `RequestResponse` now. Their `start()` and `gateway_descriptor` attribute are replaced by `request_gateway_descriptor()`.
 - `Telegram` is now generic over its `payload` type (`Telegram[GroupValueWrite]`, etc.), defaulting to `Telegram` behaving exactly as before when left unparametrized - `payload` is `None` only for that default/unparametrized case (control telegrams like ACK/Disconnect); parametrized as `Telegram[SomeAPCI]`, `payload` is `SomeAPCI`, never `None`. `Device.process()` now hands `process_group_write()`/`process_group_response()`/`process_group_read()` a `Telegram` narrowed to the APCI type it already verified via `isinstance`, propagated through `RemoteValue.process()` and every device's `process_group_*` override. No behavior change - `RemoteValue.process()` keeps its own `isinstance` check since, unlike the management case below, nothing enforces the payload type before it's called directly.
 - Add `APCIRequest` to `xknx.telegram.apci` - an `APCI` subclass carrying the KNX-spec-defined response type of a request service as its type argument, eg. `class MemoryRead(APCIRequest[MemoryResponse])`. `RESPONSE_TYPE` is derived from that argument. All 21 point-to-point request services with a spec-defined response were converted; group and broadcast services (`GroupValueRead`, `IndividualAddressRead`, `DomainAddressRead`, ...) stay plain `APCI` since they are never sent via `P2PConnection.request()`. `request()` no longer takes an `expected=` argument - it infers and verifies the expected response from the payload's type and returns the correspondingly typed `Telegram[ResponseType]`, so procedures no longer need `assert isinstance(response.payload, ResponseType)` (or even a `None` check) to get a typed `.payload`.
-
-### Bugfixes
-
-- `Device.__eq__()` returns `NotImplemented` for non-`Device` operands instead of raising `AttributeError`, so comparing a device to any other object evaluates to `False` now.
 
 # 3.20.0 DeviceManagement and Expose init 2026-08-16
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,8 @@ nav_order: 2
   hash(rv_1)  # before: TypeError: unhashable type; now: works
   rv_1.my_own_attribute = 1  # before: works; now: AttributeError
   ```
+- Remove device lookup by name or index from `xknx.devices`. `xknx.devices["NameOfDevice"]` and `xknx.devices[0]` are gone - device names are never checked for uniqueness, so the lookup could return any one of several devices sharing a name. Keep a reference to the device object instead, or iterate `xknx.devices` to find it. `device in xknx.devices` takes the `Device` object now instead of its name.
+- `Devices.async_add()` and `Devices.async_remove()` raise `ValueError` when the device object is already registered, or not registered at all. Adding a device twice had it receive every telegram twice and fire its callbacks twice; removing an unregistered one cancelled its tasks and unregistered its state updater before failing. Registered devices are identified by object identity now - `Device.__eq__()` compares attributes, so two distinct devices of equal state no longer shadow each other in `device in xknx.devices` or `async_remove()`.
 
 ### Connection
 
@@ -36,6 +38,10 @@ nav_order: 2
 - `DescriptionQuery` and `SearchExtendedQuery` derive from `RequestResponse` now. Their `start()` and `gateway_descriptor` attribute are replaced by `request_gateway_descriptor()`.
 - `Telegram` is now generic over its `payload` type (`Telegram[GroupValueWrite]`, etc.), defaulting to `Telegram` behaving exactly as before when left unparametrized - `payload` is `None` only for that default/unparametrized case (control telegrams like ACK/Disconnect); parametrized as `Telegram[SomeAPCI]`, `payload` is `SomeAPCI`, never `None`. `Device.process()` now hands `process_group_write()`/`process_group_response()`/`process_group_read()` a `Telegram` narrowed to the APCI type it already verified via `isinstance`, propagated through `RemoteValue.process()` and every device's `process_group_*` override. No behavior change - `RemoteValue.process()` keeps its own `isinstance` check since, unlike the management case below, nothing enforces the payload type before it's called directly.
 - Add `APCIRequest` to `xknx.telegram.apci` - an `APCI` subclass carrying the KNX-spec-defined response type of a request service as its type argument, eg. `class MemoryRead(APCIRequest[MemoryResponse])`. `RESPONSE_TYPE` is derived from that argument. All 21 point-to-point request services with a spec-defined response were converted; group and broadcast services (`GroupValueRead`, `IndividualAddressRead`, `DomainAddressRead`, ...) stay plain `APCI` since they are never sent via `P2PConnection.request()`. `request()` no longer takes an `expected=` argument - it infers and verifies the expected response from the payload's type and returns the correspondingly typed `Telegram[ResponseType]`, so procedures no longer need `assert isinstance(response.payload, ResponseType)` (or even a `None` check) to get a typed `.payload`.
+
+### Bugfixes
+
+- `Device.__eq__()` returns `NotImplemented` for non-`Device` operands instead of raising `AttributeError`, so comparing a device to any other object evaluates to `False` now.
 
 # 3.20.0 DeviceManagement and Expose init 2026-08-16
 

--- a/docs/switch.md
+++ b/docs/switch.md
@@ -30,9 +30,6 @@ Switches are simple representations of binary actors. They mainly support switch
 switch = Switch(xknx, "TestOutlet", group_address="1/2/3")
 xknx.devices.async_add(switch)
 
-# Accessing switch via xknx.devices
-await xknx.devices["TestOutlet"].set_on()
-
 # Switching switch on
 await switch.set_on()
 # Switching switch off

--- a/docs/time.md
+++ b/docs/time.md
@@ -18,7 +18,7 @@ time_device = TimeDevice(xknx, "TimeTest", group_address="1/2/3", localtime=True
 xknx.devices.async_add(time_device)
 
 # `sync()` doesn't send a GroupValueRead when localtime is True but sends the current time to KNX bus
-await xknx.devices["TimeTest"].sync()
+await time_device.sync()
 ```
 
 * `xknx` is the XKNX object.

--- a/docs/xknx.md
+++ b/docs/xknx.md
@@ -115,8 +115,9 @@ asyncio.run(main())
 
 # [](#header-2)Devices
 
-To attach a device to XKNX call `xknx.devices.async_add(device)`. Added devices may be accessed by their name: `xknx.devices['NameOfDevice']`. When an update via KNX GroupValueWrite or GroupValueResponse was received devices will be updated accordingly.
-To remove a device from XKNX call `xknx.devices.async_remove(device)`. Removed devices can be re-added at a later point. This cancels background tasks of that device and disconnects it from receiving new telegrams.
+To attach a device to XKNX call `xknx.devices.async_add(device)`. Keep your own reference to the device object to interact with it. When an update via KNX GroupValueWrite or GroupValueResponse was received devices will be updated accordingly.
+To remove a device from XKNX call `xknx.devices.async_remove(device)`. This cancels background tasks of that device and disconnects it from receiving new telegrams. Removed devices can be re-added at a later point.
+Adding a device object that is already registered, or removing one that isn't, raises a `ValueError`.
 
 Example:
 
@@ -124,8 +125,8 @@ Example:
 switch = Switch(xknx, name="TestSwitch", group_address="1/1/11")
 xknx.devices.async_add(switch)
 
-await xknx.devices["TestSwitch"].set_on()
-await xknx.devices["TestSwitch"].set_off()
+await switch.set_on()
+await switch.set_off()
 ```
 
 # [](#header-2)Callbacks

--- a/examples/example_devices.py
+++ b/examples/example_devices.py
@@ -7,15 +7,22 @@ from xknx.devices import Switch
 
 
 async def main() -> None:
-    """Add test Switch to devices storage and access it by name."""
+    """Add test Switch to devices storage and use it."""
     xknx = XKNX()
     await xknx.start()
     switch = Switch(xknx, name="TestOutlet", group_address="1/1/11")
     xknx.devices.async_add(switch)
 
-    await xknx.devices["TestOutlet"].set_on()
+    # devices registered in the storage receive telegrams from the bus
+    assert switch in xknx.devices
+    for device in xknx.devices:
+        print(device)
+
+    await switch.set_on()
     await asyncio.sleep(2)
-    await xknx.devices["TestOutlet"].set_off()
+    await switch.set_off()
+
+    xknx.devices.async_remove(switch)
     await xknx.stop()
 
 

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -120,19 +120,22 @@ class TestDevices:
         assert list(xknx.devices) == [light]
         assert light.device_updated_cbs == [xknx.devices.device_updated]
 
-    def test_remove_equal_devices(self) -> None:
-        """Test removing one of two registered devices of equal state."""
+    def test_devices_compare_by_identity(self) -> None:
+        """Test that devices of identical configuration are distinct objects."""
         xknx = XKNX()
         sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
         sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
+        assert sensor1 != sensor2
+        assert len({sensor1, sensor2}) == 2  # hashable by identity
+
+        # both can be registered and removed independently
         xknx.devices.async_add(sensor1)
         xknx.devices.async_add(sensor2)
-        assert sensor1 == sensor2  # equal state, but distinct objects
+        assert sensor2 in xknx.devices
 
         xknx.devices.async_remove(sensor2)
-        remaining = list(xknx.devices)
-        assert len(remaining) == 1
-        assert remaining[0] is sensor1
+        assert list(xknx.devices) == [sensor1]
+        assert sensor2 not in xknx.devices
 
     @patch.multiple(Device, __abstractmethods__=set())
     def test_add_remove(self) -> None:

--- a/test/devices_tests/devices_test.py
+++ b/test/devices_tests/devices_test.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from xknx import XKNX
-from xknx.devices import BinarySensor, Device, Light, Switch
+from xknx.devices import BinarySensor, Device, Light
 from xknx.telegram import GroupAddress
 
 
@@ -15,34 +15,6 @@ class TestDevices:
     #
     # XKNX Config
     #
-    def test_get_item(self) -> None:
-        """Test get item by name or by index."""
-        xknx = XKNX()
-        light1 = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
-        xknx.devices.async_add(light1)
-        switch1 = Switch(xknx, "TestOutlet_1", group_address="1/2/3")
-        xknx.devices.async_add(switch1)
-        light2 = Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
-        xknx.devices.async_add(light2)
-        switch2 = Switch(xknx, "TestOutlet_2", group_address="1/2/4")
-        xknx.devices.async_add(switch2)
-
-        assert xknx.devices["Living-Room.Light_1"] == light1
-        assert xknx.devices["TestOutlet_1"] == switch1
-        assert xknx.devices["Living-Room.Light_2"] == light2
-        assert xknx.devices["TestOutlet_2"] == switch2
-        with pytest.raises(KeyError):
-            # pylint: disable=pointless-statement
-            xknx.devices["TestOutlet_2sdds"]
-
-        assert xknx.devices[0] == light1
-        assert xknx.devices[1] == switch1
-        assert xknx.devices[2] == light2
-        assert xknx.devices[3] == switch2
-        with pytest.raises(IndexError):
-            # pylint: disable=pointless-statement
-            xknx.devices[4]
-
     def test_device_by_group_address(self) -> None:
         """Test get devices by group address."""
         xknx = XKNX()
@@ -106,16 +78,61 @@ class TestDevices:
     def test_contains(self) -> None:
         """Test __contains__() function."""
         xknx = XKNX()
+        light1 = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        light2 = Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
+        light3 = Light(xknx, "Living-Room.Light_3", group_address_switch="1/6/9")
+        xknx.devices.async_add(light1)
+        xknx.devices.async_add(light2)
+
+        assert light1 in xknx.devices
+        assert light2 in xknx.devices
+        assert light3 not in xknx.devices
+        # devices are not looked up by name
+        assert "Living-Room.Light_1" not in xknx.devices  # type: ignore[operator]
+
+    def test_add_twice(self) -> None:
+        """Test adding the same device twice."""
+        xknx = XKNX()
+        light = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        xknx.devices.async_add(light)
+
+        with pytest.raises(ValueError, match="already registered"):
+            xknx.devices.async_add(light)
+        assert len(xknx.devices) == 1
+        assert light.device_updated_cbs == [xknx.devices.device_updated]
+
+        # an equal, but distinct device is not considered registered
         xknx.devices.async_add(
             Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
         )
-        xknx.devices.async_add(
-            Light(xknx, "Living-Room.Light_2", group_address_switch="1/6/8")
-        )
+        assert len(xknx.devices) == 2
 
-        assert "Living-Room.Light_1" in xknx.devices
-        assert "Living-Room.Light_2" in xknx.devices
-        assert "Living-Room.Light_3" not in xknx.devices
+    def test_remove_not_registered(self) -> None:
+        """Test removing a device that is not registered."""
+        xknx = XKNX()
+        light = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        other = Light(xknx, "Living-Room.Light_1", group_address_switch="1/6/7")
+        xknx.devices.async_add(light)
+
+        with pytest.raises(ValueError, match="not registered"):
+            xknx.devices.async_remove(other)
+        # the equal, but not registered device didn't affect the registered one
+        assert list(xknx.devices) == [light]
+        assert light.device_updated_cbs == [xknx.devices.device_updated]
+
+    def test_remove_equal_devices(self) -> None:
+        """Test removing one of two registered devices of equal state."""
+        xknx = XKNX()
+        sensor1 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
+        sensor2 = BinarySensor(xknx, "Diningroom", group_address_state="3/0/1")
+        xknx.devices.async_add(sensor1)
+        xknx.devices.async_add(sensor2)
+        assert sensor1 == sensor2  # equal state, but distinct objects
+
+        xknx.devices.async_remove(sensor2)
+        remaining = list(xknx.devices)
+        assert len(remaining) == 1
+        assert remaining[0] is sensor1
 
     @patch.multiple(Device, __abstractmethods__=set())
     def test_add_remove(self) -> None:
@@ -128,7 +145,7 @@ class TestDevices:
         assert len(xknx.devices) == 2
         xknx.devices.async_remove(device1)
         assert len(xknx.devices) == 1
-        assert "TestDevice1" not in xknx.devices
+        assert device1 not in xknx.devices
         xknx.devices.async_remove(device2)
         assert len(xknx.devices) == 0
 
@@ -142,7 +159,7 @@ class TestDevices:
             xknx.devices.process(xknx.telegrams.get_nowait())
         assert light1.state
 
-        device2 = xknx.devices["Living-Room.Light_1"]
+        device2 = next(iter(xknx.devices))
         await device2.set_off()
         xknx.devices.process(xknx.telegrams.get_nowait())
         assert not light1.state

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -134,9 +134,3 @@ class Device(ABC):
             group_address in remote_value.group_addresses()
             for remote_value in self._iter_remote_values()
         )
-
-    def __eq__(self, other: object) -> bool:
-        """Compare for quality."""
-        if not isinstance(other, Device):
-            return NotImplemented
-        return self.__dict__ == other.__dict__

--- a/xknx/devices/device.py
+++ b/xknx/devices/device.py
@@ -137,4 +137,6 @@ class Device(ABC):
 
     def __eq__(self, other: object) -> bool:
         """Compare for quality."""
+        if not isinstance(other, Device):
+            return NotImplemented
         return self.__dict__ == other.__dict__

--- a/xknx/devices/devices.py
+++ b/xknx/devices/devices.py
@@ -66,21 +66,8 @@ class Devices:
         return len(self.__devices)
 
     def __contains__(self, device: Device) -> bool:
-        """Return if device is registered. Devices are identified by object identity."""
-        return self._index_of(device) is not None
-
-    def _index_of(self, device: Device) -> int | None:
-        """Return the index of a registered device object or None if it is not registered."""
-        # `list.index()` and `list.remove()` compare by equality - `Device.__eq__()`
-        # compares attributes, so two distinct devices of equal state would match
-        return next(
-            (
-                index
-                for index, registered in enumerate(self.__devices)
-                if registered is device
-            ),
-            None,
-        )
+        """Return if device is registered."""
+        return device in self.__devices
 
     def async_add(self, device: Device) -> None:
         """Add device to active XKNX devices."""
@@ -95,13 +82,12 @@ class Devices:
 
     def async_remove(self, device: Device) -> None:
         """Remove device from XKNX devices."""
-        index = self._index_of(device)
-        if index is None:
+        if device not in self:
             raise ValueError(f"Device is not registered: {device}")
         device.async_remove_tasks()
         device.unregister_state_updater()
         device.unregister_device_updated_cb(self.device_updated)
-        del self.__devices[index]
+        self.__devices.remove(device)
 
     def device_updated(self, device: Device) -> None:
         """Call all registered device updated callbacks of device."""

--- a/xknx/devices/devices.py
+++ b/xknx/devices/devices.py
@@ -61,25 +61,31 @@ class Devices:
             if device.has_group_address(group_address):
                 yield device
 
-    def __getitem__(self, key: str | int) -> Device:
-        """Return device by name or by index."""
-        for device in self.__devices:
-            if device.name == key:
-                return device
-        if isinstance(key, int):
-            return self.__devices[key]
-        raise KeyError
-
     def __len__(self) -> int:
         """Return number of devices within vector."""
         return len(self.__devices)
 
-    def __contains__(self, key: str) -> bool:
-        """Return if devices with name 'key' is within devices."""
-        return any(device.name == key for device in self.__devices)
+    def __contains__(self, device: Device) -> bool:
+        """Return if device is registered. Devices are identified by object identity."""
+        return self._index_of(device) is not None
+
+    def _index_of(self, device: Device) -> int | None:
+        """Return the index of a registered device object or None if it is not registered."""
+        # `list.index()` and `list.remove()` compare by equality - `Device.__eq__()`
+        # compares attributes, so two distinct devices of equal state would match
+        return next(
+            (
+                index
+                for index, registered in enumerate(self.__devices)
+                if registered is device
+            ),
+            None,
+        )
 
     def async_add(self, device: Device) -> None:
         """Add device to active XKNX devices."""
+        if device in self:
+            raise ValueError(f"Device is already registered: {device}")
         device.register_device_updated_cb(self.device_updated)
         self.__devices.append(device)
         device.register_state_updater()
@@ -89,10 +95,13 @@ class Devices:
 
     def async_remove(self, device: Device) -> None:
         """Remove device from XKNX devices."""
+        index = self._index_of(device)
+        if index is None:
+            raise ValueError(f"Device is not registered: {device}")
         device.async_remove_tasks()
         device.unregister_state_updater()
         device.unregister_device_updated_cb(self.device_updated)
-        self.__devices.remove(device)
+        del self.__devices[index]
 
     def device_updated(self, device: Device) -> None:
         """Call all registered device updated callbacks of device."""

--- a/xknx/devices/light.py
+++ b/xknx/devices/light.py
@@ -108,10 +108,6 @@ class _SwitchAndBrightness:
         if self.brightness.writable:
             self.brightness.set(0)
 
-    def __eq__(self, other: object) -> bool:
-        """Compare for equality."""
-        return self.__dict__ == other.__dict__
-
 
 class Light(Device):
     """Class for managing a light."""


### PR DESCRIPTION
Closes #1636

Device names are never checked for uniqueness, so `xknx.devices["name"]` could return any one of several devices sharing a name. Lookup by index has no real use. Applications should keep a reference to the device object instead, or iterate `xknx.devices` to find it.

## Breaking changes

- `Devices.__getitem__()` is gone - both `xknx.devices["NameOfDevice"]` and `xknx.devices[0]`.
- `device in xknx.devices` takes the `Device` object now instead of its name. Typing it as `Device` rather than dropping `__contains__` altogether keeps the migration statically detectable - mypy reports `Unsupported operand types for in ("str" and "Devices")` instead of silently evaluating to `False` via the `__iter__` fallback.
- `Devices.async_add()` and `Devices.async_remove()` raise `ValueError` when the device object is already registered, or not registered at all. Adding a device twice had it receive every telegram twice and fire its callbacks twice; removing an unregistered one cancelled its tasks and unregistered its state updater before failing.
- `Device.__eq__()` is removed - see below.

## Removing `Device.__eq__()`

`Device.__eq__()` compared `self.__dict__ == other.__dict__`. It arrived in 7dea4d1b (Aug 2020) to serve the YAML config test suite, which asserted that a device parsed from `xknx.yaml` equalled a hand constructed one:

```python
self.assertEqual(
    TestConfig.xknx.devices['Living-Room.Light_1'],
    Light(TestConfig.xknx, 'Living-Room.Light_1', group_address_switch='1/6/9', ...))
```

`xknx/config/` and its 598 line test file went away in 8784f51d (Apr 2021); the comparison stayed. `_SwitchAndBrightness.__eq__()` in `light.py` has the same lineage - added for individual colors so `Light.__dict__` would compare those by value for those same config tests. Neither has a caller left anywhere in the library.

Consequences:

- Devices compare by identity, which is the natural semantics for these objects.
- `Device` is hashable again. Defining `__eq__` is what set `__hash__ = None`; not defining it restores the inherited `object.__hash__`, so devices work in sets and as dict keys.
- `Devices._index_of()` is retired. `list.__contains__()` and `list.remove()` are identity based once equality is identity, so `__contains__()` and `async_remove()` use them directly again.
- `"name" in xknx.devices` returns `False` rather than raising `AttributeError: 'str' object has no attribute '__dict__'`, and mypy still flags it via the `Device` annotation.

`RemoteValue.__eq__()` is untouched - unlike these two it has direct test coverage and is not a config era leftover.

## Not included

`__slots__` on devices. Both removed methods read `self.__dict__`, so this change unblocks it, and `xknx.remote_value` is fully slotted since #1921 - but devices stay unslotted deliberately. Applications keep references to device objects and may want to hang their own metadata on them; `__slots__` would turn that into an `AttributeError`. That flexibility is worth more than the memory here, since there is no performance upside to trade for it:

- device `__dict__` is 176 KiB of a 3099 KiB 1000 device install (6%), and the realized saving would be lower still - instance dicts are key-sharing, so `sys.getsizeof(obj.__dict__)` overstates what slotting reclaims
- attribute reads differ by ~1% between dict and slots

## Also updated

`docs/xknx.md`, `docs/switch.md`, `docs/time.md` and `examples/example_devices.py` no longer demonstrate name lookup - the example now shows add / contains / iterate / remove instead.

## Test plan

- `test_get_item` removed; `test_add_twice`, `test_remove_not_registered` and `test_devices_compare_by_identity` added; `test_contains`, `test_add_remove` and `test_modification_of_device` updated.
- Full suite passes (3878), `ruff check`, `ruff format`, `mypy xknx` and the pylint pre-commit hooks are clean.
- Nothing in the existing suite double-adds or double-removes, so the new guards broke no callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
