### PR TITLE
Remove ha_device_class

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,7 @@ nav_order: 2
 - `Sensor`, `NumericValue` and `ExposeSensor` take `value_type` as their first argument after `xknx`, before `name`, and require it - like `payload_length` of `RawValue` above. `Sensor(xknx, "Name", value_type="temperature")` becomes `Sensor(xknx, "temperature", "Name")`. `value_type` never had a usable default: passing `None` raised `ConversionError`. `Notification` keeps its optional `value_type`, now defaulting to `"string"` instead of `None`.
 - `RemoteValueSensor`, `RemoteValueNumeric` and `RemoteValueString` take `value_type` as their first argument after `xknx` and require it. `RemoteValueString` no longer defaults to `DPTString`; pass `value_type="string"` explicitly.
 - `Scene.scene_value` is a `RemoteValueSceneControl` (DPT 18.001) instead of a `RemoteValueSceneNumber` (DPT 17.001), so its value carries the learn bit next to the scene number. Telegrams on the wire are unchanged: DPT 18.001 encodes an activation to the same octet DPT 17.001 does, and decodes one back the same way. The device callback is called for received learn telegrams of the devices `scene_number` now, not only for activations - the new `Scene.learn_requested` tells both apart.
+- Remove `ha_device_class` from `DPTBase` subclasses, `RemoteValueSensor`, `RemoteValueByLength`, `Sensor` and `NumericValue`. It mapped DPTs to Home Assistant sensor device classes - a downstream concern that Home Assistants KNX integration maintains itself since it also needs state classes and unit overrides the mapping never covered.
 
 ### Bugfixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,7 +31,7 @@ nav_order: 2
 - `Sensor`, `NumericValue` and `ExposeSensor` take `value_type` as their first argument after `xknx`, before `name`, and require it - like `payload_length` of `RawValue` above. `Sensor(xknx, "Name", value_type="temperature")` becomes `Sensor(xknx, "temperature", "Name")`. `value_type` never had a usable default: passing `None` raised `ConversionError`. `Notification` keeps its optional `value_type`, now defaulting to `"string"` instead of `None`.
 - `RemoteValueSensor`, `RemoteValueNumeric` and `RemoteValueString` take `value_type` as their first argument after `xknx` and require it. `RemoteValueString` no longer defaults to `DPTString`; pass `value_type="string"` explicitly.
 - `Scene.scene_value` is a `RemoteValueSceneControl` (DPT 18.001) instead of a `RemoteValueSceneNumber` (DPT 17.001), so its value carries the learn bit next to the scene number. Telegrams on the wire are unchanged: DPT 18.001 encodes an activation to the same octet DPT 17.001 does, and decodes one back the same way. The device callback is called for received learn telegrams of the devices `scene_number` now, not only for activations - the new `Scene.learn_requested` tells both apart.
-- Remove `ha_device_class` from `DPTBase` subclasses, `RemoteValueSensor`, `RemoteValueByLength`, `Sensor` and `NumericValue`. It mapped DPTs to Home Assistant sensor device classes - a downstream concern that Home Assistants KNX integration maintains itself since it also needs state classes and unit overrides the mapping never covered.
+- Remove `ha_device_class` from `DPTBase` subclasses, `RemoteValueSensor`, `RemoteValueByLength`, `Sensor` and `NumericValue`. Home Assistant shall maintain this itself.
 
 ### Bugfixes
 

--- a/test/devices_tests/numeric_value_test.py
+++ b/test/devices_tests/numeric_value_test.py
@@ -214,8 +214,6 @@ class TestNumericValue:
             destination_address=GroupAddress("1/2/3"),
             payload=GroupValueWrite(DPTArray((0x0C, 0x1A))),
         )
-        # test HomeAssistant device class
-        assert num_value.ha_device_class() == "temperature"
 
     #
     # SYNC

--- a/test/devices_tests/sensor_test.py
+++ b/test/devices_tests/sensor_test.py
@@ -792,8 +792,6 @@ class TestSensor:
         assert sensor.sensor_value.value == 16.96
         assert sensor.sensor_value.telegram.payload.value == DPTArray((0x06, 0xA0))
         assert sensor.resolve_state() == 16.96
-        # test HomeAssistant device class
-        assert sensor.ha_device_class() == "temperature"
 
     async def test_process_callback(self) -> None:
         """Test process / reading telegrams from telegram queue. Test if callback is called."""

--- a/test/devices_tests/weather_test.py
+++ b/test/devices_tests/weather_test.py
@@ -30,7 +30,6 @@ class TestWeather:
         assert weather.has_group_address(GroupAddress("1/3/4"))
         assert weather.temperature == 21.28
         assert weather._temperature.unit_of_measurement == "°C"
