### PR TITLE
fix: correct address filter range syntax in telegram monitor example

### DIFF
--- a/examples/example_telegram_monitor.py
+++ b/examples/example_telegram_monitor.py
@@ -25,7 +25,7 @@ def show_help() -> None:
     print("Option           Argument example")
     print("-i --ia          1.0.253                 Individual address to connect to")
     print(
-        "-f --filter      1/2/*,1/4/[5-6]         Filter for specific group addresses"
+        "-f --filter      1/2/*,1/4/5-6           Filter for specific group addresses"
     )
     print(
         "-k --knxproject  myproject.knxproj       Load KNX project file for address resolution"
@@ -33,8 +33,8 @@ def show_help() -> None:
     print("-h --help                                Print help")
     print()
     print("Example:")
-    print('python example_telegram_monitor.py -i "1.0.253" -f 1/2/*,1/4/[5-6]')
-    print("This will listen to all telegrams for group addresses 1/2/* and 1/4/[5-6].")
+    print('python example_telegram_monitor.py -i "1.0.253" -f 1/2/*,1/4/5-6')
+    print("This will listen to all telegrams for group addresses 1/2/* and 1/4/5-6.")
 
 
 def load_project(file_path: str) -> KNXProject:


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

`AddressFilter` parses ranges as '1/4/5-6' - the bracketed '1/4/[5-6]' form shown in the example's help text raises `ValueError`.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [ ] The documentation has been adjusted accordingly
- [ ] Tests have been added that prove the fix is effective or that the feature works
- [ ] The changes are documented in the changelog (docs/changelog.md)