### PR TITLE
feat: add command line interface

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ nav_order: 2
 
 # Unreleased changes
 
+### New Features
+
+- Add a command line interface. Installing xknx puts an `xknx` command on the path (also available via `python -m xknx`) providing `scan`, `group read`, `group write` and `group monitor` commands. See `xknx --help`.
+
 ### Breaking changes
 
 - Rename `xknx.management.management.MANAGAMENT_ACK_TIMEOUT` and `MANAGAMENT_CONNECTION_TIMEOUT` to `MANAGEMENT_ACK_TIMEOUT` and `MANAGEMENT_CONNECTION_TIMEOUT` - they were misspelled.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ requires-python = ">=3.11.0"
 homepage = "https://xknx.io/"
 repository = "https://github.com/XKNX/xknx.git"
 
+[project.scripts]
+xknx = "xknx.cli:main"
+
 
 [dependency-groups]
 dev = [
@@ -170,6 +173,7 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 "examples/*" = ["T20"] # print-used
+"xknx/cli/*" = ["T20"] # print-used - CLI output
 "test/*" = [
   "RUF012",
   "SLF",    # private member access

--- a/test/cli_tests/__init__.py
+++ b/test/cli_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the xknx command line interface."""

--- a/test/cli_tests/cli_test.py
+++ b/test/cli_tests/cli_test.py
@@ -224,45 +224,84 @@ def test_internal_or_invalid_group_address(
     assert "Error:" in capsys.readouterr().err
 
 
-def test_scan(capsys: pytest.CaptureFixture[str]) -> None:
-    """Test the scan command prints found gateways."""
-    gateway = GatewayDescriptor(
-        ip_addr="10.0.0.1",
-        port=3671,
-        name="TestGateway",
-        individual_address=IndividualAddress("1.0.0"),
-        supports_tunnelling=True,
-    )
+TEST_GATEWAY = GatewayDescriptor(
+    ip_addr="10.0.0.1",
+    port=3671,
+    name="TestGateway",
+    individual_address=IndividualAddress("1.0.0"),
+    supports_tunnelling=True,
+)
 
-    async def _scan(
-        *, stop_on_found: int | None = None
-    ) -> AsyncIterator[GatewayDescriptor]:
-        yield gateway
+
+def _scanner_mock(
+    gateways: list[GatewayDescriptor], error: Exception | None = None
+) -> Mock:
+    """Create a GatewayScanner mock yielding the given gateways."""
+
+    async def _scan() -> AsyncIterator[GatewayDescriptor]:
+        if error is not None:
+            raise error
+        for gateway in gateways:
+            yield gateway
 
     scanner_mock = Mock()
     scanner_mock.async_scan = _scan
-    scanner_mock.found_gateways = {"hpai": gateway}
-    with patch("xknx.cli.scan.GatewayScanner", return_value=scanner_mock):
-        assert main(["-v", "scan", "--timeout", "1"]) == 0
+    return scanner_mock
+
+
+def test_scan(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the scan command with an explicit local IP prints found gateways."""
+    with patch(
+        "xknx.cli.scan.GatewayScanner", return_value=_scanner_mock([TEST_GATEWAY])
+    ) as scanner_cls:
+        assert main(["--local-ip", "10.0.0.2", "scan", "--timeout", "1"]) == 0
+    assert scanner_cls.call_args.kwargs["local_ip"] == "10.0.0.2"
+    assert scanner_cls.call_args.kwargs["timeout_in_seconds"] == 1.0
     out = capsys.readouterr().out
     assert "TestGateway" in out
     assert "1.0.0 10.0.0.1:3671" in out
     assert "tunnelling: UDP" in out
 
 
+def test_scan_local_ip_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test scan errors are raised when an explicit local IP was given."""
+    with patch(
+        "xknx.cli.scan.GatewayScanner",
+        return_value=_scanner_mock([], error=CommunicationError("bind failed")),
+    ):
+        assert main(["--local-ip", "10.0.0.2", "scan"]) == 1
+    assert "Error: bind failed" in capsys.readouterr().err
+
+
+def test_scan_all_interfaces(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the scan command scans all non-loopback interfaces by default."""
+    local_ips = [
+        Mock(ip="10.0.0.2"),
+        Mock(ip="127.0.0.1"),  # loopback is skipped
+        Mock(ip="192.168.0.2"),
+        Mock(ip="172.20.0.2"),
+    ]
+    scanners = [
+        _scanner_mock([], error=CommunicationError("bind failed")),  # ignored
+        _scanner_mock([TEST_GATEWAY]),
+        _scanner_mock([TEST_GATEWAY]),  # same gateway heard on another interface
+    ]
+    with (
+        patch("xknx.cli.scan.get_local_ips", return_value=local_ips),
+        patch("xknx.cli.scan.GatewayScanner", side_effect=scanners) as scanner_cls,
+    ):
+        assert main(["-v", "scan"]) == 0
+    assert scanner_cls.call_count == 3
+    out = capsys.readouterr().out
+    assert out.count("TestGateway") == 1  # deduplicated
+
+
 def test_scan_no_gateways(capsys: pytest.CaptureFixture[str]) -> None:
     """Test the scan command without results."""
-
-    async def _scan(
-        *, stop_on_found: int | None = None
-    ) -> AsyncIterator[GatewayDescriptor]:
-        return
-        yield
-
-    scanner_mock = Mock()
-    scanner_mock.async_scan = _scan
-    scanner_mock.found_gateways = {}
-    with patch("xknx.cli.scan.GatewayScanner", return_value=scanner_mock):
+    with (
+        patch("xknx.cli.scan.get_local_ips", return_value=[Mock(ip="10.0.0.2")]),
+        patch("xknx.cli.scan.GatewayScanner", return_value=_scanner_mock([])),
+    ):
         assert main(["-vv", "scan"]) == 0
     assert "No gateways found." in capsys.readouterr().out
 

--- a/test/cli_tests/cli_test.py
+++ b/test/cli_tests/cli_test.py
@@ -1,0 +1,313 @@
+"""Test the xknx command line interface."""
+
+import argparse
+from collections.abc import AsyncIterator
+import runpy
+import sys
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from xknx.cli import main
+from xknx.cli._command import Command, connection_config, gateway_argument
+from xknx.cli.group._base import GroupCommand
+from xknx.cli.group.monitor import print_telegram
+from xknx.cli.group.write import parse_raw_value
+from xknx.dpt import DPTBinary
+from xknx.exceptions import CommunicationError
+from xknx.io import DEFAULT_MCAST_PORT, ConnectionType, GatewayDescriptor
+from xknx.telegram import GroupAddress, IndividualAddress, Telegram, TelegramDirection
+from xknx.telegram.apci import GroupValueRead, GroupValueWrite
+
+
+def _interface_mock() -> Mock:
+    """Create a KNX/IP interface mock."""
+    mock = Mock()
+    mock.start = AsyncMock()
+    mock.stop = AsyncMock()
+    mock.send_cemi = AsyncMock()
+    return mock
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("on", True),
+        ("True", True),
+        ("off", False),
+        ("FALSE", False),
+        ("50", 50),
+        ("21.5", 21.5),
+        ("something", "something"),
+    ],
+)
+def test_parse_raw_value(raw: str, expected: bool | int | float | str) -> None:
+    """Test parsing raw command line values."""
+    result = parse_raw_value(raw)
+    assert result == expected
+    assert type(result) is type(expected)
+
+
+def test_command_discovery() -> None:
+    """Test the command tree is built from direct subclasses."""
+    top_level = {
+        command.name: bool(command.subcommands()) for command in Command.subcommands()
+    }
+    assert top_level == {"scan": False, "group": True}
+    group_commands = {command.name for command in GroupCommand.subcommands()}
+    assert group_commands == {"read", "write", "monitor"}
+
+
+def test_connection_config_automatic() -> None:
+    """Test connection config without a gateway option."""
+    args = argparse.Namespace(gateway=None, local_ip=None)
+    config = connection_config(args)
+    assert config.connection_type is ConnectionType.AUTOMATIC
+    assert config.local_ip is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("10.0.0.1", ("10.0.0.1", DEFAULT_MCAST_PORT)),
+        ("10.0.0.1:1234", ("10.0.0.1", 1234)),
+        ("[2001:db8::1]", ("2001:db8::1", DEFAULT_MCAST_PORT)),
+        ("[2001:db8::1]:3671", ("2001:db8::1", 3671)),
+    ],
+)
+def test_gateway_argument(raw: str, expected: tuple[str, int]) -> None:
+    """Test parsing valid gateway arguments."""
+    assert gateway_argument(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        ":3671",  # missing host
+        "10.0.0.1:0",  # port out of range
+        "10.0.0.1:65536",  # port out of range
+        "10.0.0.1:notaport",  # invalid port
+        "2001:db8::1",  # unbracketed IPv6 mis-splits into an invalid port
+    ],
+)
+def test_gateway_argument_invalid(raw: str) -> None:
+    """Test invalid gateway arguments are rejected."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        gateway_argument(raw)
+
+
+def test_connection_config_tunneling() -> None:
+    """Test connection config with a gateway option."""
+    args = argparse.Namespace(gateway=("10.0.0.1", 1234), local_ip="10.0.0.2")
+    config = connection_config(args)
+    assert config.connection_type is ConnectionType.TUNNELING
+    assert config.gateway_ip == "10.0.0.1"
+    assert config.gateway_port == 1234
+    assert config.local_ip == "10.0.0.2"
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],  # missing subcommand
+        ["group"],  # missing group subcommand
+        ["group", "read"],  # missing group address
+        ["group", "unknown"],  # unknown group subcommand
+        ["group", "write", "1/2/3"],  # missing value
+        ["unknown"],  # unknown subcommand
+        ["--gateway", ":3671", "scan"],  # invalid gateway
+        ["--gateway", "10.0.0.1:99999", "group", "read", "1/2/3"],  # port out of range
+    ],
+)
+def test_parser_errors(argv: list[str]) -> None:
+    """Test invalid command lines exit with an argparse error."""
+    with pytest.raises(SystemExit):
+        main(argv)
+
+
+def test_read(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the read command prints the received value."""
+    read_mock = AsyncMock(return_value=21.5)
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch("xknx.cli.group.read.read_group_value", read_mock),
+    ):
+        assert main(["group", "read", "1/2/3", "--type", "temperature"]) == 0
+    assert read_mock.call_args.args[1] == "1/2/3"
+    assert read_mock.call_args.kwargs["value_type"] == "temperature"
+    assert capsys.readouterr().out == "21.5\n"
+
+
+def test_read_no_response(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the read command without a response."""
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch("xknx.cli.group.read.read_group_value", AsyncMock(return_value=None)),
+    ):
+        assert main(["group", "read", "1/2/3"]) == 1
+    assert "No response received." in capsys.readouterr().err
+
+
+def test_write() -> None:
+    """Test the write command."""
+    write_mock = Mock()
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch("xknx.cli.group.write.group_value_write", write_mock),
+    ):
+        assert main(["--gateway", "10.0.0.1", "group", "write", "1/2/3", "on"]) == 0
+    assert write_mock.call_args.args[1:] == ("1/2/3", True)
+    assert write_mock.call_args.kwargs["value_type"] is None
+
+
+def test_write_with_type_passes_raw_string() -> None:
+    """Test the write command passes the raw string to the DPT transcoder."""
+    write_mock = Mock()
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch("xknx.cli.group.write.group_value_write", write_mock),
+    ):
+        assert main(["group", "write", "1/2/3", "on", "--type", "switch"]) == 0
+    assert write_mock.call_args.args[1:] == ("1/2/3", "on")
+    assert write_mock.call_args.kwargs["value_type"] == "switch"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "21.5",  # float requires a transcoder
+        "something",  # string requires a transcoder
+        "100",  # out of DPTBinary range
+        "-1",  # out of DPTBinary range
+    ],
+)
+def test_write_requires_type(value: str, capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the write command rejects values without --type before connecting."""
+    assert main(["group", "write", "1/2/3", value]) == 1
+    assert "--type is required" in capsys.readouterr().err
+
+
+def test_write_invalid_type(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the write command rejects an unknown DPT type before connecting."""
+    assert main(["group", "write", "1/2/3", "1", "--type", "unknown"]) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+def test_read_invalid_type(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the read command rejects an unknown DPT type before connecting."""
+    assert main(["group", "read", "1/2/3", "--type", "unknown"]) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+def test_scan(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the scan command prints found gateways."""
+    gateway = GatewayDescriptor(
+        ip_addr="10.0.0.1",
+        port=3671,
+        name="TestGateway",
+        individual_address=IndividualAddress("1.0.0"),
+        supports_tunnelling=True,
+    )
+
+    async def _scan(
+        *, stop_on_found: int | None = None
+    ) -> AsyncIterator[GatewayDescriptor]:
+        yield gateway
+
+    scanner_mock = Mock()
+    scanner_mock.async_scan = _scan
+    scanner_mock.found_gateways = {"hpai": gateway}
+    with patch("xknx.cli.scan.GatewayScanner", return_value=scanner_mock):
+        assert main(["-v", "scan", "--timeout", "1"]) == 0
+    out = capsys.readouterr().out
+    assert "TestGateway" in out
+    assert "1.0.0 10.0.0.1:3671" in out
+    assert "tunnelling: UDP" in out
+
+
+def test_scan_no_gateways(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the scan command without results."""
+
+    async def _scan(
+        *, stop_on_found: int | None = None
+    ) -> AsyncIterator[GatewayDescriptor]:
+        return
+        yield
+
+    scanner_mock = Mock()
+    scanner_mock.async_scan = _scan
+    scanner_mock.found_gateways = {}
+    with patch("xknx.cli.scan.GatewayScanner", return_value=scanner_mock):
+        assert main(["-vv", "scan"]) == 0
+    assert "No gateways found." in capsys.readouterr().out
+
+
+def test_monitor() -> None:
+    """Test the monitor command runs until interrupted."""
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch("xknx.xknx.XKNX.loop_until_sigint", AsyncMock()) as loop_mock,
+    ):
+        assert main(["group", "monitor", "--filter", "1/2/*,1/4/5-6"]) == 0
+    loop_mock.assert_called_once()
+
+
+def test_keyboard_interrupt_exit_code() -> None:
+    """Test an interrupted command exits with 130."""
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch(
+            "xknx.cli.group.read.read_group_value",
+            AsyncMock(side_effect=KeyboardInterrupt),
+        ),
+    ):
+        assert main(["group", "read", "1/2/3"]) == 130
+
+
+def test_scan_rejects_gateway(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the scan command rejects the --gateway option."""
+    assert main(["--gateway", "10.0.0.1", "scan"]) == 2
+    assert "--gateway is not applicable" in capsys.readouterr().err
+
+
+def test_print_telegram(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test printing received telegrams."""
+    telegram = Telegram(
+        destination_address=GroupAddress("1/2/3"),
+        direction=TelegramDirection.INCOMING,
+        payload=GroupValueWrite(DPTBinary(1)),
+    )
+    print_telegram(telegram)
+    out = capsys.readouterr().out
+    assert "1/2/3" in out
+    assert "| 1" in out
+
+    read_telegram = Telegram(
+        destination_address=GroupAddress("1/2/3"),
+        direction=TelegramDirection.INCOMING,
+        payload=GroupValueRead(),
+    )
+    print_telegram(read_telegram)
+    assert "GroupValueRead" in capsys.readouterr().out
+
+
+def test_communication_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test XKNX exceptions are reported with exit code 1."""
+    with (
+        patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
+        patch(
+            "xknx.cli.group.read.read_group_value",
+            AsyncMock(side_effect=CommunicationError("boom")),
+        ),
+    ):
+        assert main(["group", "read", "1/2/3"]) == 1
+    assert "Error: boom" in capsys.readouterr().err
+
+
+def test_main_module() -> None:
+    """Test `python -m xknx --help`."""
+    with (
+        patch.object(sys, "argv", ["xknx", "--help"]),
+        pytest.raises(SystemExit),
+    ):
+        runpy.run_module("xknx", run_name="__main__")

--- a/test/cli_tests/cli_test.py
+++ b/test/cli_tests/cli_test.py
@@ -13,7 +13,7 @@ from xknx.cli._command import Command, connection_config, gateway_argument
 from xknx.cli.group._base import GroupCommand
 from xknx.cli.group.monitor import print_telegram
 from xknx.cli.group.write import parse_raw_value
-from xknx.dpt import DPTBinary
+from xknx.dpt import DPTBinary, DPTSwitch, DPTTemperature
 from xknx.exceptions import CommunicationError
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionType, GatewayDescriptor
 from xknx.telegram import GroupAddress, IndividualAddress, Telegram, TelegramDirection
@@ -71,8 +71,7 @@ def test_connection_config_automatic() -> None:
     [
         ("10.0.0.1", ("10.0.0.1", DEFAULT_MCAST_PORT)),
         ("10.0.0.1:1234", ("10.0.0.1", 1234)),
-        ("[2001:db8::1]", ("2001:db8::1", DEFAULT_MCAST_PORT)),
-        ("[2001:db8::1]:3671", ("2001:db8::1", 3671)),
+        ("gateway.example", ("gateway.example", DEFAULT_MCAST_PORT)),
     ],
 )
 def test_gateway_argument(raw: str, expected: tuple[str, int]) -> None:
@@ -87,7 +86,11 @@ def test_gateway_argument(raw: str, expected: tuple[str, int]) -> None:
         "10.0.0.1:0",  # port out of range
         "10.0.0.1:65536",  # port out of range
         "10.0.0.1:notaport",  # invalid port
-        "2001:db8::1",  # unbracketed IPv6 mis-splits into an invalid port
+        "2001:db8::1",  # IPv6 is not supported by the KNX/IP interface
+        "[2001:db8::1]:3671",  # IPv6 is not supported by the KNX/IP interface
+        "gateway.example/path",  # not plain 'host[:port]'
+        "user@gateway.example",  # not plain 'host[:port]'
+        "gateway.example?x=1",  # not plain 'host[:port]'
     ],
 )
 def test_gateway_argument_invalid(raw: str) -> None:
@@ -133,8 +136,8 @@ def test_read(capsys: pytest.CaptureFixture[str]) -> None:
         patch("xknx.cli.group.read.read_group_value", read_mock),
     ):
         assert main(["group", "read", "1/2/3", "--type", "temperature"]) == 0
-    assert read_mock.call_args.args[1] == "1/2/3"
-    assert read_mock.call_args.kwargs["value_type"] == "temperature"
+    assert read_mock.call_args.args[1] == GroupAddress("1/2/3")
+    assert read_mock.call_args.kwargs["value_type"] is DPTTemperature
     assert capsys.readouterr().out == "21.5\n"
 
 
@@ -156,20 +159,20 @@ def test_write() -> None:
         patch("xknx.cli.group.write.group_value_write", write_mock),
     ):
         assert main(["--gateway", "10.0.0.1", "group", "write", "1/2/3", "on"]) == 0
-    assert write_mock.call_args.args[1:] == ("1/2/3", True)
+    assert write_mock.call_args.args[1:] == (GroupAddress("1/2/3"), True)
     assert write_mock.call_args.kwargs["value_type"] is None
 
 
-def test_write_with_type_passes_raw_string() -> None:
-    """Test the write command passes the raw string to the DPT transcoder."""
+def test_write_with_type_converts_value() -> None:
+    """Test the write command converts the value with the DPT transcoder."""
     write_mock = Mock()
     with (
         patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
         patch("xknx.cli.group.write.group_value_write", write_mock),
     ):
         assert main(["group", "write", "1/2/3", "on", "--type", "switch"]) == 0
-    assert write_mock.call_args.args[1:] == ("1/2/3", "on")
-    assert write_mock.call_args.kwargs["value_type"] == "switch"
+    assert write_mock.call_args.args[1:] == (GroupAddress("1/2/3"), DPTBinary(True))
+    assert write_mock.call_args.kwargs["value_type"] is DPTSwitch
 
 
 @pytest.mark.parametrize(
@@ -196,6 +199,28 @@ def test_write_invalid_type(capsys: pytest.CaptureFixture[str]) -> None:
 def test_read_invalid_type(capsys: pytest.CaptureFixture[str]) -> None:
     """Test the read command rejects an unknown DPT type before connecting."""
     assert main(["group", "read", "1/2/3", "--type", "unknown"]) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+def test_write_invalid_value_for_type(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test the write command rejects an unconvertible value before connecting."""
+    assert main(["group", "write", "1/2/3", "nope", "--type", "temperature"]) == 1
+    assert "Error:" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["group", "read", "i-test"],  # internal group address
+        ["group", "write", "i-test", "on"],  # internal group address
+        ["group", "read", "99/9/9"],  # invalid group address
+    ],
+)
+def test_internal_or_invalid_group_address(
+    argv: list[str], capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Test commands reject internal or invalid group addresses before connecting."""
+    assert main(argv) == 1
     assert "Error:" in capsys.readouterr().err
 
 
@@ -248,7 +273,10 @@ def test_monitor() -> None:
         patch("xknx.xknx.knx_interface_factory", return_value=_interface_mock()),
         patch("xknx.xknx.XKNX.loop_until_sigint", AsyncMock()) as loop_mock,
     ):
-        assert main(["group", "monitor", "--filter", "1/2/*,1/4/5-6"]) == 0
+        assert (
+            main(["group", "monitor", "--filter", "1/2/*", "--filter", "1/4/5-6,8"])
+            == 0
+        )
     loop_mock.assert_called_once()
 
 

--- a/test/cli_tests/cli_test.py
+++ b/test/cli_tests/cli_test.py
@@ -20,6 +20,13 @@ from xknx.telegram import GroupAddress, IndividualAddress, Telegram, TelegramDir
 from xknx.telegram.apci import GroupValueRead, GroupValueWrite
 
 
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove xknx environment variables."""
+    monkeypatch.delenv("XKNX_GATEWAY", raising=False)
+    monkeypatch.delenv("XKNX_LOCAL_IP", raising=False)
+
+
 def _interface_mock() -> Mock:
     """Create a KNX/IP interface mock."""
     mock = Mock()
@@ -161,6 +168,44 @@ def test_write() -> None:
         assert main(["--gateway", "10.0.0.1", "group", "write", "1/2/3", "on"]) == 0
     assert write_mock.call_args.args[1:] == (GroupAddress("1/2/3"), True)
     assert write_mock.call_args.kwargs["value_type"] is None
+
+
+def test_defaults_from_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test the gateway and local IP default to environment variables."""
+    monkeypatch.setenv("XKNX_GATEWAY", "10.0.0.1:1234")
+    monkeypatch.setenv("XKNX_LOCAL_IP", "10.0.0.2")
+    with (
+        patch(
+            "xknx.xknx.knx_interface_factory", return_value=_interface_mock()
+        ) as factory_mock,
+        patch("xknx.cli.group.write.group_value_write"),
+    ):
+        assert main(["group", "write", "1/2/3", "on"]) == 0
+    config = factory_mock.call_args.kwargs["connection_config"]
+    assert config.connection_type is ConnectionType.TUNNELING
+    assert config.gateway_ip == "10.0.0.1"
+    assert config.gateway_port == 1234
+    assert config.local_ip == "10.0.0.2"
+
+
+def test_argument_overrides_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test an explicit --gateway wins over the environment variable."""
+    monkeypatch.setenv("XKNX_GATEWAY", "10.0.0.1")
+    with (
+        patch(
+            "xknx.xknx.knx_interface_factory", return_value=_interface_mock()
+        ) as factory_mock,
+        patch("xknx.cli.group.write.group_value_write"),
+    ):
+        assert main(["--gateway", "10.0.0.9", "group", "write", "1/2/3", "on"]) == 0
+    assert factory_mock.call_args.kwargs["connection_config"].gateway_ip == "10.0.0.9"
+
+
+def test_invalid_environment_gateway(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test an invalid $XKNX_GATEWAY exits with an argparse error."""
+    monkeypatch.setenv("XKNX_GATEWAY", ":3671")
+    with pytest.raises(SystemExit):
+        main(["group", "read", "1/2/3"])
 
 
 def test_write_with_type_converts_value() -> None:

--- a/xknx/__main__.py
+++ b/xknx/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point for `python -m xknx`."""
+
+import sys
+
+from xknx.cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xknx/cli/__init__.py
+++ b/xknx/cli/__init__.py
@@ -6,6 +6,7 @@ import argparse
 import asyncio
 from collections.abc import Callable, Coroutine, Sequence
 import logging
+import os
 import sys
 from typing import Any
 
@@ -40,9 +41,16 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--gateway",
         type=gateway_argument,
-        help="KNX/IP tunneling gateway as 'host[:port]' (default: automatic discovery)",
+        default=os.environ.get("XKNX_GATEWAY"),
+        help="KNX/IP tunneling gateway as 'host[:port]'"
+        " (default: XKNX_GATEWAY environment variable, or automatic discovery)",
     )
-    parser.add_argument("--local-ip", help="local IP address or interface name to use")
+    parser.add_argument(
+        "--local-ip",
+        default=os.environ.get("XKNX_LOCAL_IP"),
+        help="local IP address or interface name to use"
+        " (default: XKNX_LOCAL_IP environment variable)",
+    )
     subparsers = parser.add_subparsers(
         title="commands",
         metavar="<command>",

--- a/xknx/cli/__init__.py
+++ b/xknx/cli/__init__.py
@@ -1,0 +1,96 @@
+"""Command line interface for xknx."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Callable, Coroutine, Sequence
+import logging
+import sys
+from typing import Any
+
+from xknx.exceptions import XKNXException
+
+from . import group, scan
+from ._command import Command, gateway_argument
+
+__all__ = ["group", "main", "scan"]
+
+
+def _add_command(subparsers: Any, command_cls: type[Command]) -> None:
+    """Register a command class with a subparsers action."""
+    command = command_cls()
+    subparser = subparsers.add_parser(command.name, help=command.help_text)
+    command.configure(subparser)
+    subparser.set_defaults(func=command.run)
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Create the xknx argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="xknx", description="Command line interface for xknx."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="increase verbosity (-v: info, -vv: debug)",
+    )
+    parser.add_argument(
+        "--gateway",
+        type=gateway_argument,
+        help="KNX/IP tunneling gateway as 'host[:port]' (default: automatic discovery)",
+    )
+    parser.add_argument("--local-ip", help="local IP address or interface name to use")
+    subparsers = parser.add_subparsers(
+        title="commands",
+        metavar="<command>",
+        dest="command",
+        required=True,
+        help="run 'xknx <command> --help' for command specific options",
+    )
+
+    for command_cls in Command.subcommands():
+        if subcommand_classes := command_cls.subcommands():
+            group_parser = subparsers.add_parser(
+                command_cls.name, help=command_cls.help_text
+            )
+            group_subparsers = group_parser.add_subparsers(
+                title="commands",
+                metavar="<command>",
+                dest="subcommand",
+                required=True,
+                help=f"run 'xknx {command_cls.name} <command> --help'"
+                " for command specific options",
+            )
+            for subcommand_cls in subcommand_classes:
+                _add_command(group_subparsers, subcommand_cls)
+        else:
+            _add_command(subparsers, command_cls)
+
+    return parser
+
+
+def _setup_logging(verbosity: int) -> None:
+    """Configure logging according to the verbosity level."""
+    level = logging.WARNING
+    if verbosity == 1:
+        level = logging.INFO
+    elif verbosity > 1:
+        level = logging.DEBUG
+    logging.basicConfig(level=level)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the xknx command line interface."""
+    args = _parser().parse_args(argv)
+    _setup_logging(args.verbose)
+    handler: Callable[[argparse.Namespace], Coroutine[Any, Any, int]] = args.func
+    try:
+        return asyncio.run(handler(args))
+    except KeyboardInterrupt:
+        return 130  # 128 + SIGINT
+    except (XKNXException, ValueError) as err:
+        print(f"Error: {err}", file=sys.stderr)
+        return 1

--- a/xknx/cli/_command.py
+++ b/xknx/cli/_command.py
@@ -1,0 +1,64 @@
+"""Base class and shared helpers for xknx CLI commands."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import argparse
+from typing import ClassVar
+from urllib.parse import urlsplit
+
+from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
+
+
+def gateway_argument(value: str) -> tuple[str, int]:
+    """Parse and validate a gateway 'host[:port]' command line argument."""
+    try:
+        split = urlsplit(f"//{value}")
+        host = split.hostname
+        port = split.port  # raises ValueError for invalid or out of range ports
+    except ValueError as err:
+        raise argparse.ArgumentTypeError(str(err)) from None
+    if not host:
+        raise argparse.ArgumentTypeError(f"missing host in {value!r}")
+    if port == 0:
+        raise argparse.ArgumentTypeError("port out of range: 0")
+    return host, port if port is not None else DEFAULT_MCAST_PORT
+
+
+def connection_config(args: argparse.Namespace) -> ConnectionConfig:
+    """Build a ConnectionConfig from the global command line options."""
+    if args.gateway is not None:
+        host, port = args.gateway
+        return ConnectionConfig(
+            connection_type=ConnectionType.TUNNELING,
+            gateway_ip=host,
+            gateway_port=port,
+            local_ip=args.local_ip,
+        )
+    return ConnectionConfig(local_ip=args.local_ip)
+
+
+class Command(ABC):
+    """
+    Base class for xknx CLI commands.
+
+    Direct subclasses form the top level of the command line interface.
+    A concrete subclass is a command; an abstract subclass with subclasses
+    of its own is a command group whose members are its direct subclasses
+    (see `xknx.cli.group`).
+    """
+
+    name: ClassVar[str]
+    help_text: ClassVar[str]
+
+    @classmethod
+    def subcommands(cls) -> list[type[Command]]:
+        """Return the directly derived command classes."""
+        return cls.__subclasses__()
+
+    def configure(self, parser: argparse.ArgumentParser) -> None:  # noqa: B027
+        """Add command specific arguments to the parser - optional override."""
+
+    @abstractmethod
+    async def run(self, args: argparse.Namespace) -> int:
+        """Run the command."""

--- a/xknx/cli/_command.py
+++ b/xknx/cli/_command.py
@@ -5,24 +5,29 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import argparse
 from typing import ClassVar
-from urllib.parse import urlsplit
 
 from xknx.io import DEFAULT_MCAST_PORT, ConnectionConfig, ConnectionType
 
 
 def gateway_argument(value: str) -> tuple[str, int]:
     """Parse and validate a gateway 'host[:port]' command line argument."""
-    try:
-        split = urlsplit(f"//{value}")
-        host = split.hostname
-        port = split.port  # raises ValueError for invalid or out of range ports
-    except ValueError as err:
-        raise argparse.ArgumentTypeError(str(err)) from None
+    host, _, port_str = value.partition(":")
+    if "[" in value or ":" in port_str:
+        # the KNX/IP interface resolves IPv4 addresses only
+        raise argparse.ArgumentTypeError("IPv6 gateway addresses are not supported")
+    if any(char in value for char in "/@?#"):
+        raise argparse.ArgumentTypeError(f"expected 'host[:port]', got {value!r}")
     if not host:
         raise argparse.ArgumentTypeError(f"missing host in {value!r}")
-    if port == 0:
-        raise argparse.ArgumentTypeError("port out of range: 0")
-    return host, port if port is not None else DEFAULT_MCAST_PORT
+    port = DEFAULT_MCAST_PORT
+    if port_str:
+        try:
+            port = int(port_str)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"invalid port {port_str!r}") from None
+        if not 1 <= port <= 65535:
+            raise argparse.ArgumentTypeError(f"port out of range: {port}")
+    return host, port
 
 
 def connection_config(args: argparse.Namespace) -> ConnectionConfig:

--- a/xknx/cli/group/__init__.py
+++ b/xknx/cli/group/__init__.py
@@ -1,0 +1,5 @@
+"""Commands for KNX group address communication."""
+
+from . import monitor, read, write
+
+__all__ = ["monitor", "read", "write"]

--- a/xknx/cli/group/_base.py
+++ b/xknx/cli/group/_base.py
@@ -1,0 +1,26 @@
+"""Base class for `xknx group` commands."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+import argparse
+
+from xknx import XKNX
+
+from .._command import Command, connection_config
+
+
+class GroupCommand(Command):
+    """Group address communication over a KNX bus connection."""
+
+    name = "group"
+    help_text = "read, write and monitor group addresses"
+
+    async def run(self, args: argparse.Namespace) -> int:
+        """Connect to the KNX bus and execute the command."""
+        async with XKNX(connection_config=connection_config(args)) as xknx:
+            return await self.execute(xknx, args)
+
+    @abstractmethod
+    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+        """Execute the command on a connected XKNX instance."""

--- a/xknx/cli/group/_base.py
+++ b/xknx/cli/group/_base.py
@@ -17,10 +17,10 @@ class GroupCommand(Command):
     help_text = "read, write and monitor group addresses"
 
     async def run(self, args: argparse.Namespace) -> int:
-        """Connect to the KNX bus and execute the command."""
+        """Connect to the KNX bus and run the command."""
         async with XKNX(connection_config=connection_config(args)) as xknx:
-            return await self.execute(xknx, args)
+            return await self.run_connected(xknx, args)
 
     @abstractmethod
-    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+    async def run_connected(self, xknx: XKNX, args: argparse.Namespace) -> int:
         """Execute the command on a connected XKNX instance."""

--- a/xknx/cli/group/monitor.py
+++ b/xknx/cli/group/monitor.py
@@ -1,0 +1,51 @@
+"""The `xknx group monitor` command."""
+
+from __future__ import annotations
+
+import argparse
+
+from xknx import XKNX
+from xknx.telegram import AddressFilter, Telegram
+from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
+
+from ._base import GroupCommand
+
+
+def print_telegram(telegram: Telegram) -> None:
+    """Print a received telegram."""
+    payload: str | int | tuple[int, ...]
+    if isinstance(telegram.payload, GroupValueWrite | GroupValueResponse):
+        payload = telegram.payload.value.value
+    else:
+        payload = telegram.payload.__class__.__name__
+    print(
+        f"{telegram.direction.value:8} {telegram.source_address!s:20} | "
+        f"{telegram.destination_address!s:24} | {payload}"
+    )
+
+
+class MonitorCommand(GroupCommand):
+    """Print group telegrams from the KNX bus."""
+
+    name = "monitor"
+    help_text = "print group telegrams from the KNX bus"
+
+    def configure(self, parser: argparse.ArgumentParser) -> None:
+        """Add the monitor command arguments."""
+        parser.add_argument(
+            "--filter",
+            help="comma-separated group address patterns, e.g. '1/2/*,1/4/5-6'",
+        )
+
+    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+        """Print telegrams from the KNX bus until interrupted."""
+        address_filters = (
+            [AddressFilter(pattern) for pattern in args.filter.split(",")]
+            if args.filter
+            else None
+        )
+        xknx.telegram_queue.register_telegram_received_cb(
+            print_telegram, address_filters
+        )
+        await xknx.loop_until_sigint()
+        return 0

--- a/xknx/cli/group/monitor.py
+++ b/xknx/cli/group/monitor.py
@@ -41,12 +41,12 @@ class MonitorCommand(GroupCommand):
 
     async def run(self, args: argparse.Namespace) -> int:
         """Parse the address filters before connecting."""
-        # parsed results are passed through to `execute`
+        # parsed results are passed through to `run_connected`
         if args.filter:
             args.filter = [AddressFilter(pattern) for pattern in args.filter]
         return await super().run(args)
 
-    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+    async def run_connected(self, xknx: XKNX, args: argparse.Namespace) -> int:
         """Print telegrams from the KNX bus until interrupted."""
         xknx.telegram_queue.register_telegram_received_cb(print_telegram, args.filter)
         await xknx.loop_until_sigint()

--- a/xknx/cli/group/monitor.py
+++ b/xknx/cli/group/monitor.py
@@ -34,18 +34,20 @@ class MonitorCommand(GroupCommand):
         """Add the monitor command arguments."""
         parser.add_argument(
             "--filter",
-            help="comma-separated group address patterns, e.g. '1/2/*,1/4/5-6'",
+            action="append",
+            help="group address pattern, e.g. '1/2/*' or '1/4/5-6,8';"
+            " repeat the option for multiple filters",
         )
+
+    async def run(self, args: argparse.Namespace) -> int:
+        """Parse the address filters before connecting."""
+        # parsed results are passed through to `execute`
+        if args.filter:
+            args.filter = [AddressFilter(pattern) for pattern in args.filter]
+        return await super().run(args)
 
     async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
         """Print telegrams from the KNX bus until interrupted."""
-        address_filters = (
-            [AddressFilter(pattern) for pattern in args.filter.split(",")]
-            if args.filter
-            else None
-        )
-        xknx.telegram_queue.register_telegram_received_cb(
-            print_telegram, address_filters
-        )
+        xknx.telegram_queue.register_telegram_received_cb(print_telegram, args.filter)
         await xknx.loop_until_sigint()
         return 0

--- a/xknx/cli/group/read.py
+++ b/xknx/cli/group/read.py
@@ -7,6 +7,7 @@ import sys
 
 from xknx import XKNX
 from xknx.dpt import DPTBase
+from xknx.telegram import GroupAddress
 from xknx.tools import read_group_value
 
 from ._base import GroupCommand
@@ -26,9 +27,11 @@ class ReadCommand(GroupCommand):
         )
 
     async def run(self, args: argparse.Namespace) -> int:
-        """Validate the value type before connecting."""
+        """Validate the group address and value type before connecting."""
+        # parsed results are passed through to `execute`
+        args.group_address = GroupAddress(args.group_address)
         if args.type is not None:
-            DPTBase.get_dpt(args.type)  # raises ValueError for unknown types
+            args.type = DPTBase.get_dpt(args.type)  # raises ValueError if unknown
         return await super().run(args)
 
     async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:

--- a/xknx/cli/group/read.py
+++ b/xknx/cli/group/read.py
@@ -1,0 +1,41 @@
+"""The `xknx group read` command."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from xknx import XKNX
+from xknx.dpt import DPTBase
+from xknx.tools import read_group_value
+
+from ._base import GroupCommand
+
+
+class ReadCommand(GroupCommand):
+    """Read the value of a group address."""
+
+    name = "read"
+    help_text = "read a group address value"
+
+    def configure(self, parser: argparse.ArgumentParser) -> None:
+        """Add the read command arguments."""
+        parser.add_argument("group_address", help="KNX group address, e.g. '1/2/3'")
+        parser.add_argument(
+            "--type", help="DPT value type, e.g. 'temperature' or '9.001'"
+        )
+
+    async def run(self, args: argparse.Namespace) -> int:
+        """Validate the value type before connecting."""
+        if args.type is not None:
+            DPTBase.get_dpt(args.type)  # raises ValueError for unknown types
+        return await super().run(args)
+
+    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+        """Read the value of a group address and print it."""
+        value = await read_group_value(xknx, args.group_address, value_type=args.type)
+        if value is None:
+            print("No response received.", file=sys.stderr)
+            return 1
+        print(value)
+        return 0

--- a/xknx/cli/group/read.py
+++ b/xknx/cli/group/read.py
@@ -28,13 +28,13 @@ class ReadCommand(GroupCommand):
 
     async def run(self, args: argparse.Namespace) -> int:
         """Validate the group address and value type before connecting."""
-        # parsed results are passed through to `execute`
+        # parsed results are passed through to `run_connected`
         args.group_address = GroupAddress(args.group_address)
         if args.type is not None:
             args.type = DPTBase.get_dpt(args.type)  # raises ValueError if unknown
         return await super().run(args)
 
-    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+    async def run_connected(self, xknx: XKNX, args: argparse.Namespace) -> int:
         """Read the value of a group address and print it."""
         value = await read_group_value(xknx, args.group_address, value_type=args.type)
         if value is None:

--- a/xknx/cli/group/write.py
+++ b/xknx/cli/group/write.py
@@ -42,7 +42,7 @@ class WriteCommand(GroupCommand):
 
     async def run(self, args: argparse.Namespace) -> int:
         """Validate the group address, value and value type before connecting."""
-        # parsed results are passed through to `execute`
+        # parsed results are passed through to `run_connected`
         args.group_address = GroupAddress(args.group_address)
         if args.type is not None:
             # convert before connecting to fail early for unknown types
@@ -62,7 +62,7 @@ class WriteCommand(GroupCommand):
             args.value = value
         return await super().run(args)
 
-    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+    async def run_connected(self, xknx: XKNX, args: argparse.Namespace) -> int:
         """Send a GroupValueWrite telegram."""
         group_value_write(xknx, args.group_address, args.value, value_type=args.type)
         return 0

--- a/xknx/cli/group/write.py
+++ b/xknx/cli/group/write.py
@@ -7,6 +7,7 @@ import sys
 
 from xknx import XKNX
 from xknx.dpt import DPTBase
+from xknx.telegram import GroupAddress
 from xknx.tools import group_value_write
 
 from ._base import GroupCommand
@@ -40,10 +41,15 @@ class WriteCommand(GroupCommand):
         parser.add_argument("--type", help="DPT value type, e.g. 'percent' or '9.001'")
 
     async def run(self, args: argparse.Namespace) -> int:
-        """Validate the value and value type before connecting."""
+        """Validate the group address, value and value type before connecting."""
+        # parsed results are passed through to `execute`
+        args.group_address = GroupAddress(args.group_address)
         if args.type is not None:
-            # the raw string value is parsed by the DPT transcoder in `execute`
-            DPTBase.get_dpt(args.type)  # raises ValueError for unknown types
+            # convert before connecting to fail early for unknown types
+            # or invalid values
+            transcoder = DPTBase.get_dpt(args.type)
+            args.value = transcoder.to_knx(args.value)
+            args.type = transcoder
         else:
             value = parse_raw_value(args.value)
             if not isinstance(value, int) or not 0 <= value <= 63:

--- a/xknx/cli/group/write.py
+++ b/xknx/cli/group/write.py
@@ -1,0 +1,62 @@
+"""The `xknx group write` command."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from xknx import XKNX
+from xknx.dpt import DPTBase
+from xknx.tools import group_value_write
+
+from ._base import GroupCommand
+
+
+def parse_raw_value(raw: str) -> bool | int | float | str:
+    """Parse a raw command line value into a Python value."""
+    if raw.lower() in ("on", "true"):
+        return True
+    if raw.lower() in ("off", "false"):
+        return False
+    try:
+        return int(raw)
+    except ValueError:
+        try:
+            return float(raw)
+        except ValueError:
+            return raw
+
+
+class WriteCommand(GroupCommand):
+    """Write a value to a group address."""
+
+    name = "write"
+    help_text = "write a value to a group address"
+
+    def configure(self, parser: argparse.ArgumentParser) -> None:
+        """Add the write command arguments."""
+        parser.add_argument("group_address", help="KNX group address, e.g. '1/2/3'")
+        parser.add_argument("value", help="value to write, e.g. 'on', '50' or '21.5'")
+        parser.add_argument("--type", help="DPT value type, e.g. 'percent' or '9.001'")
+
+    async def run(self, args: argparse.Namespace) -> int:
+        """Validate the value and value type before connecting."""
+        if args.type is not None:
+            # the raw string value is parsed by the DPT transcoder in `execute`
+            DPTBase.get_dpt(args.type)  # raises ValueError for unknown types
+        else:
+            value = parse_raw_value(args.value)
+            if not isinstance(value, int) or not 0 <= value <= 63:
+                print(
+                    "Error: --type is required for values other than 'on'/'off' "
+                    "or raw integers 0-63.",
+                    file=sys.stderr,
+                )
+                return 1
+            args.value = value
+        return await super().run(args)
+
+    async def execute(self, xknx: XKNX, args: argparse.Namespace) -> int:
+        """Send a GroupValueWrite telegram."""
+        group_value_write(xknx, args.group_address, args.value, value_type=args.type)
+        return 0

--- a/xknx/cli/scan.py
+++ b/xknx/cli/scan.py
@@ -3,12 +3,43 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
+import ipaddress
+import logging
 import sys
 
 from xknx import XKNX
-from xknx.io import GatewayScanner
+from xknx.exceptions import XKNXException
+from xknx.io import GatewayDescriptor, GatewayScanner
+from xknx.io.util import get_local_ips
 
 from ._command import Command
+
+logger = logging.getLogger("xknx.cli")
+
+
+def _print_gateway(gateway: GatewayDescriptor) -> None:
+    """Print a found gateway."""
+    tunnelling = (
+        "Secure"
+        if gateway.tunnelling_requires_secure
+        else "TCP"
+        if gateway.supports_tunnelling_tcp
+        else "UDP"
+        if gateway.supports_tunnelling
+        else "No"
+    )
+    routing = (
+        "Secure"
+        if gateway.routing_requires_secure
+        else "Yes"
+        if gateway.supports_routing
+        else "No"
+    )
+    print(
+        f"{gateway.individual_address} {gateway.ip_addr}:{gateway.port} "
+        f"{gateway.name!r} tunnelling: {tunnelling} routing: {routing}"
+    )
 
 
 class ScanCommand(Command):
@@ -27,7 +58,7 @@ class ScanCommand(Command):
         )
 
     async def run(self, args: argparse.Namespace) -> int:
