### PR TITLE
Remove RemoteValue.__eq__ and make remote values slotted

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,17 @@ nav_order: 2
 
 - Drop support for Python 3.10. XKNX requires Python 3.11 or newer now.
 - Remove `xknx.util`. Its only member was `asyncio_timeout` - a backport of `asyncio.timeout` for Python versions not providing it - so use `asyncio.timeout` directly.
+- Remove `RemoteValue.__eq__()`. It compared `__dict__` attributes - a leftover of the YAML config handling removed in 1.0 - and raised `AttributeError` when compared to an object without a `__dict__`. Remote values compare by identity now, which also makes them hashable again, so they can be used in sets and as dict keys.
+- All classes in `xknx.remote_value` define `__slots__` now. Setting an attribute that isn't declared by the class raises `AttributeError` instead of silently creating it.
+
+  ```python
+  rv_1 = RemoteValueSwitch(xknx, group_address="1/2/3")
+  rv_2 = RemoteValueSwitch(xknx, group_address="1/2/3")
+
+  rv_1 == rv_2  # before: True (equal attributes); now: False (distinct objects)
+  hash(rv_1)  # before: TypeError: unhashable type; now: works
+  rv_1.my_own_attribute = 1  # before: works; now: AttributeError
+  ```
 
 ### Connection
 

--- a/test/remote_value_tests/remote_value_test.py
+++ b/test/remote_value_tests/remote_value_test.py
@@ -12,6 +12,13 @@ from xknx.telegram import GroupAddress, Telegram, TelegramDecodedData
 from xknx.telegram.apci import GroupValueWrite
 
 
+class _RemoteValue2ByteFloat(RemoteValue[float]):
+    """Concrete RemoteValue to test the base class implementation."""
+
+    __slots__ = ()
+    dpt_class = DPT2ByteFloat
+
+
 @patch.multiple(RemoteValue, __abstractmethods__=set())
 class TestRemoteValue:
     """Test class for RemoteValue objects."""
@@ -19,8 +26,7 @@ class TestRemoteValue:
     async def test_get_set_value(self) -> None:
         """Test value getter and setter."""
         xknx = XKNX()
-        remote_value = RemoteValue(xknx)
-        remote_value.to_knx = DPT2ByteFloat.to_knx
+        remote_value = _RemoteValue2ByteFloat(xknx)
         remote_value.after_update_cb = Mock()
 
         assert remote_value.value is None
@@ -31,9 +37,9 @@ class TestRemoteValue:
             remote_value.value = "a"
         # new value is used in response Telegram
         test_payload = remote_value.to_knx(2.2)
-        remote_value.send_raw = Mock()
-        remote_value.respond()
-        remote_value.send_raw.assert_called_with(test_payload, response=True)
+        with patch.object(_RemoteValue2ByteFloat, "send_raw") as send_raw_mock:
+            remote_value.respond()
+            send_raw_mock.assert_called_with(test_payload, response=True)
         # callback is not called when setting value programmatically
         remote_value.after_update_cb.assert_not_called()
         # no Telegram was sent to the queue
@@ -42,8 +48,7 @@ class TestRemoteValue:
     def test_set_value(self) -> None:
         """Test set_value awaitable."""
         xknx = XKNX()
-        remote_value = RemoteValue(xknx)
-        remote_value.to_knx = DPT2ByteFloat.to_knx
+        remote_value = _RemoteValue2ByteFloat(xknx)
         remote_value.after_update_cb = Mock()
 
         remote_value.update_value(3.3)
@@ -229,8 +234,7 @@ class TestRemoteValue:
     def test_process_passive_address(self) -> None:
         """Test if passive group addresses are processed."""
         xknx = XKNX()
-        remote_value = RemoteValue(xknx, group_address=["1/2/3", "1/1/1"])
-        remote_value.dpt_class = DPT2ByteFloat
+        remote_value = _RemoteValue2ByteFloat(xknx, group_address=["1/2/3", "1/1/1"])
 
         assert remote_value.writable
         assert not remote_value.readable
@@ -261,15 +265,14 @@ class TestRemoteValue:
             remote_value.process(telegram)
 
         # doesn't raise with `dpt_class` set