-        assert weather._temperature.ha_device_class == "temperature"
 
     async def test_brightness(self) -> None:
         """Test resolve state for brightness east, west and south."""
@@ -75,19 +74,15 @@ class TestWeather:
 
         assert weather.brightness_east == 366346.24
         assert weather._brightness_east.unit_of_measurement == "lx"
-        assert weather._brightness_east.ha_device_class == "illuminance"
 
         assert weather.brightness_west == 365690.88
         assert weather._brightness_west.unit_of_measurement == "lx"
-        assert weather._brightness_west.ha_device_class == "illuminance"
 
         assert weather.brightness_south == 365035.52
         assert weather._brightness_south.unit_of_measurement == "lx"
-        assert weather._brightness_south.ha_device_class == "illuminance"
 
         assert weather.brightness_north == 365035.52
         assert weather._brightness_north.unit_of_measurement == "lx"
-        assert weather._brightness_north.ha_device_class == "illuminance"
 
     @pytest.mark.parametrize(
         ("value", "payload"),
@@ -110,7 +105,6 @@ class TestWeather:
 
         assert weather.air_pressure == value
         assert weather._air_pressure.unit_of_measurement == "Pa"
-        assert weather._air_pressure.ha_device_class == "pressure"
 
     async def test_humidity(self) -> None:
         """Test humidity telegram."""
@@ -126,7 +120,6 @@ class TestWeather:
 
         assert weather.humidity == 55.8
         assert weather._humidity.unit_of_measurement == "%"
-        assert weather._humidity.ha_device_class == "humidity"
 
     async def test_wind_speed(self) -> None:
         """Test wind speed received."""
@@ -144,7 +137,6 @@ class TestWeather:
 
         assert weather.wind_speed == 469237.76
         assert weather._wind_speed.unit_of_measurement == "m/s"
-        assert weather._wind_speed.ha_device_class == "wind_speed"
 
     async def test_wind_bearing(self) -> None:
         """Test wind bearing received."""
@@ -162,7 +154,6 @@ class TestWeather:
 
         assert weather.wind_bearing == 270
         assert weather._wind_bearing.unit_of_measurement == "°"
-        assert weather._wind_bearing.ha_device_class is None
 
     def test_state_lightning(self) -> None:
         """Test current_state returns lightning if wind alarm and rain alarm are true."""

--- a/xknx/devices/numeric_value.py
+++ b/xknx/devices/numeric_value.py
@@ -87,10 +87,6 @@ class NumericValue(Device):
         """Return the unit of measurement."""
         return self.sensor_value.unit_of_measurement
 
-    def ha_device_class(self) -> str | None:
-        """Return the home assistant device class as string."""
-        return self.sensor_value.ha_device_class
-
     def resolve_state(self) -> float | int | None:
         """Return the current state of the sensor as a human readable string."""
         return self.sensor_value.value

--- a/xknx/devices/sensor.py
+++ b/xknx/devices/sensor.py
@@ -79,10 +79,6 @@ class Sensor(Device):
         """Return the unit of measurement."""
         return self.sensor_value.unit_of_measurement
 
-    def ha_device_class(self) -> str | None:
-        """Return the home assistant device class as string."""
-        return self.sensor_value.ha_device_class
-
     def resolve_state(self) -> Any | None:
         """Return the current state of the sensor as a human readable string."""
         return self.sensor_value.value

--- a/xknx/dpt/dpt.py
+++ b/xknx/dpt/dpt.py
@@ -75,7 +75,6 @@ class DPTBase(ABC):
     dpt_sub_number: int | None = None
     value_type: str | None = None
     unit: str | None = None
-    ha_device_class: str | None = None
 
     @classmethod
     def dpt_number_str(cls) -> str:

--- a/xknx/dpt/dpt_13.py
+++ b/xknx/dpt/dpt_13.py
@@ -49,7 +49,6 @@ class DPTActiveEnergy(DPT4ByteSigned):
     dpt_sub_number = 10
     value_type = "active_energy"
     unit = "Wh"
-    ha_device_class = "energy"
 
 
 class DPTApparantEnergy(DPT4ByteSigned):
@@ -77,7 +76,6 @@ class DPTActiveEnergykWh(DPT4ByteSigned):
     dpt_sub_number = 13
     value_type = "active_energy_kwh"
     unit = "kWh"
-    ha_device_class = "energy"
 
 
 class DPTApparantEnergykVAh(DPT4ByteSigned):

--- a/xknx/dpt/dpt_14.py
+++ b/xknx/dpt/dpt_14.py
@@ -243,7 +243,6 @@ class DPTElectricCurrent(DPT4ByteFloat):
     dpt_sub_number = 19
     value_type = "electric_current"
     unit = "A"
-    ha_device_class = "current"
 
 
 class DPTElectricCurrentDensity(DPT4ByteFloat):
@@ -370,7 +369,6 @@ class DPTFrequency(DPT4ByteFloat):
     dpt_sub_number = 33
     value_type = "frequency"
     unit = "Hz"
-    ha_device_class = "frequency"
 
 
 class DPTAngularFrequency(DPT4ByteFloat):
@@ -425,7 +423,6 @@ class DPTLength(DPT4ByteFloat):
     dpt_sub_number = 39
     value_type = "length"
     unit = "m"
-    ha_device_class = "distance"
 
 
 class DPTLightQuantity(DPT4ByteFloat):
@@ -534,7 +531,6 @@ class DPTMass(DPT4ByteFloat):
     dpt_sub_number = 51
     value_type = "mass"
     unit = "kg"
-    ha_device_class = "weight"
 
 
 class DPTMassFlux(DPT4ByteFloat):
@@ -580,7 +576,6 @@ class DPTPower(DPT4ByteFloat):
     dpt_sub_number = 56
     value_type = "power"
     unit = "W"
-    ha_device_class = "power"
 
 
 class DPTPowerFactor(DPT4ByteFloat):
@@ -589,7 +584,6 @@ class DPTPowerFactor(DPT4ByteFloat):
     dpt_main_number = 14
     dpt_sub_number = 57
     value_type = "powerfactor"
-    ha_device_class = "power_factor"
 
 
 class DPTPressure(DPT4ByteFloat):
@@ -599,7 +593,6 @@ class DPTPressure(DPT4ByteFloat):
     dpt_sub_number = 58
     value_type = "pressure"
     unit = "Pa"
-    ha_device_class = "pressure"
 
 
 class DPTReactance(DPT4ByteFloat):
@@ -663,7 +656,6 @@ class DPTSpeed(DPT4ByteFloat):
     dpt_sub_number = 65
     value_type = "speed"
     unit = "m/s"
-    ha_device_class = "speed"
 
 
 class DPTStress(DPT4ByteFloat):
@@ -799,7 +791,6 @@ class DPTApparentPower(DPT4ByteFloat):
     dpt_sub_number = 80
     value_type = "apparent_power"
     unit = "VA"
-    ha_device_class = "apparent_power"
 
 
 class DPTVolumeFluxMeter(DPT4ByteFloat):

--- a/xknx/dpt/dpt_29.py
+++ b/xknx/dpt/dpt_29.py
@@ -31,7 +31,6 @@ class DPTActiveEnergy8Byte(DPT8ByteSigned):
     dpt_sub_number = 10
     value_type = "active_energy_8byte"
     unit = "Wh"
-    ha_device_class = "energy"
 
 
 class DPTApparantEnergy8Byte(DPT8ByteSigned):

--- a/xknx/dpt/dpt_7.py
+++ b/xknx/dpt/dpt_7.py
@@ -131,7 +131,6 @@ class DPTLengthMm(DPT2ByteUnsigned):
     dpt_sub_number = 11
     value_type = "length_mm"
     unit = "mm"
-    ha_device_class = "distance"
 
 
 class DPTUElCurrentmA(DPT2ByteUnsigned):
@@ -141,7 +140,6 @@ class DPTUElCurrentmA(DPT2ByteUnsigned):
     dpt_sub_number = 12
     value_type = "current"
     unit = "mA"
-    ha_device_class = "current"
 
 
 class DPTBrightness(DPT2ByteUnsigned):
@@ -151,7 +149,6 @@ class DPTBrightness(DPT2ByteUnsigned):
     dpt_sub_number = 13
     value_type = "brightness"
     unit = "lx"
-    ha_device_class = "illuminance"
 
 
 class DPTColorTemperature(DPT2ByteUnsigned):

--- a/xknx/dpt/dpt_8.py
+++ b/xknx/dpt/dpt_8.py
@@ -149,4 +149,3 @@ class DPTLengthM(DPT2ByteSigned):
     dpt_sub_number = 12
     value_type = "length_m"
     unit = "m"
-    ha_device_class = "distance"

--- a/xknx/dpt/dpt_9.py
+++ b/xknx/dpt/dpt_9.py
@@ -93,7 +93,6 @@ class DPTTemperature(DPT2ByteFloat):
     dpt_sub_number = 1
     value_type = "temperature"
     unit = "°C"
-    ha_device_class = "temperature"
 
     value_min = -273
     value_max = 670760
@@ -106,7 +105,6 @@ class DPTTemperatureDifference2Byte(DPT2ByteFloat):
     dpt_sub_number = 2
     value_type = "temperature_difference_2byte"
     unit = "K"
-    ha_device_class = "temperature"
 
     value_min = -670760
     value_max = 670760
@@ -131,7 +129,6 @@ class DPTLux(DPT2ByteFloat):
     dpt_sub_number = 4
     value_type = "illuminance"
     unit = "lx"
-    ha_device_class = "illuminance"
 
     value_min = 0
     value_max = 670760
@@ -144,7 +141,6 @@ class DPTWsp(DPT2ByteFloat):
     dpt_sub_number = 5
     value_type = "wind_speed_ms"
     unit = "m/s"
-    ha_device_class = "wind_speed"
 
     value_min = 0
     value_max = 670760
@@ -157,7 +153,6 @@ class DPTPressure2Byte(DPT2ByteFloat):
     dpt_sub_number = 6
     value_type = "pressure_2byte"
     unit = "Pa"
-    ha_device_class = "pressure"
 
     value_min = 0
     value_max = 670760
@@ -170,7 +165,6 @@ class DPTHumidity(DPT2ByteFloat):
     dpt_sub_number = 7
     value_type = "humidity"
     unit = "%"
-    ha_device_class = "humidity"
 
     value_min = 0
     value_max = 670760
@@ -225,7 +219,6 @@ class DPTVoltage(DPT2ByteFloat):
     dpt_sub_number = 20
     value_type = "voltage"
     unit = "mV"
-    ha_device_class = "voltage"
 
 
 class DPTCurrent(DPT2ByteFloat):
@@ -235,7 +228,6 @@ class DPTCurrent(DPT2ByteFloat):
     dpt_sub_number = 21
     value_type = "curr"
     unit = "mA"
-    ha_device_class = "current"
 
 
 class DPTPowerDensity(DPT2ByteFloat):
@@ -263,7 +255,6 @@ class DPTPower2Byte(DPT2ByteFloat):
     dpt_sub_number = 24
     value_type = "power_2byte"
     unit = "kW"
-    ha_device_class = "power"
 
 
 class DPTVolumeFlow(DPT2ByteFloat):
@@ -294,7 +285,6 @@ class DPTTemperatureF(DPT2ByteFloat):
     dpt_sub_number = 27
     value_type = "temperature_f"
     unit = "°F"
-    ha_device_class = "temperature"
 
     value_min = -459.6
     value_max = 670760
@@ -307,7 +297,6 @@ class DPTWspKmh(DPT2ByteFloat):
     dpt_sub_number = 28
     value_type = "wind_speed_kmh"
     unit = "km/h"
-    ha_device_class = "wind_speed"
 
     value_min = 0
     value_max = 670760

--- a/xknx/remote_value/remote_value_by_length.py
+++ b/xknx/remote_value/remote_value_by_length.py
@@ -81,13 +81,6 @@ class RemoteValueByLength(RemoteValue[float]):
             return None
         return self._internal_dpt_class.unit
 
-    @property
-    def ha_device_class(self) -> str | None:
-        """Return a string representing the home assistant device class."""
-        if not self._internal_dpt_class:
-            return None
-        return getattr(self._internal_dpt_class, "ha_device_class", None)
-
     def _determine_dpt_class(self, payload: DPTArray | DPTBinary) -> type[DPTNumeric]:
         """Test if telegram payload may be parsed."""
         if isinstance(payload, DPTArray):

--- a/xknx/remote_value/remote_value_sensor.py
+++ b/xknx/remote_value/remote_value_sensor.py
@@ -64,11 +64,6 @@ class _RemoteValueGeneric(RemoteValue[ValueT]):
         """Return the unit of measurement."""
         return self.dpt_class.unit
 
-    @property
-    def ha_device_class(self) -> str | None:
-        """Return a string representing the home assistant device class."""
-        return getattr(self.dpt_class, "ha_device_class", None)
-
 
 class RemoteValueSensor(_RemoteValueGeneric[int | float | str]):
     """Abstraction for sensor DPT types."""


### PR DESCRIPTION
`ha_device_class` mapped DPT classes to Home Assistant sensor device classes. Home Assistant's KNX integration doesn't read it anymore — it builds its own DPT table in `homeassistant/components/knx/dpt.py`, keyed on the DPT number string, because it also needs sensor state classes and unit overrides that this attribute never covered. A grep over the integration finds zero references.

Removed from:

- `DPTBase.ha_device_class` and the 27 subclasses declaring one (DPT 7, 8, 9, 13, 14, 29)
- `RemoteValueSensor.ha_device_class` / `RemoteValueByLength.ha_device_class`
- `Sensor.ha_device_class()` / `NumericValue.ha_device_class()`

`unit` / `unit_of_measurement` stays — HA still reads `dpt_class.unit`.

Breaking change, changelog entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)