-        """Scan for KNX/IP gateways and print what is found."""
+        """Scan for KNX/IP gateways on all interfaces and print what is found."""
         if args.gateway is not None:
             print(
                 "Error: --gateway is not applicable to 'scan' - it uses"
@@ -35,30 +66,53 @@ class ScanCommand(Command):
                 file=sys.stderr,
             )
             return 2
-        gatewayscanner = GatewayScanner(
-            XKNX(), local_ip=args.local_ip, timeout_in_seconds=args.timeout
+        if args.local_ip is not None:
+            local_ips = [args.local_ip]
+        else:
+            local_ips = [
+                ip.ip
+                for ip in get_local_ips()
+                if isinstance(ip.ip, str)
+                and not ipaddress.IPv4Address(ip.ip).is_loopback
+            ]
+        xknx = XKNX()
+        found: set[tuple[str, int]] = set()
+        await asyncio.gather(
+            *(
+                self._scan_interface(
+                    xknx,
+                    local_ip=local_ip,
+                    timeout=args.timeout,
+                    found=found,
+                    ignore_errors=args.local_ip is None,
+                )
+                for local_ip in dict.fromkeys(local_ips)
+            )
         )
-        async for gateway in gatewayscanner.async_scan():
-            tunnelling = (
-                "Secure"
-                if gateway.tunnelling_requires_secure
-                else "TCP"
-                if gateway.supports_tunnelling_tcp
-                else "UDP"
-                if gateway.supports_tunnelling
-                else "No"
-            )
-            routing = (
-                "Secure"
-                if gateway.routing_requires_secure
-                else "Yes"
-                if gateway.supports_routing
-                else "No"
-            )
-            print(
-                f"{gateway.individual_address} {gateway.ip_addr}:{gateway.port} "
-                f"{gateway.name!r} tunnelling: {tunnelling} routing: {routing}"
-            )
-        if not gatewayscanner.found_gateways:
+        if not found:
             print("No gateways found.")
         return 0
+
+    async def _scan_interface(
+        self,
+        xknx: XKNX,
+        local_ip: str,
+        timeout: float,
+        found: set[tuple[str, int]],
+        ignore_errors: bool,
+    ) -> None:
+        """Scan for gateways on a single interface."""
+        gatewayscanner = GatewayScanner(
+            xknx, local_ip=local_ip, timeout_in_seconds=timeout
+        )
+        try:
+            async for gateway in gatewayscanner.async_scan():
+                key = (gateway.ip_addr, gateway.port)
+                if key in found:
+                    continue
+                found.add(key)
+                _print_gateway(gateway)
+        except (XKNXException, OSError) as err:
+            if not ignore_errors:
+                raise
+            logger.debug("Scan failed on %s: %s", local_ip, err)

--- a/xknx/cli/scan.py
+++ b/xknx/cli/scan.py
@@ -1,0 +1,64 @@
+"""The `xknx scan` command."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from xknx import XKNX
+from xknx.io import GatewayScanner
+
+from ._command import Command
+
+
+class ScanCommand(Command):
+    """Scan for KNX/IP gateways."""
+
+    name = "scan"
+    help_text = "scan for KNX/IP gateways"
+
+    def configure(self, parser: argparse.ArgumentParser) -> None:
+        """Add the scan command arguments."""
+        parser.add_argument(
+            "--timeout",
+            type=float,
+            default=3.0,
+            help="scan timeout in seconds (default: 3)",
+        )
+
+    async def run(self, args: argparse.Namespace) -> int:
+        """Scan for KNX/IP gateways and print what is found."""
+        if args.gateway is not None:
+            print(
+                "Error: --gateway is not applicable to 'scan' - it uses"
+                " multicast discovery.",
+                file=sys.stderr,
+            )
+            return 2
+        gatewayscanner = GatewayScanner(
+            XKNX(), local_ip=args.local_ip, timeout_in_seconds=args.timeout
+        )
+        async for gateway in gatewayscanner.async_scan():
+            tunnelling = (
+                "Secure"
+                if gateway.tunnelling_requires_secure
+                else "TCP"
+                if gateway.supports_tunnelling_tcp
+                else "UDP"
+                if gateway.supports_tunnelling
+                else "No"
+            )
+            routing = (
+                "Secure"
+                if gateway.routing_requires_secure
+                else "Yes"
+                if gateway.supports_routing
+                else "No"
+            )
+            print(
+                f"{gateway.individual_address} {gateway.ip_addr}:{gateway.port} "
+                f"{gateway.name!r} tunnelling: {tunnelling} routing: {routing}"
+            )
+        if not gatewayscanner.found_gateways:
+            print("No gateways found.")
+        return 0


### PR DESCRIPTION
<!--
  You are awesome! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template!.
-->
## Description

Proof-of-concept for a command line interface for xknx. Installing the package puts an `xknx`
command on the path (also available via `python -m xknx`) — no new
dependencies, stdlib `argparse` only.

```
$ xknx --help
usage: xknx [-h] [-v] [--gateway GATEWAY] [--local-ip LOCAL_IP] <command> ...

Command line interface for xknx.

options:
  -h, --help           show this help message and exit
  -v, --verbose        increase verbosity (-v: info, -vv: debug)
  --gateway GATEWAY    KNX/IP tunneling gateway as 'host[:port]' (default: XKNX_GATEWAY environment variable, or automatic discovery)
  --local-ip LOCAL_IP  local IP address or interface name to use (default: XKNX_LOCAL_IP environment variable)

commands:
  <command>            run 'xknx <command> --help' for command specific options
    group              read, write and monitor group addresses
    scan               scan for KNX/IP gateways
```

**Commands**

- `xknx scan` — discover KNX/IP gateways via multicast and print their
  capabilities.
- `xknx group read <ga> [--type <dpt>]` — read a group address value once and
  print it (exit 1 on no response).
- `xknx group write <ga> <value> [--type <dpt>]` — write a value. With
  `--type` the raw string is handed to the DPT transcoder; without it,
  `on`/`off` and raw integers 0–63 are sent as `DPTBinary`.
- `xknx group monitor [--filter <patterns>]` — print group telegrams until
  Ctrl+C (uses `XKNX.loop_until_sigint()`).

Connection is `AUTOMATIC` discovery by default; `--gateway host[:port]`
forces tunneling. Argument errors, unknown DPT types and invalid
values are rejected *before* connecting; `KeyboardInterrupt` exits 130,
`XKNXException`/`ValueError` exit 1 with a message on stderr.

**Design**

Commands are classes. `Command` (in `xknx/cli/_command.py`) defines the
contract (`name`, `help_text`, `configure(parser)`, `async run(args)`); the
parser is built from the class hierarchy — direct subclasses of `Command`
form the top level, and an abstract subclass with subclasses of its own is a
command group whose members are its direct subclasses. `GroupCommand` is the
first group: it owns the group's name/help and the shared
connect-and-`run()` lifecycle. The package layout mirrors the command
tree (`xknx/cli/group/{read,write,monitor}.py`), so adding a command is a new
module with one class, and adding a group is a new subpackage — no central
registry to maintain.

Deliberately out of scope for this first iteration (candidates for
follow-ups): secure/routing connection options, DPT inspection commands
(`dpt list`/`describe`, encode/decode), device management commands
(restart, individual address programming), a docs page (`xknx --help` is
the documentation for now), and `xknxproject`-based telegram decoding.

## Type of change
<!--
Please tick the applicable options.
NOTE: Ticking multiple options most likely indicates
that your change is to big and it is suggested to split it into several smaller PRs.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The documentation has been adjusted accordingly (CLI `--help`)
- [x] Tests have been added that prove the fix is effective or that the feature works
- [x] The changes are documented in the changelog (docs/changelog.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)