-        remote_value.dpt_class = DPT2ByteFloat
-        remote_value.value = 3.3
-        remote_value.process(telegram)
+        remote_value_dpt = _RemoteValue2ByteFloat(xknx, group_address="1/1/1")
+        remote_value_dpt.value = 3.3
+        remote_value_dpt.process(telegram)
 
     def test_pre_decoded_telegram(self) -> None:
         """Test if pre-decoded Telegram is processed."""
         xknx = XKNX()
-        remote_value = RemoteValue(xknx, group_address="1/1/1")
-        remote_value.dpt_class = DPT2ByteFloat
+        remote_value = _RemoteValue2ByteFloat(xknx, group_address="1/1/1")
 
         test_payload = "invalid for testing"
         telegram = Telegram(
@@ -280,27 +283,21 @@ class TestRemoteValue:
         assert remote_value.process(telegram)
         assert remote_value.value == 3.3
 
-    def test_eq(self) -> None:
-        """Test __eq__ operator."""
+    def test_compare_by_identity(self) -> None:
+        """Test that remote values of identical configuration are distinct objects."""
         xknx = XKNX()
         remote_value1 = RemoteValue(xknx, group_address=GroupAddress("1/1/1"))
         remote_value2 = RemoteValue(xknx, group_address=GroupAddress("1/1/1"))
-        remote_value3 = RemoteValue(xknx, group_address=GroupAddress("1/1/2"))
-        remote_value4 = RemoteValue(xknx, group_address=GroupAddress("1/1/1"))
-        remote_value4.fnord = "fnord"
 
-        def _callback() -> None:
-            pass
+        assert remote_value1 != remote_value2
+        assert remote_value1 != "not a RemoteValue"
+        assert len({remote_value1, remote_value2}) == 2  # hashable by identity
 
-        remote_value5 = RemoteValue(
-            xknx, group_address=GroupAddress("1/1/1"), after_update_cb=_callback()
-        )
+    def test_no_instance_dict(self) -> None:
+        """Test that remote values are slotted."""
+        remote_value = RemoteValue(XKNX(), group_address=GroupAddress("1/1/1"))
 
-        assert remote_value1 == remote_value2
-        assert remote_value2 == remote_value1
-        assert remote_value1 != remote_value3
-        assert remote_value3 != remote_value1
-        assert remote_value1 != remote_value4
-        assert remote_value4 != remote_value1
-        assert remote_value1 == remote_value5
-        assert remote_value5 == remote_value1
+        assert not hasattr(remote_value, "__dict__")
+        with pytest.raises(AttributeError):
+            # pylint: disable=assigning-non-slot
+            remote_value.fnord = "fnord"

--- a/test/str_test.py
+++ b/test/str_test.py
@@ -90,8 +90,9 @@ class TestStringRepresentations:
             == '<RemoteValue device_name="MyDevice" feature_name="Unknown" <1/2/3, 1/2/4, [], None /> />'
         )
 
