### PR TITLE
Fix the misspelled management constants and name the rate limit default

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ nav_order: 2
 
 ### Breaking changes
 
+- Rename `xknx.management.management.MANAGAMENT_ACK_TIMEOUT` and `MANAGAMENT_CONNECTION_TIMEOUT` to `MANAGEMENT_ACK_TIMEOUT` and `MANAGEMENT_CONNECTION_TIMEOUT` - they were misspelled.
 - Drop support for Python 3.10. XKNX requires Python 3.11 or newer now.
 - Remove `xknx.util`. Its only member was `asyncio_timeout` - a backport of `asyncio.timeout` for Python versions not providing it - so use `asyncio.timeout` directly.
 - Remove `RemoteValue.__eq__()`. It compared `__dict__` attributes - a leftover of the YAML config handling removed in 1.0 - and raised `AttributeError` when compared to an object without a `__dict__`. Remote values compare by identity now, which also makes them hashable again, so they can be used in sets and as dict keys.

--- a/test/management_tests/management_test.py
+++ b/test/management_tests/management_test.py
@@ -14,7 +14,7 @@ from xknx.exceptions import (
     ManagementConnectionRefused,
     ManagementConnectionTimeout,
 )
-from xknx.management.management import MANAGAMENT_ACK_TIMEOUT
+from xknx.management.management import MANAGEMENT_ACK_TIMEOUT
 from xknx.telegram import (
     GroupAddress,
     IndividualAddress,
@@ -96,13 +96,13 @@ async def test_ack_timeout(time_travel: EventLoopClockAdvancer) -> None:
     assert xknx.cemi_handler.send_telegram.call_args_list == [
         call(device_desc_read),
     ]
-    await time_travel(MANAGAMENT_ACK_TIMEOUT)
+    await time_travel(MANAGEMENT_ACK_TIMEOUT)
     # telegram repeated
     assert xknx.cemi_handler.send_telegram.call_args_list == [
         call(device_desc_read),
         call(device_desc_read),
     ]
-    await time_travel(MANAGAMENT_ACK_TIMEOUT)
+    await time_travel(MANAGEMENT_ACK_TIMEOUT)
     with pytest.raises(ManagementConnectionTimeout):
         # still no ACK -> timeout
         await task

--- a/test/management_tests/procedures/network/test_nm_individual_address_write.py
+++ b/test/management_tests/procedures/network/test_nm_individual_address_write.py
@@ -7,7 +7,7 @@ import pytest
 
 from xknx import XKNX
 from xknx.exceptions import ManagementConnectionError
-from xknx.management.management import MANAGAMENT_CONNECTION_TIMEOUT
+from xknx.management.management import MANAGEMENT_CONNECTION_TIMEOUT
 from xknx.management.procedures.network.nm_individual_address_write import (
     nm_individual_address_write,
 )
@@ -80,14 +80,14 @@ async def test_nm_individual_address_write(time_travel: EventLoopClockAdvancer) 
     )
 
     # make sure first request (address check) times out
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
 
     # send response to device in programming mode
     xknx.management.process(address_reply_message)
 
     # confirm device is up and running
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
     xknx.management.process(ack)
     xknx.management.process(device_desc_resp)
 
@@ -273,7 +273,7 @@ async def test_nm_individual_address_write_address_occupied_by_disconnect(
     ]
 
     # no device in programming mode → timeout → error
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
     with pytest.raises(
         ManagementConnectionError, match="No device in programming mode"
     ):
@@ -386,16 +386,16 @@ async def test_nm_individual_address_write_programming_failed(
     )
 
     # make sure first request (address check) times out
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
 
     # send response to device in programming mode
     xknx.management.process(address_reply_message)
 
     # device experienced error, so set connection request timeout
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
-    await time_travel(MANAGAMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
+    await time_travel(MANAGEMENT_CONNECTION_TIMEOUT)
 
     assert xknx.cemi_handler.send_telegram.call_args_list == [
         call(connect),

--- a/xknx/management/management.py
+++ b/xknx/management/management.py
@@ -38,6 +38,8 @@ logger = logging.getLogger("xknx.management")
 
 MANAGEMENT_ACK_TIMEOUT = 3
 MANAGEMENT_CONNECTION_TIMEOUT = 6
+# telegrams per second a point-to-point connection sends at most
+MANAGEMENT_RATE_LIMIT = 20
 
 
 class Management:
@@ -88,7 +90,7 @@ class Management:
         return
 
     async def connect(
-        self, address: IndividualAddress, rate_limit: int = 20
+        self, address: IndividualAddress, rate_limit: int = MANAGEMENT_RATE_LIMIT
     ) -> P2PConnection:
         """Open a point-to-point connection to a KNX device."""
         if address in self._connections:
@@ -128,7 +130,7 @@ class Management:
 
     @asynccontextmanager
     async def connection(
-        self, address: IndividualAddress, rate_limit: int = 20
+        self, address: IndividualAddress, rate_limit: int = MANAGEMENT_RATE_LIMIT
     ) -> AsyncGenerator[P2PConnection, None]:
         """Provide a point-to-point connection to a KNX device."""
         conn = await self.connect(address, rate_limit)
@@ -278,7 +280,10 @@ class P2PConnection:
     )
 
     def __init__(
-        self, xknx: XKNX, address: IndividualAddress, rate_limit: int = 20
+        self,
+        xknx: XKNX,
+        address: IndividualAddress,
+        rate_limit: int = MANAGEMENT_RATE_LIMIT,
     ) -> None:
         """Initialize P2PConnection class."""
         self.xknx = xknx

--- a/xknx/management/management.py
+++ b/xknx/management/management.py
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
     from xknx.xknx import XKNX
 logger = logging.getLogger("xknx.management")
 
-MANAGAMENT_ACK_TIMEOUT = 3
-MANAGAMENT_CONNECTION_TIMEOUT = 6
+MANAGEMENT_ACK_TIMEOUT = 3
+MANAGEMENT_CONNECTION_TIMEOUT = 6
 
 
 class Management:
@@ -419,7 +419,7 @@ class P2PConnection:
         self._ack_waiter = asyncio.get_event_loop().create_future()
         try:
             await self.xknx.cemi_handler.send_telegram(telegram)
-            async with asyncio.timeout(MANAGAMENT_ACK_TIMEOUT):
+            async with asyncio.timeout(MANAGEMENT_ACK_TIMEOUT):
                 ack = await self._ack_waiter
         except TimeoutError:
             logger.info(
@@ -430,7 +430,7 @@ class P2PConnection:
             self._ack_waiter = asyncio.get_event_loop().create_future()
             await self.xknx.cemi_handler.send_telegram(telegram)
             try:
-                async with asyncio.timeout(MANAGAMENT_ACK_TIMEOUT):
+                async with asyncio.timeout(MANAGEMENT_ACK_TIMEOUT):
                     ack = await self._ack_waiter
             except TimeoutError:
                 raise ManagementConnectionTimeout(
@@ -457,7 +457,7 @@ class P2PConnection:
     async def _receive(self, expected_payload: type[APCI] | None) -> Telegram:
         """Wait for a telegram from the KNX device."""
         try:
-            async with asyncio.timeout(MANAGAMENT_CONNECTION_TIMEOUT):
+            async with asyncio.timeout(MANAGEMENT_CONNECTION_TIMEOUT):
                 telegram = await self._response_waiter
         except TimeoutError:
             raise ManagementConnectionTimeout(


### PR DESCRIPTION
Two small cleanups in `xknx/management/management.py`, noticed while reading the class after #1916.

### `MANAGAMENT_*` → `MANAGEMENT_*`

```python
MANAGAMENT_ACK_TIMEOUT = 3
MANAGAMENT_CONNECTION_TIMEOUT = 6
```

Misspelled since they were introduced. They are module level names without a leading underscore and the test suite imports them, so this is listed under breaking changes even though nothing inside the library exposed them further. `codespell` runs in pre-commit and does not know this one.

### `MANAGEMENT_RATE_LIMIT`

The default rate limit was written out as a literal `20` in three signatures — `Management.connect()`, `Management.connection()` and `P2PConnection.__init__()` — so changing one would have left the others silently disagreeing. It is now a module constant next to the timeouts. No behaviour change; the value is the same.

### Notes

- Two commits, one per change.
- `mypy`, `ruff`, `pylint` and the full suite (3900) pass.

There are two further things I noticed in that class but left alone, happy to open issues or PRs if wanted:

- `Management.process()` sends a `TAck` for a `TDataConnected` **before** checking whether a connection exists, so it acknowledges a telegram from a device it has no connection with and then logs `No active point-to-point connection for received telegram`. The `TConnect` branch just below correctly refuses unsolicited connections with `TDisconnect`. That is a behaviour change and wants a spec/Calimero cross-check, so it is not in here.
- After #1916 the class is asymmetric: broadcast lives behind `management.broadcast`, while point-to-point is still flat on `Management`. The same reasoning that extracted `Broadcast` would extract a point-to-point counterpart, but that renames well established public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)