-        remote_value.to_knx = lambda value: value  # to bypass NotImplementedError
-        remote_value.value = 34
+        # patch the class to bypass NotImplementedError - RemoteValue is slotted
+        with patch.object(RemoteValue, "to_knx", lambda self, value: value):
+            remote_value.value = 34
         assert (
             str(remote_value)
             == '<RemoteValue device_name="MyDevice" feature_name="Unknown" '

--- a/xknx/remote_value/remote_value.py
+++ b/xknx/remote_value/remote_value.py
@@ -41,6 +41,20 @@ RVCallbackType = Callable[[ValueT], None]
 class RemoteValue(ABC, Generic[ValueT]):
     """Class for managing remote knx value."""
 
+    __slots__ = (
+        "_payload",
+        "_sync_state",
+        "_value",
+        "after_update_cb",
+        "device_name",
+        "feature_name",
+        "group_address",
+        "group_address_state",
+        "passive_group_addresses",
+        "telegram",
+        "xknx",
+    )
+
     dpt_class: type[DPTBase] | None = None
 
     def __init__(
@@ -306,19 +320,3 @@ class RemoteValue(ABC, Generic[ValueT]):
             f'feature_name="{self.feature_name}" '
             f"{self.group_addr_str()} />"
         )
-
-    def __eq__(self, other: object) -> bool:
-        """Equal operator."""
-        for key, value in self.__dict__.items():
-            if key == "after_update_cb":
-                continue
-            if key not in other.__dict__:
-                return False
-            if other.__dict__[key] != value:
-                return False
-        for key in other.__dict__:
-            if key == "after_update_cb":
-                continue
-            if key not in self.__dict__:
-                return False
-        return True

--- a/xknx/remote_value/remote_value_by_length.py
+++ b/xknx/remote_value/remote_value_by_length.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 class RemoteValueByLength(RemoteValue[float]):
     """RemoteValue with DPT detection based on payload length of first received value."""
 
+    __slots__ = ("_dpt_classes", "_internal_dpt_class")
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_climate_mode.py
+++ b/xknx/remote_value/remote_value_climate_mode.py
@@ -42,6 +42,8 @@ HVACModeT = TypeVar(
 class RemoteValueClimateModeBase(RemoteValue[HVACModeT]):
     """Base class for binary climate mode remote values."""
 
+    __slots__ = ()
+
     @abstractmethod
     def supported_operation_modes(self) -> list[HVACOperationMode]:
         """Return a list of all supported operation modes."""
@@ -62,6 +64,7 @@ class RemoteValueClimateModeBase(RemoteValue[HVACModeT]):
 class RemoteValueOperationMode(RemoteValueClimateModeBase[HVACOperationMode]):
     """Abstraction for remote value of KNX climate operation modes."""
 
+    __slots__ = ()
     dpt_class = DPTHVACMode
 
     def __init__(
@@ -107,6 +110,7 @@ class RemoteValueOperationMode(RemoteValueClimateModeBase[HVACOperationMode]):
 class RemoteValueControllerMode(RemoteValueClimateModeBase[HVACControllerMode]):
     """Abstraction for remote value of KNX climate controller modes."""
 
+    __slots__ = ()
     dpt_class = DPTHVACContrMode
 
     def __init__(
@@ -152,6 +156,7 @@ class RemoteValueControllerMode(RemoteValueClimateModeBase[HVACControllerMode]):
 class RemoteValueHVACStatus(RemoteValueClimateModeBase[HVACStatus]):
     """Abstraction for remote value of KNX climate HVAC status (Eberle status)."""
 
+    __slots__ = ()
     dpt_class = DPTHVACStatus
 
     def __init__(
@@ -232,6 +237,8 @@ class RemoteValueBinaryOperationMode(
 ):
     """Abstraction for remote value of split up KNX climate modes."""
 
+    __slots__ = ("operation_mode",)
+
     def __init__(
         self,
         xknx: XKNX,
@@ -311,6 +318,8 @@ class RemoteValueBinaryOperationMode(
 
 class RemoteValueBinaryHeatCool(RemoteValueClimateModeBase[HVACControllerMode]):
     """Abstraction for remote value of heat/cool controller mode."""
+
+    __slots__ = ("controller_mode",)
 
     def __init__(
         self,

--- a/xknx/remote_value/remote_value_color_rgb.py
+++ b/xknx/remote_value/remote_value_color_rgb.py
@@ -14,4 +14,5 @@ from .remote_value import RemoteValue
 class RemoteValueColorRGB(RemoteValue[RGBColor]):
     """Abstraction for remote value of KNX DPT 232.600 (DPT_Color_RGB)."""
 
+    __slots__ = ()
     dpt_class = DPTColorRGB

--- a/xknx/remote_value/remote_value_color_rgbw.py
+++ b/xknx/remote_value/remote_value_color_rgbw.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 class RemoteValueColorRGBW(RemoteValue[RGBWColor]):
     """Abstraction for remote value of KNX DPT 251.600 (DPT_Color_RGBW)."""
 
+    __slots__ = ("_valid_value",)
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_color_xyy.py
+++ b/xknx/remote_value/remote_value_color_xyy.py
@@ -14,4 +14,5 @@ from .remote_value import RemoteValue
 class RemoteValueColorXYY(RemoteValue[XYYColor]):
     """Abstraction for remote value of KNX DPT 242.600 (DPT_Colour_xyY)."""
 
+    __slots__ = ()
     dpt_class = DPTColorXYY

--- a/xknx/remote_value/remote_value_datetime.py
+++ b/xknx/remote_value/remote_value_datetime.py
@@ -17,16 +17,19 @@ from .remote_value import RemoteValue
 class RemoteValueTime(RemoteValue[KNXTime]):
     """Abstraction for remote value of KNX 3 octet time."""
 
+    __slots__ = ()
     dpt_class = DPTTime
 
 
 class RemoteValueDate(RemoteValue[KNXDate]):
     """Abstraction for remote value of KNX 3 octet date."""
 
+    __slots__ = ()
     dpt_class = DPTDate
 
 
 class RemoteValueDateTime(RemoteValue[KNXDateTime]):
     """Abstraction for remote value of KNX 8 octet datetime."""
 
+    __slots__ = ()
     dpt_class = DPTDateTime

--- a/xknx/remote_value/remote_value_dpt_value_1_ucount.py
+++ b/xknx/remote_value/remote_value_dpt_value_1_ucount.py
@@ -14,4 +14,5 @@ from .remote_value import RemoteValue
 class RemoteValueDptValue1Ucount(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 5.010."""
 
+    __slots__ = ()
     dpt_class = DPTValue1Ucount

--- a/xknx/remote_value/remote_value_raw.py
+++ b/xknx/remote_value/remote_value_raw.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 class RemoteValueRaw(RemoteValue[int]):
     """Abstraction for raw values."""
 
+    __slots__ = ("payload_length",)
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_scaling.py
+++ b/xknx/remote_value/remote_value_scaling.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 class RemoteValueScaling(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 5.001 (DPT_Scaling)."""
 
+    __slots__ = ("range_from", "range_to")
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_scene_number.py
+++ b/xknx/remote_value/remote_value_scene_number.py
@@ -14,4 +14,5 @@ from .remote_value import RemoteValue
 class RemoteValueSceneNumber(RemoteValue[int]):
     """Abstraction for remote value of KNX DPT 17.001 (DPT_Scene_Number)."""
 
+    __slots__ = ()
     dpt_class = DPTSceneNumber

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -24,6 +24,8 @@ ValueT = TypeVar("ValueT")
 class _RemoteValueGeneric(RemoteValue[ValueT]):
     """Abstraction for generic DPT types."""
 
+    __slots__ = ("dpt_class",)
+
     dpt_base_class: type[DPTBase]
     _default_dpt_class: type[DPTBase] | None = None
     dpt_class: type[DPTBase]
@@ -77,6 +79,7 @@ class _RemoteValueGeneric(RemoteValue[ValueT]):
 class RemoteValueSensor(_RemoteValueGeneric[int | float | str]):
     """Abstraction for sensor DPT types."""
 
+    __slots__ = ()
     dpt_base_class = DPTBase
     dpt_class: type[DPTBase]
 
@@ -84,6 +87,7 @@ class RemoteValueSensor(_RemoteValueGeneric[int | float | str]):
 class RemoteValueNumeric(_RemoteValueGeneric[int | float]):
     """Abstraction for numeric DPT types."""
 
+    __slots__ = ()
     dpt_base_class = DPTNumeric
     dpt_class: type[DPTNumeric]
 
@@ -91,6 +95,7 @@ class RemoteValueNumeric(_RemoteValueGeneric[int | float]):
 class RemoteValueString(_RemoteValueGeneric[str]):
     """Abstraction for string DPT types."""
 
+    __slots__ = ()
     dpt_base_class = DPTString
     dpt_class: type[DPTString]
     _default_dpt_class = DPTString

--- a/xknx/remote_value/remote_value_setpoint_shift.py
+++ b/xknx/remote_value/remote_value_setpoint_shift.py
@@ -28,6 +28,8 @@ class SetpointShiftMode(Enum):
 class RemoteValueSetpointShift(RemoteValue[float]):
     """Abstraction for remote value of KNX DPT 6.010."""
 
+    __slots__ = ("_internal_dpt_class", "setpoint_shift_step")
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_step.py
+++ b/xknx/remote_value/remote_value_step.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 class RemoteValueStep(RemoteValue["RemoteValueStep.Direction"]):
     """Abstraction for remote value of KNX DPT 1.007 / DPT_Step."""
 
+    __slots__ = ("invert",)
+
     class Direction(Enum):
         """Enum for indicating the direction."""
 

--- a/xknx/remote_value/remote_value_switch.py
+++ b/xknx/remote_value/remote_value_switch.py
@@ -20,6 +20,8 @@ if TYPE_CHECKING:
 class RemoteValueSwitch(RemoteValue[bool]):
     """Abstraction for remote value of KNX DPT 1.001 / DPT_Switch."""
 
+    __slots__ = ("invert",)
+
     def __init__(
         self,
         xknx: XKNX,

--- a/xknx/remote_value/remote_value_temp.py
+++ b/xknx/remote_value/remote_value_temp.py
@@ -14,4 +14,5 @@ from .remote_value import RemoteValue
 class RemoteValueTemp(RemoteValue[float]):
     """Abstraction for remote value of KNX 9.001 (DPT_Value_Temp)."""
 
+    __slots__ = ()
     dpt_class = DPTTemperature

--- a/xknx/remote_value/remote_value_updown.py
+++ b/xknx/remote_value/remote_value_updown.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 class RemoteValueUpDown(RemoteValue["RemoteValueUpDown.Direction"]):
     """Abstraction for remote value of KNX DPT 1.008 / DPT_UpDown."""
 
+    __slots__ = ("invert",)
+
     class Direction(Enum):
         """Enum for indicating the direction."""
 


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description
<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Follow-up to the `Device.__eq__()` removal, for `RemoteValue`.

`RemoteValue.__eq__()` compared `self.__dict__` against `other.__dict__`, skipping `after_update_cb`. It is the counterpart of `Device.__eq__()` - a leftover of the YAML config handling removed in 1.0, where a device parsed from `xknx.yaml` had to compare equal to a hand constructed one. The only caller left was `test_eq()`, testing the operator for its own sake.

Two things it caused on the way:

- Defining `__eq__` without `__hash__` sets `__hash__ = None`, so remote values were **unhashable** - they could not go into a set or be used as a dict key. `StateUpdater` keys its workers by `id(remote_value)` precisely because it could not rely on this.
- It raised `AttributeError` when compared to any object without a `__dict__` (`rv == None`, `rv == 1`, ...) instead of evaluating to `False` - the same bug that was fixed and then removed for `Device`.

Remote values compare by identity now, which is the natural semantics for these objects, and are hashable again.

With `__eq__` gone, nothing reads `RemoteValue.__dict__` any more, so every class in `xknx/remote_value/` declares `__slots__`. Remote values are the most numerous objects in a running xknx instance - a handful per device - so this drops the per instance `__dict__` and speeds up attribute access. It follows what most of the library already does (`StateUpdater`, `Devices`, `TelegramQueue`, `Telegram`, `GroupAddress`, the `io` transports, the `apci` classes).

Notes for review:

- `dpt_class` stays a plain class attribute on `RemoteValue` - a class body may not both list a name in `__slots__` and assign it. `_RemoteValueGeneric` is the one class that assigns `dpt_class` per instance, so it declares `__slots__ = ("dpt_class",)`; the slot descriptor shadows the base's `dpt_class = None` for that branch of the hierarchy.
- Subclasses that add no attributes get `__slots__ = ()` so they stay dict-less.
- Subclasses outside this package that do not declare `__slots__` themselves keep getting a `__dict__` automatically - so this is not breaking for downstream subclasses, only for setting undeclared attributes on xknx's own remote values.
- Tests no longer patch methods or `dpt_class` onto RemoteValue *instances*: a concrete `_RemoteValue2ByteFloat` subclass and `patch.object()` on the class take over.

```python
rv_1 = RemoteValueSwitch(xknx, group_address="1/2/3")
rv_2 = RemoteValueSwitch(xknx, group_address="1/2/3")

rv_1 == rv_2  # before: True (equal attributes); now: False (distinct objects)
hash(rv_1)  # before: TypeError: unhashable type; now: works
rv_1.my_own_attribute = 1  # before: works; now: AttributeError
```

Fixes # (issue)

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
